### PR TITLE
Reach the dead measure beside a line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+- feat(core)!: **the pointer tolerance reaches along a line, not just around the
+  point.** A glyph's box is its run's ink height by its own advance, so the two
+  axes fail differently: across a line the dead gap is the leading, a few points
+  wide and belonging to the neighbouring line, while along one it is the rest of
+  the measure the line does not fill — 248 of 443 points beside a seeded
+  `usaf_memo` body line, 56% of that line's width — belonging to that line's own
+  end. The radius added for the leading is two orders short of the measure, and
+  widening it until it reached would answer for ink most of a page away. Hit
+  ranking now divides the horizontal leg by `LINE_REACH` before measuring, making
+  the admitted region an ellipse `tol` tall and `tol * LINE_REACH` wide: a click
+  out in a line's own whitespace answers with that line, and one a row up still
+  answers with the row above. The ratio is the engine's rather than the caller's,
+  `tol` being the pointer's slack and a screen quantity where this is a property
+  of how text is set. Containment is still distance zero — scaling a leg cannot
+  turn a non-zero gap into a zero one — so `tol = 0` remains exact containment and
+  no point that resolved exactly changes answer. The break is behavioural, not a
+  signature: `field_at` / `position_at` answer where they previously returned
+  nothing, and a consumer relying on a whitespace click resolving to nothing sees
+  a field.
+
 - feat(core)!: **`fieldAt` and `positionAt` take a pointer tolerance, and
   resolve to the nearest ink rather than the first containing it.** A glyph's
   box is its run's ink height by its own advance, so a text column answers over

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -54,7 +54,7 @@ use typst::utils::PicoStr;
 use typst::World;
 use typst_layout::PagedDocument;
 
-use quillmark_core::{ContentHit, HitGranularity, RenderedRegion};
+use quillmark_core::{ContentHit, HitGranularity, RenderedRegion, LINE_REACH};
 
 use crate::emit::SegmentMap;
 use crate::world::QuillWorld;
@@ -109,17 +109,19 @@ impl Aabb {
     }
 
     /// Gap from `(x, y)` to this box: zero inside it (edges included), else the
-    /// length of the shortest vector reaching it, absent when either side is not
-    /// finite. The one measure both point queries rank by, so a tolerance of
-    /// zero is exactly containment, and an absent gap is one no `tol` reaches.
-    /// `RenderedRegion::distance` carries why the finite check is load-bearing.
+    /// shortest vector reaching it with its horizontal leg divided by
+    /// [`LINE_REACH`], absent when either side is not finite. The one measure
+    /// both point queries rank by, so a tolerance of zero is exactly
+    /// containment, and an absent gap is one no `tol` reaches.
+    /// `RenderedRegion::distance` carries the scaling and why the finite check
+    /// is load-bearing.
     fn distance(&self, x: f64, y: f64) -> Option<f64> {
         let corners = [self.min_x, self.min_y, self.max_x, self.max_y];
         let finite = x.is_finite() && y.is_finite() && corners.iter().all(|v| v.is_finite());
         finite.then(|| {
             let dx = (self.min_x - x).max(0.0).max(x - self.max_x);
             let dy = (self.min_y - y).max(0.0).max(y - self.max_y);
-            dx.hypot(dy)
+            (dx / LINE_REACH as f64).hypot(dy)
         })
     }
 }

--- a/crates/backends/typst/tests/hit_tolerance.rs
+++ b/crates/backends/typst/tests/hit_tolerance.rs
@@ -182,6 +182,74 @@ fn a_tolerance_never_changes_an_answer_an_exact_hit_already_had() {
     assert!(filled > 0, "the sweep crosses ink it only reaches under tolerance");
 }
 
