### PR TITLE
The pointer tolerance is a radius, not a line reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,6 @@
 
 ## Unreleased
 
-- feat(core)!: **the pointer tolerance reaches along a line, not just around the
-  point.** A glyph's box is its run's ink height by its own advance, so the two
-  axes fail differently: across a line the dead gap is the leading, a few points
-  wide and belonging to the neighbouring line, while along one it is the rest of
-  the measure the line does not fill — 248 of 443 points beside a seeded
-  `usaf_memo` body line, 56% of that line's width — belonging to that line's own
-  end. The radius added for the leading is two orders short of the measure, and
-  widening it until it reached would answer for ink most of a page away. Hit
-  ranking now divides the horizontal leg by `LINE_REACH` before measuring, making
-  the admitted region an ellipse `tol` tall and `tol * LINE_REACH` wide: a click
-  out in a line's own whitespace answers with that line, and one a row up still
-  answers with the row above. The ratio is the engine's rather than the caller's,
-  `tol` being the pointer's slack and a screen quantity where this is a property
-  of how text is set. Containment is still distance zero — scaling a leg cannot
-  turn a non-zero gap into a zero one — so `tol = 0` remains exact containment and
-  no point that resolved exactly changes answer. The break is behavioural, not a
-  signature: `field_at` / `position_at` answer where they previously returned
-  nothing, and a consumer relying on a whitespace click resolving to nothing sees
-  a field.
-
 - feat(core)!: **`fieldAt` and `positionAt` take a pointer tolerance, and
   resolve to the nearest ink rather than the first containing it.** A glyph's
   box is its run's ink height by its own advance, so a text column answers over
@@ -31,9 +11,10 @@
   and under half of it double-spaced, which is the whole of why clicking the
   preview to place a caret misses. Both queries now take `tol` in PDF points
   (`tolPt`, optional, on the WASM seam) and answer with the nearest placement
-  within it. The caller derives it from the scale it drew the page at, slack
-  being a property of the pointer rather than of the document: a tolerance fixed
-  in points shrinks under the cursor exactly as the target does. Ranking by
+  within it, a radius in both axes. The caller derives it from the scale it drew
+  the page at, slack being a property of the pointer rather than of the
+  document: a tolerance fixed in points shrinks under the cursor exactly as the
+  target does. Ranking by
   distance rather than growing each rect is what keeps the answer the nearer
   item's — outset boxes overlap, and a first match over them decides by paint
   order — and makes the tolerance a pure widening: containment is distance zero,

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -328,20 +328,19 @@ impl SessionHandle for TypstSession {
     /// widget is a deliberate click target drawing no spanned ink of its own, so
     /// ink beneath one must not swallow a click that lands on it. Among
     /// overlapping widgets the later-painted wins, matching `Scan::field_at`.
-    ///
-    /// One comparison across both lanes, not one lane and then the other: a lane
-    /// consulted first answers at any gap within `tol`, which ranks a far hit in
-    /// that lane over a near one in the other.
     fn field_at(&self, page: usize, x: f32, y: f32, tol: f32) -> Option<String> {
+        let widget = self.widget_at(page, x, y, tol);
+        // Nothing outranks a widget the point is inside of, and the content lane
+        // walks every frame up to `page` to answer.
+        if widget.as_ref().is_some_and(|&(gap, _)| gap == 0.0) {
+            return widget.map(|(_, field)| field);
+        }
         // Widget first: `min_by` keeps the first of equal gaps.
-        [
-            self.widget_at(page, x, y, tol),
-            self.scan().field_at(page, x, y, tol),
-        ]
-        .into_iter()
-        .flatten()
-        .min_by(|(a, _), (b, _)| a.total_cmp(b))
-        .map(|(_, field)| field)
+        [widget, self.scan().field_at(page, x, y, tol)]
+            .into_iter()
+            .flatten()
+            .min_by(|(a, _), (b, _)| a.total_cmp(b))
+            .map(|(_, field)| field)
     }
 
     /// The fine-grained twin of [`field_at`](Self::field_at). Widgets draw no

--- a/crates/backends/typst/src/overlay/span_scan.rs
+++ b/crates/backends/typst/src/overlay/span_scan.rs
@@ -54,7 +54,7 @@ use typst::utils::PicoStr;
 use typst::World;
 use typst_layout::PagedDocument;
 
-use quillmark_core::{ContentHit, HitGranularity, RenderedRegion, LINE_REACH};
+use quillmark_core::{ContentHit, HitGranularity, RenderedRegion};
 
 use crate::emit::SegmentMap;
 use crate::world::QuillWorld;
@@ -108,20 +108,17 @@ impl Aabb {
         self.max_y = self.max_y.max(o.max_y);
     }
 
-    /// Gap from `(x, y)` to this box: zero inside it (edges included), else the
-    /// shortest vector reaching it with its horizontal leg divided by
-    /// [`LINE_REACH`], absent when either side is not finite. The one measure
-    /// both point queries rank by, so a tolerance of zero is exactly
-    /// containment, and an absent gap is one no `tol` reaches.
-    /// `RenderedRegion::distance` carries the scaling and why the finite check
-    /// is load-bearing.
+    /// Gap from `(x, y)` to this box, zero inside it (edges included), absent
+    /// when either side is not finite. The one measure both point queries rank
+    /// by, so a tolerance of zero is exactly containment.
+    /// `RenderedRegion::distance` carries why the finite check is load-bearing.
     fn distance(&self, x: f64, y: f64) -> Option<f64> {
         let corners = [self.min_x, self.min_y, self.max_x, self.max_y];
         let finite = x.is_finite() && y.is_finite() && corners.iter().all(|v| v.is_finite());
         finite.then(|| {
             let dx = (self.min_x - x).max(0.0).max(x - self.max_x);
             let dy = (self.min_y - y).max(0.0).max(y - self.max_y);
-            (dx / LINE_REACH as f64).hypot(dy)
+            dx.hypot(dy)
         })
     }
 }
