### PR TITLE
fix: the ingress boundaries enforce what the parser does

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,27 @@
   `SessionHandle::{field_at,position_at}` and their `LiveSession` forwarders,
   which a type checker reports; `0.0` is the previous behaviour exactly. The
   WASM argument is optional and defaults to `0`, so no JS caller changes.
+- fix(core): **the payload ingresses refuse what no parse can produce.** The
+  wire `TryFrom`, the storage DTO and `push_card` / `insert_card` each admitted
+  a payload whose markdown does not read back: a duplicate field key, more
+  fields than `MAX_FIELD_COUNT`, a repeated `$` entry, a comment whose text
+  spans lines, and a composable card carrying `$quill` or `$seed`. The comment
+  is the one that fails quietly — `#` opens a single line, so a text of
+  `"hi\ninjected: pwned"` emits bare YAML after the first line and re-reads as
+  a field nobody wrote. The rest emit markdown the parser rejects, and a
+  composable `$quill` also trips the `debug_assert` in `from_main_and_cards`,
+  which the rebuild behind `compile_data` runs: a render panicked on a debug
+  build where it owed an error. `PayloadViolation` carries the verdict —
+  `FieldViolation`'s seam one level up, reading the item list rather than one
+  item — which the wire maps to `WireError::InvalidPayload` and the DTO to
+  `StorageError::Malformed`, so both boundaries share one message. The
+  `$quill` / `$seed` half is positional, since a `CardWire` is equally how the
+  main card is read back, so it sits at placement beside the `$kind` gate as
+  `EditError::RootOnlyEntry` (`edit::root_only_entry`). The DTO refuses a root
+  `$kind` other than `main` and synthesises an absent one, as the parser does.
+  Additive: `validate_payload`, `PayloadViolation`, `MetaKey::ALL`. Both error
+  enums are `#[non_exhaustive]`, so no compiling caller changes, and no
+  document the format calls readable is refused.
 - fix(cli): **`render -f svg` / `-f png` writes every page.** The Typst backend
   emits one artifact per page and the command wrote `artifacts.first()`,
   discarding the rest with no warning, so a multi-page document produced a

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -492,8 +492,8 @@ impl TryFrom<DocumentV0_112_0> for Document {
             ));
         }
         // The root's `$kind` is `main` by position: any other value emits a root
-        // block the parser rejects. An absent one is synthesised, as the parser
-        // does and as the V0_81_0 hop already does, so the emit stays parseable.
+        // block the parser rejects. An absent one is synthesised so the emit
+        // stays parseable, as the parser and the V0_81_0 hop both do.
         match main.kind() {
             Some("main") => {}
             None => main.payload_mut().set_kind("main"),
@@ -1070,10 +1070,8 @@ impl From<CommentPathSegmentV0_82_0> for CommentPathSegmentV0_92_0 {
     }
 }
 