+/// A short line with the rest of its measure empty beside it: `intro` is one
+/// line, `body` fills the measure below.
+fn open_with_a_short_line() -> LiveSession {
+    let data = serde_json::json!({
+        "intro": content("Short."),
+        "body": content(&"Body text that fills the measure and wraps past one line. ".repeat(3)),
+    });
+    TypstBackend
+        .open(&quill(YAML, PLATE), &data)
+        .expect("open")
+}
+
+/// A click out in the measure beside a line answers with that line, at a gap two
+/// orders past the slack that reaches it.
+#[test]
+fn a_click_out_in_the_measure_answers_with_the_line_it_is_level_with() {
+    let session = open_with_a_short_line();
+    let intro = session
+        .regions()
+        .into_iter()
+        .find(|r| r.field == "intro")
+        .expect("intro surfaces a region");
+    let y = (intro.rect[1] + intro.rect[3]) / 2.0;
+    let far = intro.rect[2] + 120.0;
+    assert!(
+        session.field_at(0, far, y, 0.0).is_none(),
+        "the probe sits in dead measure, not on ink"
+    );
+
+    assert_eq!(
+        session.field_at(0, far, y, 3.1).as_deref(),
+        Some("intro"),
+        "a click 120pt out in the measure answers with the line level with it"
+    );
+    let hit = session
+        .position_at(0, far, y, 3.1)
+        .expect("and resolves to a content position");
+    assert_eq!(hit.field, "intro");
+}
+
+/// Ink the point is inside of outranks a line-end however far the reach would
+/// stretch to it.
+#[test]
+fn the_measure_reach_never_outranks_ink_the_point_is_inside() {
+    let session = open_with_a_short_line();
+    let regions = session.regions();
+    let intro = regions
+        .iter()
+        .find(|r| r.field == "intro")
+        .expect("intro surfaces a region");
+    let far = intro.rect[2] + 120.0;
+
+    // The body's own rows, at the same column the intro's line-end reaches.
+    let body_rows: Vec<f32> = regions
+        .iter()
+        .filter(|r| r.field == "body")
+        .map(|r| (r.rect[1] + r.rect[3]) / 2.0)
+        .collect();
+    assert!(!body_rows.is_empty(), "the body surfaces regions: {regions:?}");
+    for y in body_rows {
+        assert_eq!(
+            session.field_at(0, far, y, 3.1).as_deref(),
+            Some("body"),
+            "a point on the body's own ink at ({far}, {y}) stays the body's"
+        );
+    }
+}
+
 #[test]
 fn a_point_past_the_tolerance_is_still_a_miss() {
     let session = open();

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -47,7 +47,7 @@ pub use types::{Artifact, OutputFormat, RenderOptions};
 pub mod region;
 pub use region::{
     doc_path_to_plate_addr, field_boxes, plate_addr_to_doc_path, regions_to_doc_path, ContentHit,
-    HitGranularity, RenderedRegion,
+    HitGranularity, RenderedRegion, LINE_REACH,
 };
 
 pub mod session;

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -40,6 +40,21 @@
 //! the same sidecar on request ([`RenderOptions::regions`](crate::RenderOptions)).
 //! Empty for backends that place no schema fields.
 
+/// How much further a tolerance reaches along a line of text than across one.
+///
+/// The dead gap a click lands in differs by two orders between the axes: across
+/// a line it is the leading, a few points wide and belonging to the neighbouring
+/// line; along one it is the rest of the measure, hundreds of points wide and
+/// belonging to that line's own end. One radius widened to cross a measure
+/// answers for ink most of a page away.
+///
+/// Hit ranking divides the horizontal gap by this before measuring, so the
+/// region a tolerance admits is `tol` tall and `tol * LINE_REACH` wide — ~400pt
+/// at the ~3.1pt a 2 CSS px pointer is worth. Unlike `tol` it is the engine's:
+/// pointer slack is a screen quantity, where this is a property of how text is
+/// set.
+pub const LINE_REACH: f32 = 128.0;
+
 /// One schema field placement's extent on a rendered page.
 ///
 /// `rect` is `[x0, y0, x1, y1]` in PDF points with a **bottom-left** origin:
@@ -98,11 +113,12 @@ impl RenderedRegion {
     }
 
     /// Gap in PDF points from the point to this region's rect: zero inside it,
-    /// else the length of the shortest vector reaching it; `None` on another
-    /// page, or when either side is not finite. What a tolerant hit-test ranks
-    /// by, so a tolerance of zero admits exactly what
-    /// [`contains`](Self::contains) does, and an absent gap is one no tolerance
-    /// reaches.
+    /// else the shortest vector reaching it with its horizontal leg divided by
+    /// [`LINE_REACH`]. `None` on another page, or when either side is not
+    /// finite. What a tolerant hit-test ranks by, so a tolerance of zero admits
+    /// exactly what [`contains`](Self::contains) does — scaling a leg cannot
+    /// turn a non-zero gap into a zero one — and an absent gap is one no
+    /// tolerance reaches.
     ///
     /// The finite check is load-bearing: `f32::max` returns the non-NaN side, so
     /// a NaN on either side otherwise collapses both axes to zero and reads as
@@ -112,7 +128,7 @@ impl RenderedRegion {
         (self.page == page && finite).then(|| {
             let dx = (self.rect[0] - x).max(0.0).max(x - self.rect[2]);
             let dy = (self.rect[1] - y).max(0.0).max(y - self.rect[3]);
-            dx.hypot(dy)
+            (dx / LINE_REACH).hypot(dy)
         })
     }
 }

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -304,6 +304,19 @@ paragraph is live over roughly two thirds of its own height at default leading,
 and under half of it double-spaced. Both point queries therefore take a
 tolerance: the nearest ink within `tolPt` answers, `0` being exact containment.
 