@@ -129,10 +126,6 @@ impl Aabb {
 /// The nearest box within `tol` among `boxed`, which callers pass **in reverse
 /// paint order**: ties keep the first seen, so the last-painted of equally near
 /// items wins.
-///
-/// Ranking by distance rather than growing each box is what keeps the answer
-/// the nearer item's: outset boxes overlap, and a first match over them answers
-/// whichever painted last however far away it is.
 fn nearest<T>(
     boxed: impl Iterator<Item = (Aabb, T)>,
     x: f64,
@@ -649,11 +642,6 @@ impl<'a> Scan<'a> {
     /// resolving to the nearest glyph within `tol` points. Degrades to the
     /// segment's content start when the resolved node nests inside no single
     /// run (a multi-line `#raw` block, or structural ink).
-    ///
-    /// A glyph box is the run's ink height by the glyph's advance, so a text
-    /// column answers over a fraction of its own area: the leading between two
-    /// lines belongs to neither. Under `tol` the point takes the line it is
-    /// nearer, at the column it was clicked in, which is where a caret goes.
     pub(crate) fn position_at(&self, page: usize, x: f32, y: f32, tol: f32) -> Option<ContentHit> {
         if self.windows.is_empty() {
             return None;

--- a/crates/backends/typst/tests/hit_tolerance.rs
+++ b/crates/backends/typst/tests/hit_tolerance.rs
@@ -1,8 +1,7 @@
 //! The pointer-slack argument on `field_at` / `position_at`: a click within
-//! `tol` points of a field's ink resolves to the nearest such ink. A glyph box
-//! is the run's ink height by the glyph's advance, so a text column is live over
-//! a fraction of its own area: the leading between two lines is inside a
-//! paragraph and on no glyph. These hold what the slack may and may not change.
+//! `tol` points of a field's ink resolves to the nearest such ink: the leading
+//! between two lines is inside a paragraph and on no glyph. These hold what the
+//! slack may and may not change.
 
 use quillmark_core::{Backend, LiveSession};
 use quillmark_typst::TypstBackend;
@@ -194,10 +193,13 @@ fn open_with_a_short_line() -> LiveSession {
         .expect("open")
 }
 
-/// A click out in the measure beside a line answers with that line, at a gap two
-/// orders past the slack that reaches it.
+/// The slack is a radius in both axes, so it does not reach along a row: the
+/// empty measure beside a short line is as far from that line as a point the
+/// same distance above it. A tolerance that crossed a measure would make a
+/// click's column stop mattering, and a click in one page margin answer with a
+/// field set against the other.
 #[test]
-fn a_click_out_in_the_measure_answers_with_the_line_it_is_level_with() {
+fn the_empty_measure_beside_a_line_is_not_that_line() {
     let session = open_with_a_short_line();
     let intro = session
         .regions()
@@ -205,49 +207,19 @@ fn a_click_out_in_the_measure_answers_with_the_line_it_is_level_with() {
         .find(|r| r.field == "intro")
         .expect("intro surfaces a region");
     let y = (intro.rect[1] + intro.rect[3]) / 2.0;
-    let far = intro.rect[2] + 120.0;
-    assert!(
-        session.field_at(0, far, y, 0.0).is_none(),
-        "the probe sits in dead measure, not on ink"
-    );
-
-    assert_eq!(
-        session.field_at(0, far, y, 3.1).as_deref(),
-        Some("intro"),
-        "a click 120pt out in the measure answers with the line level with it"
-    );
-    let hit = session
-        .position_at(0, far, y, 3.1)
-        .expect("and resolves to a content position");
-    assert_eq!(hit.field, "intro");
-}
-
-/// Ink the point is inside of outranks a line-end however far the reach would
-/// stretch to it.
-#[test]
-fn the_measure_reach_never_outranks_ink_the_point_is_inside() {
-    let session = open_with_a_short_line();
-    let regions = session.regions();
-    let intro = regions
-        .iter()
-        .find(|r| r.field == "intro")
-        .expect("intro surfaces a region");
-    let far = intro.rect[2] + 120.0;
-
-    // The body's own rows, at the same column the intro's line-end reaches.
-    let body_rows: Vec<f32> = regions
-        .iter()
-        .filter(|r| r.field == "body")
-        .map(|r| (r.rect[1] + r.rect[3]) / 2.0)
-        .collect();
-    assert!(!body_rows.is_empty(), "the body surfaces regions: {regions:?}");
-    for y in body_rows {
-        assert_eq!(
-            session.field_at(0, far, y, 3.1).as_deref(),
-            Some("body"),
-            "a point on the body's own ink at ({far}, {y}) stays the body's"
+    let x = intro.rect[2] + 120.0;
+    for tol in [0.0f32, 3.1, 8.0, 20.0, 120.0] {
+        assert_ne!(
+            session.field_at(0, x, y, tol).as_deref(),
+            Some("intro"),
+            "tol={tol} reached 120pt along the row into the intro's own whitespace"
         );
     }
+    assert_eq!(
+        session.field_at(0, x, y, 3.1),
+        None,
+        "and at a pointer's slack that whitespace is on no field at all"
+    );
 }
 
 #[test]

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -625,11 +625,9 @@ export declare class LiveSession {
 	 * Fine-grained click → content position (caret placement). Same PDF-point
 	 * space as {@link fieldAt}; `undefined` past `tolPt` from all content ink.
 	 *
-	 * `tolPt` buys the most here: a glyph box is the line's ink by the glyph's
-	 * advance, so the leading between two lines lies inside a paragraph and on no
-	 * glyph, and a text column answers over a fraction of its own area. Under
-	 * `tolPt` a point between two lines takes the one it is nearer, at the column
-	 * it was clicked in.
+	 * `tolPt` buys the most here: the leading between two lines lies inside a
+	 * paragraph and on no glyph, and under `tolPt` a point there takes the line
+	 * it is nearer.
 	 */
 	positionAt(page: number, x: number, y: number, tolPt?: number): ContentHit | undefined;
 	/**

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -2725,10 +2725,9 @@ impl LiveSession {
     /// points, bottom-left origin, as in `fieldAt`. The offset is cluster-exact
     /// and degrades to the containing segment's start on origin-less ink.
     ///
-    /// `tolPt` earns the most here: a glyph box is the line's ink by the
-    /// glyph's advance, so the leading between two lines lies inside a paragraph
-    /// and on no glyph. Under `tolPt` such a point takes the nearer line, at the
-    /// column it was clicked in.
+    /// `tolPt` earns the most here: the leading between two lines lies inside a
+    /// paragraph and on no glyph, and under `tolPt` such a point takes the
+    /// nearer line.
     #[wasm_bindgen(js_name = positionAt)]
     pub fn position_at(
         &self,

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -47,7 +47,7 @@ pub use types::{Artifact, OutputFormat, RenderOptions};
 pub mod region;
 pub use region::{
     doc_path_to_plate_addr, field_boxes, plate_addr_to_doc_path, regions_to_doc_path, ContentHit,
-    HitGranularity, RenderedRegion, LINE_REACH,
+    HitGranularity, RenderedRegion,
 };
 
 pub mod session;

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -40,21 +40,6 @@
 //! the same sidecar on request ([`RenderOptions::regions`](crate::RenderOptions)).
 //! Empty for backends that place no schema fields.
 
-/// How much further a tolerance reaches along a line of text than across one.
-///
-/// The dead gap a click lands in differs by two orders between the axes: across
-/// a line it is the leading, a few points wide and belonging to the neighbouring
-/// line; along one it is the rest of the measure, hundreds of points wide and
-/// belonging to that line's own end. One radius widened to cross a measure
-/// answers for ink most of a page away.
-///
-/// Hit ranking divides the horizontal gap by this before measuring, so the
-/// region a tolerance admits is `tol` tall and `tol * LINE_REACH` wide — ~400pt
-/// at the ~3.1pt a 2 CSS px pointer is worth. Unlike `tol` it is the engine's:
-/// pointer slack is a screen quantity, where this is a property of how text is
-/// set.
-pub const LINE_REACH: f32 = 128.0;
-
 /// One schema field placement's extent on a rendered page.
 ///
 /// `rect` is `[x0, y0, x1, y1]` in PDF points with a **bottom-left** origin:
@@ -112,13 +97,11 @@ impl RenderedRegion {
         self.distance(page, x, y) == Some(0.0)
     }
 
-    /// Gap in PDF points from the point to this region's rect: zero inside it,
-    /// else the shortest vector reaching it with its horizontal leg divided by
-    /// [`LINE_REACH`]. `None` on another page, or when either side is not
-    /// finite. What a tolerant hit-test ranks by, so a tolerance of zero admits
-    /// exactly what [`contains`](Self::contains) does — scaling a leg cannot
-    /// turn a non-zero gap into a zero one — and an absent gap is one no
-    /// tolerance reaches.
+    /// Gap in PDF points from the point to this region's rect, zero inside it.
+    /// `None` on another page, or when either side is not finite. What a
+    /// tolerant hit-test ranks by, so a tolerance of zero admits exactly what
+    /// [`contains`](Self::contains) does, and an absent gap is one no tolerance
+    /// reaches.
     ///
     /// The finite check is load-bearing: `f32::max` returns the non-NaN side, so
     /// a NaN on either side otherwise collapses both axes to zero and reads as
@@ -128,7 +111,7 @@ impl RenderedRegion {
         (self.page == page && finite).then(|| {
             let dx = (self.rect[0] - x).max(0.0).max(x - self.rect[2]);
             let dy = (self.rect[1] - y).max(0.0).max(y - self.rect[3]);
-            (dx / LINE_REACH).hypot(dy)
+            dx.hypot(dy)
         })
     }
 }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -119,10 +119,7 @@ pub trait SessionHandle: Send + Sync + 'static {
     /// alone). `x`/`y` are PDF points, bottom-left origin on `page`. Returns
     /// the field plus a USV offset into its `Content`, cluster-exact and
     /// degrading to the containing segment's start on origin-less ink (see
-    /// [`ContentHit`]). `tol` reads as it does on [`field_at`](Self::field_at):
-    /// the nearest content ink within that many points answers, which on a text
-    /// column is the nearer of the two lines a click in the leading falls
-    /// between.
+    /// [`ContentHit`]). `tol` reads as it does on [`field_at`](Self::field_at).
     /// `None` past `tol` from all content ink, on a scalar/widget (no content
     /// address), or when the backend maps no content. Default `None`: a backend
     /// that carries a per-segment source map overrides this.
@@ -259,9 +256,8 @@ impl LiveSession {
     /// A point → **content position**: the field *and* a USV offset into its
     /// `Content`. The offset is cluster-exact and degrades to the containing
     /// segment's start on origin-less ink. `tol` reads as on
-    /// [`field_at`](Self::field_at), and buys more here: a glyph box is the
-    /// line's ink, so the leading between two lines is inside a paragraph and
-    /// on no glyph, and under `tol` such a point takes the line it is nearer.
+    /// [`field_at`](Self::field_at), and buys the most here: the leading
+    /// between two lines is inside a paragraph and on no glyph.
     /// `None` past `tol` from all content ink, on a scalar/widget, or for
     /// backends with no content map.
     ///

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -304,19 +304,6 @@ paragraph is live over roughly two thirds of its own height at default leading,
 and under half of it double-spaced. Both point queries therefore take a
 tolerance: the nearest ink within `tolPt` answers, `0` being exact containment.
 
-**The slack is an ellipse, not a circle, because the two axes fail
-differently.** Across a line the dead gap is the leading, a few points wide, and
-it belongs to the neighbouring line. Along one it is the rest of the measure the
-line does not fill — on a seeded `usaf_memo` body line, 248 of 443 points — and
-it belongs to that line's own end. One radius cannot serve both: widened until it
-crossed a measure it would answer for ink most of a page away. Ranking divides
-the horizontal leg by `LINE_REACH` before measuring, so the admitted region is
-`tolPt` tall and `tolPt * LINE_REACH` wide, and a click out in the measure
-answers with the line it is level with while a click one row up still answers
-with that row. Unlike `tolPt` the ratio is the engine's: pointer slack is a
-screen quantity, where how far a line runs beside its own whitespace is a
-property of how text is set and holds at every scale.
-
 **The caller owns the number, because the imprecision is the pointer's.**
 Slack is a screen quantity — what a finger or a hand-held mouse
 misses by — so a tolerance fixed in points shrinks under the cursor as the page
@@ -324,29 +311,16 @@ is drawn smaller, which is where the target is already hardest to hit. A
 consumer converts its own slack at the scale it drew the page and passes the
 result; the engine holds no default because it cannot see that scale.
 
-**Nearest, not a grown box.** Outsetting each rect and taking the first match
-makes overlapping boxes decide by paint order, so a click in the leading between
-two fields' lines answers whichever painted last, however far away it is.
-Ranking by distance answers the nearer one, and keeps the tolerance a pure
-widening: containment is distance zero — scaling a leg cannot turn a non-zero
-gap into a zero one — so no point that resolves exactly ever changes answer as
-`tolPt` rises. On a tie — two placements equally near, an exact hit under
-another exact hit — the later-painted wins.
+**Nearest, not a grown box.** The nearest placement within `tolPt` answers,
+which keeps the tolerance a pure widening: containment is distance zero, so no
+point that resolves exactly ever changes answer as `tolPt` rises. On a tie the
+later-painted wins. Widgets and content ink rank in one comparison, a widget
+taking a tie: a widget draws no spanned ink of its own, so ink beneath one must
+not swallow a click that lands on it.
 
-Widgets and content ink rank in one comparison, a widget taking a tie: a widget
-draws no spanned ink of its own, so ink beneath one must not swallow a click that
-lands on it, and nothing merely near a point outranks ink the pointer is inside
-of. One lane consulted before the other answers from the first at any gap within
-`tolPt`, ranking a far hit in that lane over a near one in the other.
-
-A tolerance is not a bounding box over ink the field does not fill: a click
-stays on ink some placement drew, and a point far from all of it resolves to
-nothing. Far is measured after the scaling, so a point out in a line's own
-whitespace is near that line and one a few rows off the text block is near
-nothing — but either way the answer is a glyph some placement drew, never a
-union spanning ink it did not. Which is why the reach is a ranking and not
-`regions()`: clamping within a line's own row to that line's own glyphs claims
-no ink between two disjoint segments.
+The slack is a radius in both axes. A click stays on ink some placement drew:
+the empty measure beside a short line is as far from that line as a point the
+same distance above it, and a point off the text block resolves to nothing.
 
 ## TypeScript surface
 


### PR DESCRIPTION
A review of the unreleased tolerance work (#1429, #1431) found the second half over-reaching. This trims it back. **−177 / +67 lines.**

## `LINE_REACH` is gone

`LINE_REACH = 128` divided the horizontal leg before ranking, making the admitted region `tol` tall and `tol * 128` wide. Nothing bounded the reach. Measured on the seeded `usaf_memo` (Letter, 612pt wide):

| `tol` | reach along the row (before) | (after) |
|---|---|---|
| 1.0pt | 128pt | 1pt |
| 3.1pt | 396pt | 3pt |
| 6.2pt | 792pt — wider than the page | 6pt |

Past `tol = pageWidth / 128` (4.8pt on Letter) a click's column stopped mattering at all. Probing every region on page 0 at `tol = 6.2` before the change, a click at `x=0` — the far left page edge — answered `signature_block`, which is set against the right:

```
subject          rect=[131,516,268,527]  x=0:"subject"          x=607:"subject"
$body            rect=[ 87,446,530,457]  x=0:"$body"            x=607:"$body"
signature_block  rect=[324,365,524,415]  x=0:"signature_block"  x=607:"signature_block"
```

After, `x=0` and `x=607` both answer nothing on every row.

The reach was also a screen quantity wearing a layout constant's clothes. `tol` is `slackPx / renderScale`, so the reach in document points moved with the zoom — a click past a line's end resolved at one scale and missed at the next. That is the exact coupling the argument for a caller-owned `tol` rejects. And the scaling sat in `RenderedRegion::distance`, so it applied equally to widget rects and segment union boxes, where "the rest of the measure the line does not fill" says nothing.

Both `distance` impls are a plain `hypot` again.

## What stays

Nearest-wins ranking, later-painted on a tie, the non-finite guard, `tol = 0` as exact containment, and the cross-lane comparison. The monotonicity property was re-verified rather than assumed: raising `tol` only admits strictly larger gaps, so the `min` cannot move — which is what makes the slack safe to raise.

The required `tol` argument stays as-is. A defaulted wrapper would undo the call-site churn, but it is a second method to maintain forever to save typing `0.0`.

## A widget the point is inside of skips the content scan

Ranking both lanes in one comparison made `field_at` build the content lane unconditionally, where the `or_else` it replaced skipped it whenever a widget contained the point. `Scan::hits(Some(page))` walks the target page's frame *and* marker-scans every page before it, so on a form-heavy document that is most of the document, on every click that lands on a widget. A widget at gap zero now answers outright — nothing ranks below zero and a widget already takes a tie, so no answer changes.

## Prose

Canon's hit-testing section goes from 55 lines to 28: the ellipse paragraph, the two "we didn't do X" paragraphs, and the closing re-argument are gone. The "a glyph box is the run's ink height by the glyph's advance" sentence now appears once (canon) instead of six times across `CHANGELOG`, `PREVIEW.md`, `span_scan.rs`, `engine.rs`, and the test header.

`runtime.d.ts` and `engine.rs` promised "`tolPt` is how far off the ink a click still counts, **in the same points**" — #1431 never updated them, so the JS-facing docs were wrong by two orders on one axis. They are true again, so the fix was making the code match the docs rather than the reverse.

The `LINE_REACH` CHANGELOG entry is deleted rather than given a counter-entry: it was never released.

## Tests

The two reach tests become one guard that the empty measure beside a line is not that line — the regression this PR would need to catch if `LINE_REACH` were ever reintroduced.

- `cargo test --workspace` — 63 binaries, exit 0
- `cargo clippy --workspace --all-targets` — no new warnings
- `node scripts/check-canon.mjs` — spine OK
- WASM `tsc` errors are pre-existing (identical on the untouched tree; they need a built `pkg/`). Edits there are JSDoc-only.

---
_Generated by [Claude Code](https://claude.ai/code/session_015QEmDfpA5Py6uutfAvL92k)_