### PR TITLE
Drop the retracted LINE_REACH entry the union merge brought back

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -11,7 +11,9 @@
 # both entries.
 #
 # It resolves silently: two branches editing the *same* entry merge to the union
-# of both, with nothing to flag it. Tolerable for prose no build step parses,
+# of both, with nothing to flag it. A deletion is not a state the union can hold
+# either, so an entry retracted on one branch returns with the next merge from a
+# branch that predates the retraction. Tolerable for prose no build step parses,
 # which is why it stays scoped to the changelog — a union-merged Cargo.lock is
 # duplicate `[[package]]` entries and a file cargo cannot read.
 #

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,26 +39,6 @@
   stored document gets a hard break, having no tag to dispatch on. The storage
   tag becomes `quillmark/document@0.112.0`; `@0.93.0` rows migrate forward on
   read. See [0.111 → 0.112](docs/migrations/0.111-to-0.112.md).
-- feat(core)!: **the pointer tolerance reaches along a line, not just around the
-  point.** A glyph's box is its run's ink height by its own advance, so the two
-  axes fail differently: across a line the dead gap is the leading, a few points
-  wide and belonging to the neighbouring line, while along one it is the rest of
-  the measure the line does not fill — 248 of 443 points beside a seeded
-  `usaf_memo` body line, 56% of that line's width — belonging to that line's own
-  end. The radius added for the leading is two orders short of the measure, and
-  widening it until it reached would answer for ink most of a page away. Hit
-  ranking now divides the horizontal leg by `LINE_REACH` before measuring, making
-  the admitted region an ellipse `tol` tall and `tol * LINE_REACH` wide: a click
-  out in a line's own whitespace answers with that line, and one a row up still
-  answers with the row above. The ratio is the engine's rather than the caller's,
-  `tol` being the pointer's slack and a screen quantity where this is a property
-  of how text is set. Containment is still distance zero — scaling a leg cannot
-  turn a non-zero gap into a zero one — so `tol = 0` remains exact containment and
-  no point that resolved exactly changes answer. The break is behavioural, not a
-  signature: `field_at` / `position_at` answer where they previously returned
-  nothing, and a consumer relying on a whitespace click resolving to nothing sees
-  a field.
-
 - feat(core)!: **`fieldAt` and `positionAt` take a pointer tolerance, and
   resolve to the nearest ink rather than the first containing it.** A glyph's
   box is its run's ink height by its own advance, so a text column answers over
@@ -71,13 +51,13 @@
   within it, a radius in both axes. The caller derives it from the scale it drew
   the page at, slack being a property of the pointer rather than of the
   document: a tolerance fixed in points shrinks under the cursor exactly as the
-  target does. Ranking by
-  distance rather than growing each rect is what keeps the answer the nearer
-  item's — outset boxes overlap, and a first match over them decides by paint
-  order — and makes the tolerance a pure widening: containment is distance zero,
-  so no point that resolves exactly changes answer however high `tol` goes, and
-  later-painted still wins a tie. `RenderedRegion::distance` is the measure, and
-  `contains` is now stated in terms of it. The break is the added argument on
+  target does. Ranking by distance rather than growing each rect is what keeps
+  the answer the nearer item's — outset boxes overlap, and a first match over
+  them decides by paint order — and makes the tolerance a pure widening:
+  containment is distance zero, so no point that resolves exactly changes answer
+  however high `tol` goes, and later-painted still wins a tie.
+  `RenderedRegion::distance` is the measure, and `contains` is now stated in
+  terms of it. The break is the added argument on
   `SessionHandle::{field_at,position_at}` and their `LiveSession` forwarders,
   which a type checker reports; `0.0` is the previous behaviour exactly. The
   WASM argument is optional and defaults to `0`, so no JS caller changes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -90,6 +90,7 @@ not_in_nav: |
   /migrations/0.108-to-0.109.md
   /migrations/0.109-to-0.110.md
   /migrations/0.110-to-0.111.md
+  /migrations/0.111-to-0.112.md
   /migrations/0.92-to-0.102.md
 
 markdown_extensions:


### PR DESCRIPTION
Post-release review of v0.111.0 → `main`. One defect, in the unreleased changelog.

## The entry

`refactor(core)!: the pointer tolerance is a radius, not a line reach` (5c9c6b1) removed `LINE_REACH` and deleted the entry describing it, saying so in its own message: *"The `LINE_REACH` CHANGELOG entry goes rather than gaining a counter-entry: it was never released."*

The entry is back on `main`. The attrs branch forked before that deletion, and `CHANGELOG.md` is `merge=union` — **the union of two sides cannot express a deletion**, so `73b65a6` (merging main into the attrs branch) restored it against the branch that had removed it:

| commit | `LINE_REACH` lines |
|---|---|
| `d8261d9` (main, post-deletion) | 0 |
| `65bf950` (attrs branch, pre-deletion) | 2 |
| `73b65a6` (their union merge) | **2** |

So the unreleased section documents hit ranking as an ellipse `tol` tall and `tol * LINE_REACH` wide, naming a constant that exists in no source file (`grep` finds it only in `CHANGELOG.md`), two lines above the entry that states the radius it actually is. Shipping 0.112 with this means telling consumers that a click out in a line's own whitespace resolves to that line, which it does not.

## Changes

- **`CHANGELOG.md`** — the entry goes, as 5c9c6b1 intended. The surviving tolerance entry already describes the final behaviour ("a radius in both axes") and is unchanged apart from a mid-paragraph reflow artifact that pass left behind.
- **`.gitattributes`** — the comment states the edit collision the union resolves silently but not the deletion it cannot hold, which is the half that bit here. One sentence added where the policy lives, since retracting an unreleased entry is normal and this recurs.
- **`mkdocs.yml`** — every migration guide is listed under `not_in_nav` except the newest, so `mkdocs build --strict` logs `migrations/0.111-to-0.112.md` as a page outside the nav. Verified from the docs job log on 1e451c1: it is **INFO**, not a warning — the build passes and the page is linked from the migrations index — so this restores the pattern rather than fixing a break.

## Verification

`cargo test --workspace`: 1274 passed, 0 failed. Docs-only diff; no source file changes.

## Not in this diff

The storage tag hard-codes `quillmark/document@0.112.0` and the guide is `0.111-to-0.112.md`, but `release-prepare.yml` takes the bump as a manual input and nothing asserts the two agree. Cut this release as `minor` (or `version_override: 0.112.0`) — a `patch` dispatch yields 0.111.1 against a 0.112.0 tag.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1knfR87vAzcAX9vCBrVy8)_