+**The slack is an ellipse, not a circle, because the two axes fail
+differently.** Across a line the dead gap is the leading, a few points wide, and
+it belongs to the neighbouring line. Along one it is the rest of the measure the
+line does not fill — on a seeded `usaf_memo` body line, 248 of 443 points — and
+it belongs to that line's own end. One radius cannot serve both: widened until it
+crossed a measure it would answer for ink most of a page away. Ranking divides
+the horizontal leg by `LINE_REACH` before measuring, so the admitted region is
+`tolPt` tall and `tolPt * LINE_REACH` wide, and a click out in the measure
+answers with the line it is level with while a click one row up still answers
+with that row. Unlike `tolPt` the ratio is the engine's: pointer slack is a
+screen quantity, where how far a line runs beside its own whitespace is a
+property of how text is set and holds at every scale.
+
 **The caller owns the number, because the imprecision is the pointer's.**
 Slack is a screen quantity — what a finger or a hand-held mouse
 misses by — so a tolerance fixed in points shrinks under the cursor as the page
@@ -315,9 +328,10 @@ result; the engine holds no default because it cannot see that scale.
 makes overlapping boxes decide by paint order, so a click in the leading between
 two fields' lines answers whichever painted last, however far away it is.
 Ranking by distance answers the nearer one, and keeps the tolerance a pure
-widening: containment is distance zero, so no point that resolves exactly ever
-changes answer as `tolPt` rises. On a tie — two placements equally near, an
-exact hit under another exact hit — the later-painted wins.
+widening: containment is distance zero — scaling a leg cannot turn a non-zero
+gap into a zero one — so no point that resolves exactly ever changes answer as
+`tolPt` rises. On a tie — two placements equally near, an exact hit under
+another exact hit — the later-painted wins.
 
 Widgets and content ink rank in one comparison, a widget taking a tie: a widget
 draws no spanned ink of its own, so ink beneath one must not swallow a click that
@@ -327,7 +341,12 @@ of. One lane consulted before the other answers from the first at any gap within
 
 A tolerance is not a bounding box over ink the field does not fill: a click
 stays on ink some placement drew, and a point far from all of it resolves to
-nothing.
+nothing. Far is measured after the scaling, so a point out in a line's own
+whitespace is near that line and one a few rows off the text block is near
+nothing — but either way the answer is a glyph some placement drew, never a
+union spanning ink it did not. Which is why the reach is a ranking and not
+`regions()`: clamping within a line's own row to that line's own glyphs claims
+no ink between two disjoint segments.
 
 ## TypeScript surface
 


### PR DESCRIPTION
Closes #1430.

## The gap

A glyph's box is its run's ink height by its own advance, so the two axes around a line fail differently. Across a line the dead gap is the leading, a few points wide, and it belongs to the neighbouring line. Along one it is the rest of the measure the line does not fill — 248 of 443 points beside a seeded `usaf_memo` body line, 56% of that line's width — and it belongs to that line's own end.

The radius from #1429 is sized from pointer slack and closes the leading. It is two orders short of a measure, and widening it until it reached would answer for ink most of a page away.

## The reach

Hit ranking divides the horizontal leg by `LINE_REACH` (128) before measuring, in both `RenderedRegion::distance` and the typst `Aabb::distance` so the widget and content lanes rank on one metric. The region a tolerance admits becomes `tol` tall and `tol * LINE_REACH` wide — about 400pt at the ~3.1pt a 2 CSS px pointer is worth, roughly a page's measure.

The ratio is the engine's rather than the caller's: `tol` is the pointer's slack and a screen quantity, where how far a line runs beside its own whitespace is a property of how text is set.

Containment stays distance zero, since scaling a leg cannot turn a non-zero gap into a zero one. So `tol = 0` is still exact containment, no point that resolved exactly changes answer, and every invariant #1429 locked in holds unchanged.

Ranking rather than a bound read off `regions()` is what keeps the canon claim honest — the issue's open question. A union over two disjoint segments spans ink no placement drew; clamping within a line's own row to that line's own glyphs does not, so `PREVIEW.md` needs no amendment on union boxes.

## Compatibility

A **behavioural break**, not a signature one: `field_at` / `position_at` answer where they previously returned nothing. A consumer relying on a whitespace click resolving to nothing sees a field.

## Tests

`cargo test --workspace` green. WASM rebuilt with `./scripts/build-wasm.sh --ci`, 255/255 vitest.

Two tests in `hit_tolerance.rs`:

- a click 120pt out in the measure beside a short line answers with that line, and answers nothing at `tol = 0`, so the probe is genuinely in dead space
- ink the point is inside of outranks a line-end however far the reach would stretch to it

## Not in scope

`positionAt` still floors to the cluster under the point with no notion of a trailing edge, so a click on a glyph's right half — and one past a line's last glyph, which this change now answers with that glyph — resolves to the position *before* the character. That only matters to a consumer placing a caret, and the consumer here does click navigation and draws none, so it is left alone rather than built ahead of a need. Same for soft-wrap affinity in `locate`: one offset maps to two caret positions at a wrap point, and `locate` picks the following line unconditionally.