-/// Reject a payload no markdown-parsed `Document` could produce: too many
-/// fields, a duplicate user-field key, a repeated `$` entry, or a comment
-/// spanning lines. The markdown parser already rejects each; this only guards
-/// hand-crafted storage DTOs.
+/// Reject a payload no markdown-parsed `Document` could produce. The parser
+/// rejects each on source; this guards hand-crafted storage DTOs.
 fn validate_dto_payload(payload: &Payload) -> Result<(), StorageError> {
     super::edit::validate_payload(payload).map_err(|v| StorageError::Malformed(v.to_string()))
 }

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -485,11 +485,24 @@ impl TryFrom<DocumentV0_112_0> for Document {
     type Error = StorageError;
 
     fn try_from(payload: DocumentV0_112_0) -> Result<Self, Self::Error> {
-        let main = Card::try_from(payload.main)?;
+        let mut main = Card::try_from(payload.main)?;
         if main.quill().is_none() {
             return Err(StorageError::Malformed(
                 "main card must carry a $quill entry".into(),
             ));
+        }
+        // The root's `$kind` is `main` by position: any other value emits a root
+        // block the parser rejects. An absent one is synthesised, as the parser
+        // does and as the V0_81_0 hop already does, so the emit stays parseable.
+        match main.kind() {
+            Some("main") => {}
+            None => main.payload_mut().set_kind("main"),
+            Some(other) => {
+                return Err(StorageError::Malformed(format!(
+                    "main card has $kind {other:?}, but `main` is reserved for \
+                     the document root"
+                )))
+            }
         }
         let cards = payload
             .cards
@@ -1058,25 +1071,11 @@ impl From<CommentPathSegmentV0_82_0> for CommentPathSegmentV0_92_0 {
 }
 
 /// Reject a payload no markdown-parsed `Document` could produce: too many
-/// fields or a duplicate user-field key. The markdown parser already
-/// rejects both; this only guards hand-crafted storage DTOs.
+/// fields, a duplicate user-field key, a repeated `$` entry, or a comment
+/// spanning lines. The markdown parser already rejects each; this only guards
+/// hand-crafted storage DTOs.
 fn validate_dto_payload(payload: &Payload) -> Result<(), StorageError> {
-    if payload.len() > crate::error::MAX_FIELD_COUNT {
-        return Err(StorageError::Malformed(format!(
-            "card has {} user fields, exceeding the maximum of {}",
-            payload.len(),
-            crate::error::MAX_FIELD_COUNT
-        )));
-    }
-    let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
-    for key in payload.keys() {
-        if !seen.insert(key.as_str()) {
-            return Err(StorageError::Malformed(format!(
-                "duplicate user-field key {key:?}"
-            )));
-        }
-    }
-    Ok(())
+    super::edit::validate_payload(payload).map_err(|v| StorageError::Malformed(v.to_string()))
 }
 
 #[cfg(test)]

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -311,14 +311,14 @@ pub enum FieldViolation {
     FillOnMapping,
 }
 
-/// A payload-level invariant violation: the item list read as a whole, where
-/// [`FieldViolation`] reads one item's own contents.
+/// A payload-level invariant violation: [`FieldViolation`]'s seam one level up,
+/// reading the item list rather than one item's contents. Shared by every
+/// payload ingestion path, each mapping it to its own error type.
 ///
-/// The same seam as [`FieldViolation`] one level up: shared by every payload
-/// ingestion path, each mapping it to its own error type. Every variant names
-/// something YAML cannot express, so a payload carrying one emits markdown the
-/// parser rejects — or, for [`MultiLineComment`](Self::MultiLineComment),
-/// silently re-reads as a different document.
+/// Every variant names something YAML cannot express, so a payload carrying one
+/// emits markdown the parser rejects — except
+/// [`MultiLineComment`](Self::MultiLineComment), which re-reads cleanly as a
+/// different document.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum PayloadViolation {
@@ -328,10 +328,10 @@ pub enum PayloadViolation {
     /// (spec §8). Comments and `$` entries are not charged, matching the bound
     /// the parser applies after `$`-key extraction.
     TooManyFields { count: usize, max: usize },
-    /// A `$` system entry appears more than once.
+    /// A `$` system entry appears more than once; emit writes its line for each.
     DuplicateMeta { key: &'static str },
-    /// Comment text spans lines. A `#` opens one line, so the lines after the
-    /// first emit as bare YAML: the payload re-reads as fields no one wrote.
+    /// Comment text spans lines. A `#` opens one line, so every line after the
+    /// first emits as bare YAML: the payload re-reads as fields no one wrote.
     MultiLineComment,
 }
 
@@ -422,8 +422,7 @@ pub fn validate_field(key: &str, value: &serde_json::Value) -> Result<(), FieldV
     Ok(())
 }
 
-/// Validate a payload as a whole: field-key uniqueness and count, `$`-entry
-/// uniqueness, and single-line comments. The per-item twin is
+/// Validate a payload against every [`PayloadViolation`]. The per-item twin is
 /// [`validate_field`].
 pub fn validate_payload(payload: &Payload) -> Result<(), PayloadViolation> {
     let max = crate::error::MAX_FIELD_COUNT;
@@ -577,12 +576,11 @@ impl Document {
         Ok(())
     }
 
-    /// The invariants a card acquires by being placed as a composable card: a
-    /// valid, non-reserved `$kind` (a card with none is rejected as an invalid
-    /// empty name), and none of the root-only `$` entries.
+    /// The `$` entries a card may carry once placed as a composable card. A
+    /// card with no `$kind` is rejected as an invalid (empty) name.
     ///
-    /// Positional, so it lives here rather than in `TryFrom<CardWire>`: a bare
-    /// [`CardWire`](crate::CardWire) is also how the *main* card is read back
+    /// Positional, so it lives here rather than in `TryFrom<CardWire>`: a
+    /// [`CardWire`](crate::CardWire) is equally how the *main* card is read back
     /// and rewritten, and carries no signal of which it is.
     fn check_composable_placement(card: &Card) -> Result<(), EditError> {
         check_kind(card.kind().unwrap_or(""))?;

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -18,7 +18,7 @@ use quillmark_content::{ApplyError, ChangeBundle, Delta, Normalized};
 use crate::document::meta::{validate_composable_kind, CardKindError};
 use crate::error::diag_args;
 use crate::document::payload::MetaKey;
-use crate::document::{Card, Codec, ContentDecodeError, Document, Payload};
+use crate::document::{Card, Codec, ContentDecodeError, Document, Payload, PayloadItem};
 use crate::quill::{CoercionError, FieldSchema, FieldType, Leniency, QuillConfig};
 use crate::value::{PathSegment, QuillValue};
 use crate::version::QuillReference;
@@ -86,6 +86,11 @@ pub enum EditError {
 
     #[error("card kind 'main' is reserved for the document root")]
     ReservedKind,
+
+    /// A card placed as a composable card carries a `$` entry that binds the
+    /// document root (`$quill`, `$seed`).
+    #[error("'{key}' is carried by the document root only, not by a composable card")]
+    RootOnlyEntry { key: String },
 
     #[error("index {index} is out of range (len = {len})")]
     IndexOutOfRange { index: usize, len: usize },
@@ -190,6 +195,7 @@ impl EditError {
             EditError::UnknownField { .. } => "edit::unknown_field",
             EditError::InvalidKindName(_) => "edit::invalid_kind_name",
             EditError::ReservedKind => "edit::reserved_kind",
+            EditError::RootOnlyEntry { .. } => "edit::root_only_entry",
             EditError::IndexOutOfRange { .. } => "edit::index_out_of_range",
             EditError::ValueTooDeep { .. } => "edit::value_too_deep",
             EditError::FillOnMapping { .. } => "edit::fill_on_mapping",
@@ -217,6 +223,7 @@ impl EditError {
             EditError::UnknownField { field, at: _ } => diag_args! { "field" => field },
             EditError::InvalidKindName(kind) => diag_args! { "kind" => kind },
             EditError::ReservedKind => diag_args! {},
+            EditError::RootOnlyEntry { key } => diag_args! { "key" => key },
             EditError::IndexOutOfRange { index, len } => diag_args! {
                 "index" => index,
                 "len" => len,
@@ -304,6 +311,50 @@ pub enum FieldViolation {
     FillOnMapping,
 }
 
+/// A payload-level invariant violation: the item list read as a whole, where
+/// [`FieldViolation`] reads one item's own contents.
+///
+/// The same seam as [`FieldViolation`] one level up: shared by every payload
+/// ingestion path, each mapping it to its own error type. Every variant names
+/// something YAML cannot express, so a payload carrying one emits markdown the
+/// parser rejects — or, for [`MultiLineComment`](Self::MultiLineComment),
+/// silently re-reads as a different document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PayloadViolation {
+    /// Two user fields share a key; a YAML mapping admits each key once.
+    DuplicateField { key: String },
+    /// More user fields than [`MAX_FIELD_COUNT`](crate::error::MAX_FIELD_COUNT)
+    /// (spec §8). Comments and `$` entries are not charged, matching the bound
+    /// the parser applies after `$`-key extraction.
+    TooManyFields { count: usize, max: usize },
+    /// A `$` system entry appears more than once.
+    DuplicateMeta { key: &'static str },
+    /// Comment text spans lines. A `#` opens one line, so the lines after the
+    /// first emit as bare YAML: the payload re-reads as fields no one wrote.
+    MultiLineComment,
+}
+
+impl std::fmt::Display for PayloadViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PayloadViolation::DuplicateField { key } => {
+                write!(f, "duplicate user-field key {key:?}")
+            }
+            PayloadViolation::TooManyFields { count, max } => write!(
+                f,
+                "card has {count} user fields, exceeding the maximum of {max}"
+            ),
+            PayloadViolation::DuplicateMeta { key } => {
+                write!(f, "duplicate `{key}` entry")
+            }
+            PayloadViolation::MultiLineComment => f.write_str(
+                "comment text spans multiple lines; a comment occupies one line",
+            ),
+        }
+    }
+}
+
 pub(crate) fn edit_error_from_violation(name: &str, v: FieldViolation) -> EditError {
     match v {
         FieldViolation::InvalidName => EditError::InvalidFieldName(name.to_string()),
@@ -367,6 +418,53 @@ pub fn validate_field(key: &str, value: &serde_json::Value) -> Result<(), FieldV
     }
     if crate::value::json_depth_exceeds(value, crate::document::limits::MAX_YAML_DEPTH) {
         return Err(FieldViolation::TooDeep);
+    }
+    Ok(())
+}
+
+/// Validate a payload as a whole: field-key uniqueness and count, `$`-entry
+/// uniqueness, and single-line comments. The per-item twin is
+/// [`validate_field`].
+pub fn validate_payload(payload: &Payload) -> Result<(), PayloadViolation> {
+    let max = crate::error::MAX_FIELD_COUNT;
+    let count = payload.len();
+    if count > max {
+        return Err(PayloadViolation::TooManyFields { count, max });
+    }
+
+    let mut fields: std::collections::HashSet<&str> = std::collections::HashSet::new();
+    let mut seen_quill = false;
+    let mut seen_kind = false;
+    let mut metas: std::collections::HashSet<MetaKey> = std::collections::HashSet::new();
+    for item in payload.items() {
+        let dup = |key| Err(PayloadViolation::DuplicateMeta { key });
+        match item {
+            PayloadItem::Field { key, .. } => {
+                if !fields.insert(key.as_str()) {
+                    return Err(PayloadViolation::DuplicateField { key: key.clone() });
+                }
+            }
+            PayloadItem::Quill { .. } => {
+                if std::mem::replace(&mut seen_quill, true) {
+                    return dup("$quill");
+                }
+            }
+            PayloadItem::Kind { .. } => {
+                if std::mem::replace(&mut seen_kind, true) {
+                    return dup("$kind");
+                }
+            }
+            PayloadItem::Meta { key, .. } => {
+                if !metas.insert(*key) {
+                    return dup(key.as_str());
+                }
+            }
+            PayloadItem::Comment { text, .. } => {
+                if text.contains(['\n', '\r']) {
+                    return Err(PayloadViolation::MultiLineComment);
+                }
+            }
+        }
     }
     Ok(())
 }
@@ -461,7 +559,7 @@ impl Document {
     /// composable kind ([`EditError::InvalidKindName`] /
     /// [`EditError::ReservedKind`] otherwise).
     pub fn push_card(&mut self, card: Card) -> Result<(), EditError> {
-        Self::check_composable_kind(&card)?;
+        Self::check_composable_placement(&card)?;
         self.cards_vec_mut().push(card);
         Ok(())
     }
@@ -474,14 +572,34 @@ impl Document {
         if index > len {
             return Err(EditError::IndexOutOfRange { index, len });
         }
-        Self::check_composable_kind(&card)?;
+        Self::check_composable_placement(&card)?;
         self.cards_vec_mut().insert(index, card);
         Ok(())
     }
 
-    /// A card with no `$kind` is rejected as an invalid (empty) name.
-    fn check_composable_kind(card: &Card) -> Result<(), EditError> {
-        check_kind(card.kind().unwrap_or(""))
+    /// The invariants a card acquires by being placed as a composable card: a
+    /// valid, non-reserved `$kind` (a card with none is rejected as an invalid
+    /// empty name), and none of the root-only `$` entries.
+    ///
+    /// Positional, so it lives here rather than in `TryFrom<CardWire>`: a bare
+    /// [`CardWire`](crate::CardWire) is also how the *main* card is read back
+    /// and rewritten, and carries no signal of which it is.
+    fn check_composable_placement(card: &Card) -> Result<(), EditError> {
+        check_kind(card.kind().unwrap_or(""))?;
+        if card.quill().is_some() {
+            return Err(EditError::RootOnlyEntry {
+                key: "$quill".to_string(),
+            });
+        }
+        if let Some(key) = MetaKey::ALL
+            .iter()
+            .find(|k| k.is_root_only() && card.payload().meta(**k).is_some())
+        {
+            return Err(EditError::RootOnlyEntry {
+                key: key.as_str().to_string(),
+            });
+        }
+        Ok(())
     }
 
     pub fn remove_card(&mut self, index: usize) -> Option<Card> {

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -39,8 +39,8 @@ pub enum MetaKey {
 }
 
 impl MetaKey {
-    /// Every variant, so a rule keyed on a property ([`is_root_only`](Self::is_root_only))
-    /// enumerates rather than naming the members it happens to match today.
+    /// Lets a rule keyed on a property ([`is_root_only`](Self::is_root_only))
+    /// enumerate rather than name the members it happens to match today.
     pub const ALL: [MetaKey; 2] = [MetaKey::Ext, MetaKey::Seed];
 
     /// The literal source key (`"$ext"` / `"$seed"`).

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -28,7 +28,7 @@ use crate::version::QuillReference;
 /// DTO. They differ in canonical sort rank, root-only-ness, and whether the
 /// seeding layer interprets them ([`crate::SeedOverlay::from_json`] reads
 /// `$seed`; `$ext` stays opaque).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[non_exhaustive]
 pub enum MetaKey {
     /// `$ext`: opaque out-of-band consumer state (editor renames, agent
@@ -39,6 +39,10 @@ pub enum MetaKey {
 }
 
 impl MetaKey {
+    /// Every variant, so a rule keyed on a property ([`is_root_only`](Self::is_root_only))
+    /// enumerates rather than naming the members it happens to match today.
+    pub const ALL: [MetaKey; 2] = [MetaKey::Ext, MetaKey::Seed];
+
     /// The literal source key (`"$ext"` / `"$seed"`).
     pub fn as_str(self) -> &'static str {
         match self {

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1074,3 +1074,158 @@ fn wire_card_rejects_value_past_depth_limit_and_bad_names() {
     );
 }
 
+
+/// `$quill` and `$seed` bind the document root. Placing a card that carries
+/// either is refused, so the emitted markdown stays parseable — the invariant
+/// `from_main_and_cards` asserts, enforced where a card is placed.
+#[test]
+fn test_insert_card_refuses_root_only_entries() {
+    use crate::document::CardWire;
+
+    let placed = |mutate: &dyn Fn(&mut CardWire)| {
+        let mut wire = CardWire::new("note".to_string(), serde_json::Value::Null);
+        mutate(&mut wire);
+        let card = Card::try_from(wire).expect("the wire stays permissive on placement metadata");
+        let mut doc = make_doc();
+        doc.push_card(card.clone()).map(|()| doc).map_err(|e| {
+            let mut doc = make_doc();
+            assert_eq!(doc.insert_card(0, card), Err(e.clone()), "push and insert agree");
+            e
+        })
+    };
+
+    assert_eq!(
+        placed(&|w| w.quill = Some("memo@1.0.0".to_string())).unwrap_err(),
+        EditError::RootOnlyEntry {
+            key: "$quill".to_string()
+        }
+    );
+    assert_eq!(
+        placed(&|w| w.seed = Some(
+            serde_json::json!({"note": {}}).as_object().unwrap().clone()
+        ))
+        .unwrap_err(),
+        EditError::RootOnlyEntry {
+            key: "$seed".to_string()
+        }
+    );
+
+    // `$ext` is not root-only: it rides any card.
+    let doc = placed(&|w| {
+        w.ext = Some(serde_json::json!({"ns": {}}).as_object().unwrap().clone())
+    })
+    .expect("$ext is allowed on a composable card");
+    let _ = Document::parse(&doc.to_markdown()).expect("emit reparses");
+
+    // The comment on `check_composable_placement`: the same wire is how the
+    // main card is read back, and that round trip must keep working.
+    let main = CardWire::from(make_doc().main());
+    assert!(main.quill.is_some());
+    Card::try_from(main).expect("the main card still crosses the wire");
+}
+
+/// A card the wire refuses never reaches placement: the payload invariants that
+/// are card-local are checked where the card is built.
+#[test]
+fn test_wire_refuses_payload_level_violations() {
+    use crate::document::wire::{CardWire, PayloadItemWire, WireError};
+
+    let built = |items: Vec<PayloadItemWire>| {
+        let mut wire = CardWire::new("note".to_string(), serde_json::Value::Null);
+        wire.payload_items = items;
+        Card::try_from(wire)
+    };
+    let field = |key: &str| PayloadItemWire::Field {
+        key: key.to_string(),
+        value: serde_json::json!(1),
+        fill: false,
+        nested_fills: Vec::new(),
+    };
+
+    let dup = built(vec![field("title"), field("title")]).unwrap_err();
+    assert!(
+        matches!(&dup, WireError::InvalidPayload { reason } if reason.contains("duplicate")),
+        "{dup:?}"
+    );
+
+    let too_many =
+        built((0..=crate::error::MAX_FIELD_COUNT).map(|i| field(&format!("f{i}"))).collect())
+            .unwrap_err();
+    assert!(
+        matches!(&too_many, WireError::InvalidPayload { reason } if reason.contains("maximum")),
+        "{too_many:?}"
+    );
+
+    // A comment spanning lines emits bare YAML after the first line: the one
+    // violation whose markdown re-reads *cleanly*, as fields no one wrote.
+    let injected = built(vec![PayloadItemWire::Comment {
+        text: "hi\ninjected: pwned".to_string(),
+        inline: false,
+    }])
+    .unwrap_err();
+    assert!(
+        matches!(&injected, WireError::InvalidPayload { reason } if reason.contains("one line")),
+        "{injected:?}"
+    );
+
+    built(vec![field("title"), field("subject")]).expect("distinct keys cross");
+}
+
+/// The storage DTO is a hand-craftable ingress, so it owns the invariants the
+/// parser enforces on source: the root's positional `$kind`, and one `$` entry
+/// per key.
+#[test]
+fn storage_dto_polices_root_kind_and_repeated_entries() {
+    let load = |items: serde_json::Value| {
+        serde_json::from_value::<crate::document::Document>(serde_json::json!({
+            "schema": "quillmark/document@0.92.0",
+            "main": {"payload": {"items": items}, "body": ""},
+            "cards": []
+        }))
+    };
+    let quill = serde_json::json!({"type": "quill", "value": "q@1.0"});
+    let kind = |v: &str| serde_json::json!({"type": "kind", "value": v});
+
+    let err = load(serde_json::json!([quill, kind("note")])).unwrap_err();
+    assert!(
+        err.to_string().contains("reserved for the document root"),
+        "a non-`main` root kind emits a block the parser rejects, got: {err}"
+    );
+
+    // Absent is not malformed: the parser synthesises it, so the DTO does too.
+    let doc = load(serde_json::json!([quill])).expect("an absent root kind loads");
+    assert_eq!(doc.main().kind(), Some("main"));
+    let reparsed = Document::parse(&doc.to_markdown()).expect("emit reparses");
+    assert_eq!(reparsed.document.main().kind(), Some("main"));
+
+    for repeated in [
+        serde_json::json!([quill, kind("main"), quill]),
+        serde_json::json!([quill, kind("main"), kind("main")]),
+    ] {
+        let err = load(repeated).unwrap_err();
+        assert!(
+            err.to_string().contains("duplicate"),
+            "a repeated `$` entry emits the line twice, got: {err}"
+        );
+    }
+}
+
+/// A comment carrying a newline emits bare YAML after its first line: the
+/// storage twin of the wire's injection guard.
+#[test]
+fn storage_dto_refuses_a_multi_line_comment() {
+    let err = serde_json::from_value::<crate::document::Document>(serde_json::json!({
+        "schema": "quillmark/document@0.92.0",
+        "main": {
+            "payload": {"items": [
+                {"type": "quill", "value": "q@1.0"},
+                {"type": "kind", "value": "main"},
+                {"type": "comment", "text": "hi\ninjected: pwned", "inline": false}
+            ]},
+            "body": ""
+        },
+        "cards": []
+    }))
+    .unwrap_err();
+    assert!(err.to_string().contains("one line"), "got: {err}");
+}

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1117,8 +1117,8 @@ fn test_insert_card_refuses_root_only_entries() {
     .expect("$ext is allowed on a composable card");
     let _ = Document::parse(&doc.to_markdown()).expect("emit reparses");
 
-    // The comment on `check_composable_placement`: the same wire is how the
-    // main card is read back, and that round trip must keep working.
+    // The same wire is how the main card is read back, so refusing `$quill` at
+    // placement must not cost that round trip.
     let main = CardWire::from(make_doc().main());
     assert!(main.quill.is_some());
     Card::try_from(main).expect("the main card still crosses the wire");
@@ -1171,9 +1171,8 @@ fn test_wire_refuses_payload_level_violations() {
     built(vec![field("title"), field("subject")]).expect("distinct keys cross");
 }
 
-/// The storage DTO is a hand-craftable ingress, so it owns the invariants the
-/// parser enforces on source: the root's positional `$kind`, and one `$` entry
-/// per key.
+/// The storage DTO is a hand-craftable ingress, so it owns the positional
+/// invariants the parser enforces on source.
 #[test]
 fn storage_dto_polices_root_kind_and_repeated_entries() {
     let load = |items: serde_json::Value| {

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -157,8 +157,9 @@ pub enum WireError {
     /// `[A-Za-z_][A-Za-z0-9_]*`, or a value (including `$ext`) nesting past the
     /// §8 depth limit.
     InvalidField { key: String, reason: String },
-    /// The `payload_items` list violates an invariant of the list as a whole:
-    /// a duplicate key, too many fields, or a comment spanning lines.
+    /// The `payload_items` list violates an invariant of the list as a whole
+    /// (`edit::PayloadViolation`): a duplicate key, a field count past the §8
+    /// bound, a comment spanning lines.
     InvalidPayload { reason: String },
 }
 
@@ -270,14 +271,13 @@ impl TryFrom<CardWire> for Card {
                 .map_err(|reason| WireError::InvalidQuillReference { value, reason })?;
             payload.set_quill(reference);
         }
-        // No `$kind` check, and none on `$quill`/`$seed` above: their validity
-        // is positional (`main` is right for the root and reserved for a
-        // composable card; `$quill`/`$seed` bind the root and are refused on a
-        // composable card) and a `CardWire` carries no signal of which it is —
-        // it is equally how the main card is read back and rewritten. All three
-        // belong to `push_card`/`insert_card`. Checking only the grammar here
-        // would split one user-facing concept across two error types and shadow
-        // the routable `EditError` code.
+        // No `$kind` check, and none on `$quill`/`$seed` above: all three are
+        // positional — `main` is right for the root and reserved for a
+        // composable card, `$quill`/`$seed` bind the root — and a `CardWire` is
+        // equally how the main card is read back and rewritten, so it carries no
+        // signal of which it is. All three belong to `push_card`/`insert_card`.
+        // Checking only the grammar here would split one user-facing concept
+        // across two error types and shadow the routable `EditError` code.
         if !wire.kind.is_empty() {
             payload.set_kind(wire.kind);
         }

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -157,6 +157,9 @@ pub enum WireError {
     /// `[A-Za-z_][A-Za-z0-9_]*`, or a value (including `$ext`) nesting past the
     /// §8 depth limit.
     InvalidField { key: String, reason: String },
+    /// The `payload_items` list violates an invariant of the list as a whole:
+    /// a duplicate key, too many fields, or a comment spanning lines.
+    InvalidPayload { reason: String },
 }
 
 impl std::fmt::Display for WireError {
@@ -168,6 +171,7 @@ impl std::fmt::Display for WireError {
             WireError::InvalidField { key, reason } => {
                 write!(f, "invalid field {key:?}: {reason}")
             }
+            WireError::InvalidPayload { reason } => f.write_str(reason),
         }
     }
 }
@@ -266,11 +270,14 @@ impl TryFrom<CardWire> for Card {
                 .map_err(|reason| WireError::InvalidQuillReference { value, reason })?;
             payload.set_quill(reference);
         }
-        // No `$kind` check: its validity is positional (`main` is right for the
-        // root, reserved for a composable card) and a `CardWire` carries no
-        // signal of which it is, so it belongs to `push_card`/`insert_card`.
-        // Checking only the grammar here would split one user-facing concept
-        // across two error types and shadow the routable `EditError` code.
+        // No `$kind` check, and none on `$quill`/`$seed` above: their validity
+        // is positional (`main` is right for the root and reserved for a
+        // composable card; `$quill`/`$seed` bind the root and are refused on a
+        // composable card) and a `CardWire` carries no signal of which it is —
+        // it is equally how the main card is read back and rewritten. All three
+        // belong to `push_card`/`insert_card`. Checking only the grammar here
+        // would split one user-facing concept across two error types and shadow
+        // the routable `EditError` code.
         if !wire.kind.is_empty() {
             payload.set_kind(wire.kind);
         }
@@ -287,6 +294,8 @@ impl TryFrom<CardWire> for Card {
         if let Some(seed) = wire.seed {
             payload.set_seed(crate::value::depth_check_meta_map(seed, too_deep("$seed"))?);
         }
+        super::edit::validate_payload(&payload)
+            .map_err(|v| WireError::InvalidPayload { reason: v.to_string() })?;
         let body = body_from_wire(&wire.body)?;
         Ok(Card::from_parts(payload, body))
     }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -613,6 +613,9 @@ mod args_canon {
             EditError::unknown_field("nope"),
             EditError::InvalidKindName("Bad".into()),
             EditError::ReservedKind,
+            EditError::RootOnlyEntry {
+                key: "$quill".into(),
+            },
             EditError::IndexOutOfRange { index: 3, len: 1 },
             EditError::ValueTooDeep { max: 8 },
             EditError::FillOnMapping {

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -134,7 +134,8 @@ state, never reaches the backend.
 the **main card only**, round-tripping through Markdown and the storage DTO and
 stripped before backends, but the seeding layer *interprets* it. It is
 **root-only** like `$quill`: a composable card carrying `$seed` is rejected at
-parse and on storage load. It answers
+parse, on storage load, and on insert (`push_card` / `insert_card`, the
+positional gate that also polices `$kind`). It answers
 "what does a *new* card of kind K start with in this document": each entry,
 keyed by composable card-kind, is a **sparse overlay** of the user fields (plus
 an optional reserved `$body` string) a freshly-added card of that kind inherits.

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -327,6 +327,7 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `edit::field_coercion_failed` | `field`, `target` | structured, coarser |
 | `edit::field_decode` | `field`, `codec` | structured, coarser |
 | `edit::reserved_kind` | — | code-determined |
+| `edit::root_only_entry` | `key` | structured |
 | `edit::import` | — | fallback |
 | `edit::content_apply` | — | fallback |
 | `conform::invalid_field_name` | `field` | structured |


### PR DESCRIPTION
Closes #1391.

## What was wrong

`TryFrom<CardWire>` and the storage DTO admitted payloads no parse could produce, and `push_card`/`insert_card` policed `$kind` alone. All four of the issue's claims reproduce on `main` with the error strings it quotes, plus two more found while reviewing:

| Ingress | Admitted | Emitted markdown |
|---|---|---|
| wire | duplicate field keys | `duplicate mapping key: title` |
| wire | 1500 fields (bound is 1000) | `Input too large` |
| wire | comment containing `\n` | **reparses cleanly, with a field no one wrote** |
| `push_card` | `$quill` / `$seed` on a composable card | `must not declare $quill` |
| DTO | main `$kind: note` | `` `main` is reserved for the document root `` |
| DTO | repeated `$quill` / `$kind` item | `duplicate mapping key: $quill` |

Two consequences are worse than the round-trip failure the issue describes:

- **A composable card carrying `$quill` panics in debug builds.** `normalize_document` rebuilds through `from_main_and_cards`, whose `debug_assert` is exactly the invariant `push_card` skipped, and `compile_data` calls it — so a render on a `maturin develop` build panicked rather than erroring.
- **The document could not be saved.** The storage DTO already enforced the composable-card quill/seed rule, so `insertCard` produced a `Document` that failed `serde` round-trip: `composable cards must not carry a $quill entry`.
- The multi-line comment is the one that does not fail loudly. It emits bare YAML after the first line, so `"hi\ninjected: pwned"` re-reads as a document carrying `injected: pwned`.

## The fix

The repo already had the seam for this. `FieldViolation` is documented as "shared by every payload ingestion path... each boundary maps it to its own error type", so this adds its sibling one level up rather than routing `validate_dto_payload` into the wire and the mutators, which would cross `StorageError` into code that owes `WireError` and `EditError`.

- **`validate_payload` → `PayloadViolation`** — duplicate field key, field count, repeated `$` entry, multi-line comment. Mapped by the wire to `WireError::InvalidPayload` and by the DTO to `StorageError::Malformed`, replacing the DTO's hand-rolled duplicate/count pair so both boundaries share one message. Counts `Payload::len()`, so comments and `$` entries are not charged against the field bound.
- **`check_composable_placement`** — the positional half, where `$kind` was already gated. New `EditError::RootOnlyEntry`. It enumerates `MetaKey::ALL` filtered by the existing `is_root_only()` rather than naming `$seed`, so a future root-only key is covered without a second edit.
- **DTO root `$kind`** — reject a present non-`main` value; synthesise an absent one, as the parser and the `V0_81_0` hop both do.

**`$quill`/`$seed` are checked at placement, never in `TryFrom<CardWire>`.** A `CardWire` is equally how the *main* card is read back and rewritten (`main` getter in both bindings, pinned by `card_wire_round_trips_quill`), so a check there would break reading the main card. This is the reasoning the existing comment already gave for `$kind`, extended to its two siblings; both tests pinning that seam still pass.

## Backwards compatibility

**No break for compiling callers, and no previously-valid document is refused.**

- New variants land on `EditError` and `WireError`, both `#[non_exhaustive]`; `MetaKey` gains `Hash` and `ALL`. All additive.
- Every `$` setter upserts, so **no in-memory write path can produce a duplicate `$` entry** — only a hand-crafted DTO can.
- No public API can set a non-`main` root `$kind`: `set_card_kind` is composable-only and `Card` exposes no kind setter.
- An **absent** root `$kind` is normalised rather than rejected, so blobs the format's own rules call readable stay readable.
- Verified: every parseable fixture in the repo still parses → saves → loads → emits, unchanged; `cargo test --workspace` green, including the legacy-schema migration tests.

The behavioural change is that four previously-accepted *corrupt* inputs now error where they used to succeed and produce an unparseable, unsaveable, or silently-altered document. One narrow case is worth calling out: a consumer who pushed a comment containing a newline through `insertCard` could have persisted a blob that now fails to load. Such a document already mutated itself on every markdown round trip, so the load error surfaces corruption rather than causing it.

## Not in scope

Four gaps in the same family, left out to keep this reviewable — the first two verified:

- `store_field` past 1000 fields builds a `Document` that **fails its own serde round-trip**. Fixing it changes `store_field`'s error surface for every caller.
- `store_seed_overlay` via `card_mut` puts root-only `$seed` on an already-placed card — positional, but *post*-placement, so this gate does not catch it.
- `MAX_CARD_COUNT` and `MAX_INPUT_SIZE` are parse-only.
- `push_card` rejects a kindless composable card that parse and the DTO both accept, so `remove_card` → `push_card` is not total. Deliberate-looking, and binding tests pin it.

Unrelated: the field-count overflow reuses `ParseError::InputTooLarge`, so exceeding 1000 *fields* reports `Input too large: 1500 bytes (max: 1000 bytes)`.

## Tests

Four added to `edit_tests.rs`, covering both mutators, all four payload violations, the `$ext`-is-not-root-only case, the main-card wire round trip, and the DTO's root-kind and repeated-entry paths.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rg6MdjeAZvKvJXBZ2u8sMZ)_