### PR TITLE
fix(pdfform): flatten keeps the background's resources and its own /Contents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@
   document-level pair rather than a `store` / `load` pair. The old names are
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
+- fix(pdfform): **flatten keeps the background's resources and its own
+  `/Contents`.** `/Resources` is inheritable, so writing a fresh one onto a page
+  that carried none shadowed the ancestor's dict and unbound every name the
+  background stream selects; the effective dict is now resolved up `/Parent`,
+  inlined onto the page and extended there. The drawn fonts take names free in
+  that dict (`Helv2` where `Helv` is taken), since a second binding for a name
+  the background uses rebinds it under a last-wins parser. A `/Contents`
+  reference naming an *array* object expands to its elements instead of being
+  wrapped, which had left an array as an element of the `/Contents` array.
 
 ## v0.112.0 - 2026-09-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "hayro",
  "hayro-svg",
  "lopdf",
+ "pdf-writer",
  "quillmark",
  "quillmark-content",
  "quillmark-core",

--- a/crates/backends/pdfform/Cargo.toml
+++ b/crates/backends/pdfform/Cargo.toml
@@ -32,3 +32,5 @@ quillmark-fixtures = { workspace = true }
 # an unpublishable cycle; cargo strips path-only dev-deps at packaging.
 quillmark = { path = "../../quillmark" }
 lopdf = { workspace = true }
+# Builds the page-tree shapes the flatten tests need but no fixture carries.
+pdf-writer = { workspace = true }

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -9,8 +9,13 @@
 //! true of any background with balanced `q`/`Q` and no dangling `cm`. Backs the
 //! SVG/PNG raster outputs only; the AcroForm PDF deliverable is stamped.
 
+use std::collections::HashSet;
+
 use quillmark_pdf::{
-    reader::{extract_outer_dict, find_dict_value, splice_dict_value, ObjectIndex, UpdatedObject},
+    reader::{
+        extract_outer_dict, find_dict_value, parse_indirect_ref, splice_dict_value, ObjectIndex,
+        UpdatedObject,
+    },
     writer::{
         alloc_id, append_refs_to_array_key, dict_object, pdf_escape, winansi_encode, OnNonArray,
     },
@@ -75,17 +80,30 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
             continue;
         }
 
-        let stream_id = alloc_id(&mut up.next_id)?;
-        up.objects.push(content_stream_object(
-            stream_id,
-            &build_content_stream(page_fields),
-        ));
-
         let page_obj_id = page_ids[page_idx];
         let what = format!("page object {page_obj_id}");
         let pg_dict = idx.dict(page_obj_id, CODE_PARSE, &what)?;
 
-        let new_pg = rewrite_page_for_flatten(pg_dict, helv_id, zadb_id, stream_id)?;
+        let resources = resolve_resources(&idx, pg_dict)?;
+        let font_inner: &[u8] = match &resources {
+            Some(res) => font_dict(res)?.map_or(&[], |f| f.inner),
+            None => &[],
+        };
+        let names = FontNames::free_in(font_inner);
+
+        let stream_id = alloc_id(&mut up.next_id)?;
+        up.objects.push(content_stream_object(
+            stream_id,
+            &build_content_stream(page_fields, &names),
+        ));
+
+        let new_pg = rewrite_page_for_flatten(
+            &idx,
+            pg_dict,
+            resources.as_deref(),
+            &[(&names.text, helv_id), (&names.check, zadb_id)],
+            stream_id,
+        )?;
         up.objects.push(dict_object(page_obj_id, &new_pg));
     }
 
@@ -100,7 +118,40 @@ fn has_drawable_value(spec: &FieldSpec) -> bool {
     }
 }
 
-fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
+/// The `/Font` resource names one page's flatten stream selects. Chosen per page
+/// because they must be free in that page's own `/Font` dict.
+struct FontNames {
+    text: String,
+    check: String,
+}
+
+impl FontNames {
+    fn free_in(font_inner: &[u8]) -> Self {
+        Self {
+            text: free_font_name(font_inner, typography::TEXT_FONT_RESOURCE),
+            check: free_font_name(font_inner, typography::CHECK_FONT_RESOURCE),
+        }
+    }
+}
+
+/// `preferred` when it is unbound in `font_inner`, else the first free
+/// `<preferred><n>`. Binding a name the background's own stream selects would
+/// rebind it there too: a dict carrying the key twice resolves last-wins.
+fn free_font_name(font_inner: &[u8], preferred: &str) -> String {
+    if find_dict_value(font_inner, preferred).is_none() {
+        return preferred.to_string();
+    }
+    let mut n = 2;
+    loop {
+        let name = format!("{preferred}{n}");
+        if find_dict_value(font_inner, &name).is_none() {
+            return name;
+        }
+        n += 1;
+    }
+}
+
+fn build_content_stream(fields: &[&FieldSpec], names: &FontNames) -> Vec<u8> {
     let mut out = Vec::new();
     for spec in fields {
         let [x0, y0, x1, y1] = spec.rect;
@@ -113,7 +164,7 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
                 // ZapfDingbats check glyphs are roughly square; centre in the box.
                 let x_pos = x0 + (w - size * typography::CHECK_GLYPH_WIDTH_FACTOR) * 0.5;
                 let y_pos = y0 + (h - size) * 0.5;
-                write_zadb_char(&mut out, x_pos, y_pos, size);
+                write_check_char(&mut out, &names.check, x_pos, y_pos, size);
             }
             FieldType::Text { .. } => {
                 if let Some(value) = &spec.value {
@@ -121,7 +172,7 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
                     let x_pos = x0 + typography::TEXT_INSET;
                     let y_top = y1 - size - typography::TEXT_TOP_INSET;
                     let lines: Vec<&str> = value.lines().collect();
-                    write_text_block(&mut out, &lines, x_pos, y_top, size, spec.rect);
+                    write_text_block(&mut out, &names.text, &lines, x_pos, y_top, size, spec.rect);
                 }
             }
             FieldType::Choice { .. } => {
@@ -129,7 +180,15 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
                     let size = typography::value_size(h);
                     let x_pos = x0 + typography::TEXT_INSET;
                     let y_pos = y0 + (h - size) * 0.5;
-                    write_text_block(&mut out, &[value.as_str()], x_pos, y_pos, size, spec.rect);
+                    write_text_block(
+                        &mut out,
+                        &names.text,
+                        &[value.as_str()],
+                        x_pos,
+                        y_pos,
+                        size,
+                        spec.rect,
+                    );
                 }
             }
         }
@@ -137,10 +196,18 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
     out
 }
 
-/// Draw `lines` in `/Helv`, clipped to `clip` so an over-long value cannot paint
-/// over neighbouring content. Bytes are transcoded to WinAnsi to match the
-/// font's `/Encoding /WinAnsiEncoding`.
-fn write_text_block(out: &mut Vec<u8>, lines: &[&str], x: f32, y: f32, size: f32, clip: [f32; 4]) {
+/// Draw `lines` in the page's text font, clipped to `clip` so an over-long value
+/// cannot paint over neighbouring content. Bytes are transcoded to WinAnsi to
+/// match the font's `/Encoding /WinAnsiEncoding`.
+fn write_text_block(
+    out: &mut Vec<u8>,
+    font: &str,
+    lines: &[&str],
+    x: f32,
+    y: f32,
+    size: f32,
+    clip: [f32; 4],
+) {
     if lines.is_empty() {
         return;
     }
@@ -156,7 +223,7 @@ fn write_text_block(out: &mut Vec<u8>, lines: &[&str], x: f32, y: f32, size: f32
     out.push(b' ');
     push_f32(out, cy1 - cy0);
     out.extend_from_slice(b" re W n\n");
-    out.extend_from_slice(b"BT\n/Helv ");
+    out.extend_from_slice(format!("BT\n/{font} ").as_bytes());
     push_f32(out, size);
     out.extend_from_slice(b" Tf\n");
     push_f32(out, x);
@@ -178,8 +245,8 @@ fn write_text_block(out: &mut Vec<u8>, lines: &[&str], x: f32, y: f32, size: f32
 
 /// Draw ZapfDingbats glyph 0x34 (`'4'`), the filled check mark — the same glyph
 /// the AcroForm stamp path declares via `/MK /CA (4)`.
-fn write_zadb_char(out: &mut Vec<u8>, x: f32, y: f32, size: f32) {
-    out.extend_from_slice(b"q\nBT\n/ZaDb ");
+fn write_check_char(out: &mut Vec<u8>, font: &str, x: f32, y: f32, size: f32) {
+    out.extend_from_slice(format!("q\nBT\n/{font} ").as_bytes());
     push_f32(out, size);
     out.extend_from_slice(b" Tf\n");
     push_f32(out, x);
@@ -189,90 +256,189 @@ fn write_zadb_char(out: &mut Vec<u8>, x: f32, y: f32, size: f32) {
 }
 
 fn rewrite_page_for_flatten(
+    idx: &ObjectIndex,
     pg_dict: &[u8],
-    helv_id: u32,
-    zadb_id: u32,
+    resources: Option<&[u8]>,
+    fonts: &[(&str, u32)],
     stream_id: u32,
 ) -> Result<Vec<u8>, PdfError> {
-    // A page `/Contents` is legitimately a bare stream reference, so the
-    // flatten stream wraps it rather than refusing it.
-    let with_stream = append_refs_to_array_key(
+    let with_stream = append_content_stream(idx, pg_dict, stream_id)?;
+    add_font_resources(&with_stream, resources, fonts)
+}
+
+/// Append the flatten stream to the page `/Contents`. A `/Contents` naming an
+/// *array* object expands to that array's elements: wrapping the reference would
+/// leave an array as an element of the `/Contents` array, which is not a content
+/// stream. A reference to a stream is legitimate and wraps.
+fn append_content_stream(
+    idx: &ObjectIndex,
+    pg_dict: &[u8],
+    stream_id: u32,
+) -> Result<Vec<u8>, PdfError> {
+    if let Some(value) = find_dict_value(pg_dict, "Contents")
+        && let Some(inner) = referenced_array_inner(idx, value)
+    {
+        let merged = format!("[{} {stream_id} 0 R]", String::from_utf8_lossy(inner).trim());
+        return Ok(splice_dict_value(
+            pg_dict,
+            b"/Contents",
+            value,
+            merged.as_bytes(),
+        ));
+    }
+    append_refs_to_array_key(
         pg_dict,
         "Contents",
         &[stream_id],
         CODE_PARSE,
         OnNonArray::Wrap,
-    )?;
-    add_font_resources(&with_stream, &[("Helv", helv_id), ("ZaDb", zadb_id)])
+    )
 }
 
-/// Inject `/<name> <font_id> 0 R` for each of `fonts` into the page's
-/// `/Resources /Font` dict, creating intermediate dicts as needed. An indirect
-/// `/Resources` or `/Font` is an error rather than a skip: a `Tf` name resolves
-/// only through the page's `/Font` subdictionary, so an uninjected name draws
-/// nothing.
-fn add_font_resources(pg_dict: &[u8], fonts: &[(&str, u32)]) -> Result<Vec<u8>, PdfError> {
+/// The elements of the array object `value` references, or `None` when `value`
+/// is not a reference or names an object that is not an array.
+fn referenced_array_inner<'a>(idx: &ObjectIndex<'a>, value: &[u8]) -> Option<&'a [u8]> {
+    let (id, _) = parse_indirect_ref(value.trim_ascii())?;
+    let (start, end) = idx.object_bytes(id)?;
+    let body = &idx.bytes()[start..end];
+    // The `<id> <gen> obj` header holds only digits, so the first `obj` is it.
+    let after_header = body.windows(3).position(|w| w == b"obj")? + 3;
+    let inner = body[after_header..].trim_ascii().strip_prefix(b"[")?;
+    let close = inner.iter().rposition(|&b| b == b']')?;
+    Some(&inner[..close])
+}
+
+/// The page's effective `/Resources` inner bytes, with an indirect `/Resources`
+/// or `/Font` replaced by an inline copy of the referenced dict. `/Resources` is
+/// inheritable (ISO 32000-1 §7.7.3.4), so a page carrying none draws with the
+/// nearest ancestor's, found by climbing `/Parent`. `None` when no node on that
+/// chain carries one.
+fn resolve_resources<'a>(
+    idx: &ObjectIndex<'a>,
+    pg_dict: &'a [u8],
+) -> Result<Option<Vec<u8>>, PdfError> {
+    // Deeper than any real page tree; a chain that long or that revisits a node
+    // is malformed, not a resource to inherit.
+    const MAX_ANCESTORS: usize = 64;
+
+    let mut node = pg_dict;
+    let mut seen = HashSet::new();
+    for _ in 0..MAX_ANCESTORS {
+        if let Some(value) = find_dict_value(node, "Resources") {
+            let inner = inline_dict(idx, value, "page /Resources")?;
+            return inline_font_dict(idx, inner).map(Some);
+        }
+        let Some((parent_id, _)) = find_dict_value(node, "Parent").and_then(parse_indirect_ref)
+        else {
+            return Ok(None);
+        };
+        if !seen.insert(parent_id) {
+            return Ok(None);
+        }
+        node = idx.dict(parent_id, CODE_PARSE, &format!("page tree node {parent_id}"))?;
+    }
+    Ok(None)
+}
+
+/// A dict-valued entry as inline bytes: an inline dict is copied as is, an
+/// indirect reference is dereferenced through `idx`. References nested in the
+/// copy stay valid — they resolve against the same file.
+fn inline_dict(idx: &ObjectIndex, value: &[u8], what: &str) -> Result<Vec<u8>, PdfError> {
+    let trimmed = value.trim_ascii();
+    if trimmed.starts_with(b"<<") {
+        return extract_outer_dict(trimmed)
+            .map(<[u8]>::to_vec)
+            .ok_or_else(|| PdfError::new(CODE_PARSE, format!("{what} dict not parseable")));
+    }
+    let (id, _) = parse_indirect_ref(trimmed).ok_or_else(|| {
+        PdfError::new(
+            CODE_PARSE,
+            format!("{what} is neither a dict nor an indirect reference"),
+        )
+    })?;
+    Ok(idx
+        .dict(id, CODE_PARSE, &format!("{what} object {id}"))?
+        .to_vec())
+}
+
+/// `res_inner` with an indirect `/Font` replaced by an inline copy, so the font
+/// dict can be read by name and extended.
+fn inline_font_dict(idx: &ObjectIndex, res_inner: Vec<u8>) -> Result<Vec<u8>, PdfError> {
+    let inlined = match find_dict_value(&res_inner, "Font") {
+        Some(font_val) if !font_val.trim_ascii().starts_with(b"<<") => {
+            let mut value = b"<< ".to_vec();
+            value.extend_from_slice(&inline_dict(idx, font_val, "page /Resources /Font")?);
+            value.extend_from_slice(b" >>");
+            Some(splice_dict_value(&res_inner, b"/Font", font_val, &value))
+        }
+        _ => None,
+    };
+    Ok(inlined.unwrap_or(res_inner))
+}
+
+/// The `/Font` subdictionary of a resolved `/Resources` dict, which
+/// [`resolve_resources`] has already inlined.
+struct FontDict<'a> {
+    /// The value span, locating the entry for a splice.
+    value: &'a [u8],
+    inner: &'a [u8],
+}
+
+fn font_dict(res_inner: &[u8]) -> Result<Option<FontDict<'_>>, PdfError> {
+    let Some(value) = find_dict_value(res_inner, "Font") else {
+        return Ok(None);
+    };
+    let inner = extract_outer_dict(value)
+        .ok_or_else(|| PdfError::new(CODE_PARSE, "page /Resources /Font dict not parseable"))?;
+    Ok(Some(FontDict { value, inner }))
+}
+
+/// Write `resources`, extended with `/<name> <font_id> 0 R` for each of `fonts`,
+/// as the page's own inline `/Resources`, creating intermediate dicts as needed.
+/// `resources` is the page's *effective* dict, possibly inherited: a page's own
+/// `/Resources` shadows the inherited one outright, so the copy has to carry the
+/// ancestor's entries forward or the background loses its names.
+fn add_font_resources(
+    pg_dict: &[u8],
+    resources: Option<&[u8]>,
+    fonts: &[(&str, u32)],
+) -> Result<Vec<u8>, PdfError> {
     let entries = fonts
         .iter()
         .map(|(name, font_id)| format!("/{name} {font_id} 0 R"))
         .collect::<Vec<_>>()
         .join(" ");
 
-    match find_dict_value(pg_dict, "Resources") {
+    let new_res_inner: Vec<u8> = match resources {
+        None => format!("/Font << {entries} >>").into_bytes(),
+        Some(res_inner) => match font_dict(res_inner)? {
+            None => {
+                let mut out = res_inner.to_vec();
+                out.extend_from_slice(format!(" /Font << {entries} >>").as_bytes());
+                out
+            }
+            Some(font) => {
+                let mut new_font_val = b"<< ".to_vec();
+                new_font_val.extend_from_slice(font.inner);
+                new_font_val.extend_from_slice(format!(" {entries} >>").as_bytes());
+                splice_dict_value(res_inner, b"/Font", font.value, &new_font_val)
+            }
+        },
+    };
+
+    let mut new_res_val = b"<< ".to_vec();
+    new_res_val.extend_from_slice(&new_res_inner);
+    new_res_val.extend_from_slice(b" >>");
+
+    Ok(match find_dict_value(pg_dict, "Resources") {
+        Some(res_val) => splice_dict_value(pg_dict, b"/Resources", res_val, &new_res_val),
         None => {
             let mut out = pg_dict.to_vec();
-            out.extend_from_slice(format!(" /Resources << /Font << {entries} >> >>").as_bytes());
-            Ok(out)
+            out.extend_from_slice(b" /Resources ");
+            out.extend_from_slice(&new_res_val);
+            out
         }
-        Some(res_val) => {
-            if !res_val.trim_ascii().starts_with(b"<<") {
-                // Indirect /Resources ref: cannot inject the named font, and the
-                // emitted `/Helv`/`/ZaDb` Tf operators would not resolve.
-                return Err(PdfError::new(
-                    CODE_PARSE,
-                    "page /Resources is an indirect reference; flatten requires inline resources",
-                ));
-            }
-            let res_inner = extract_outer_dict(res_val)
-                .ok_or_else(|| PdfError::new(CODE_PARSE, "page /Resources dict not parseable"))?;
-
-            let new_res_inner: Vec<u8> = match find_dict_value(res_inner, "Font") {
-                None => {
-                    let mut out = res_inner.to_vec();
-                    out.extend_from_slice(format!(" /Font << {entries} >>").as_bytes());
-                    out
-                }
-                Some(font_val) => {
-                    if !font_val.trim_ascii().starts_with(b"<<") {
-                        return Err(PdfError::new(
-                            CODE_PARSE,
-                            "page /Resources /Font is an indirect reference; flatten requires \
-                             an inline /Font dict",
-                        ));
-                    }
-                    let font_inner = extract_outer_dict(font_val).ok_or_else(|| {
-                        PdfError::new(CODE_PARSE, "page /Resources /Font dict not parseable")
-                    })?;
-                    let mut new_font_val = b"<< ".to_vec();
-                    new_font_val.extend_from_slice(font_inner);
-                    new_font_val.extend_from_slice(format!(" {entries} >>").as_bytes());
-
-                    splice_dict_value(res_inner, b"/Font", font_val, &new_font_val)
-                }
-            };
-
-            let mut new_res_val = b"<< ".to_vec();
-            new_res_val.extend_from_slice(&new_res_inner);
-            new_res_val.extend_from_slice(b" >>");
-
-            Ok(splice_dict_value(
-                pg_dict,
-                b"/Resources",
-                res_val,
-                &new_res_val,
-            ))
-        }
-    }
+    })
 }
 
 /// Build a base-14 Type1 font object. Symbol fonts pass `encoding: None` to keep
@@ -309,6 +475,7 @@ fn push_f32(out: &mut Vec<u8>, v: f32) {
 mod tests {
     use super::*;
     use lopdf::Document as PdfDoc;
+    use pdf_writer::{Name, Pdf, Rect, Ref};
     use quillmark_pdf::CHECKBOX_ON_STATE;
 
     /// Single-page US-Letter background, no AcroForm and no annots.
@@ -347,6 +514,171 @@ mod tests {
         haystack.windows(needle.len()).any(|w| w == needle)
     }
 
+    fn default_names() -> FontNames {
+        FontNames::free_in(b"")
+    }
+
+    /// The `/Resources` dict of the flattened PDF's only page.
+    fn page_resources(pdf: &[u8]) -> lopdf::Dictionary {
+        let doc = PdfDoc::load_mem(pdf).expect("lopdf reparse: structurally valid");
+        let (_, page_id) = doc.get_pages().into_iter().next().expect("one page");
+        doc.get_dictionary(page_id)
+            .expect("page dict")
+            .get(b"Resources")
+            .expect("page carries its own /Resources")
+            .as_dict()
+            .expect("/Resources is a dict")
+            .clone()
+    }
+
+    /// One US-Letter page whose object ids are 1 catalog, 2 `/Pages`, 3 page,
+    /// 4 a background content stream, 5 the font it selects. `on_pages` and
+    /// `on_page` write the entries under test onto the tree node and the page;
+    /// `extra` adds further objects.
+    fn build_base(
+        on_pages: impl FnOnce(&mut pdf_writer::writers::Pages),
+        on_page: impl FnOnce(&mut pdf_writer::writers::Page),
+        extra: impl FnOnce(&mut Pdf),
+    ) -> Vec<u8> {
+        let letter = Rect::new(0.0, 0.0, 612.0, 792.0);
+        let mut pdf = Pdf::new();
+        pdf.catalog(Ref::new(1)).pages(Ref::new(2));
+        {
+            let mut pages = pdf.pages(Ref::new(2));
+            pages.kids([Ref::new(3)]).count(1).media_box(letter);
+            on_pages(&mut pages);
+        }
+        {
+            let mut page = pdf.page(Ref::new(3));
+            page.parent(Ref::new(2)).media_box(letter);
+            on_page(&mut page);
+        }
+        pdf.stream(Ref::new(4), b"BT /F1 12 Tf 72 700 Td (background) Tj ET");
+        pdf.indirect(Ref::new(5))
+            .dict()
+            .pair(Name(b"Type"), Name(b"Font"))
+            .pair(Name(b"Subtype"), Name(b"Type1"))
+            .pair(Name(b"BaseFont"), Name(b"Helvetica"));
+        extra(&mut pdf);
+        pdf.finish()
+    }
+
+    #[test]
+    fn resources_inherited_from_the_page_tree_reach_the_flattened_page() {
+        let base = build_base(
+            |pages| {
+                let mut res = pages.insert(Name(b"Resources")).dict();
+                res.insert(Name(b"ProcSet"))
+                    .array()
+                    .items([Name(b"PDF"), Name(b"Text")]);
+                res.insert(Name(b"Font"))
+                    .dict()
+                    .pair(Name(b"F1"), Ref::new(5));
+            },
+            |page| {
+                page.contents(Ref::new(4));
+            },
+            |_| {},
+        );
+
+        let pdf = flatten(base, &[text_field("FullName", "Ada Lovelace")]).expect("flatten ok");
+
+        let res = page_resources(&pdf);
+        assert!(
+            res.has(b"ProcSet"),
+            "the inherited /Resources entries survive the page's own dict"
+        );
+        let fonts = res.get(b"Font").unwrap().as_dict().unwrap();
+        assert!(fonts.has(b"F1"), "the background's font binding survives");
+        assert!(
+            fonts.has(b"Helv") && fonts.has(b"ZaDb"),
+            "the drawn fonts are injected beside it"
+        );
+    }
+
+    #[test]
+    fn a_font_name_the_page_already_binds_keeps_its_own_font() {
+        let base = build_base(
+            |_| {},
+            |page| {
+                page.contents(Ref::new(4));
+                let mut res = page.insert(Name(b"Resources")).dict();
+                res.insert(Name(b"Font"))
+                    .dict()
+                    .pair(Name(b"Helv"), Ref::new(5));
+            },
+            |_| {},
+        );
+
+        let pdf = flatten(base, &[text_field("FullName", "Ada Lovelace")]).expect("flatten ok");
+
+        let fonts = page_resources(&pdf)
+            .get(b"Font")
+            .unwrap()
+            .as_dict()
+            .unwrap()
+            .clone();
+        assert_eq!(
+            fonts.get(b"Helv").unwrap().as_reference().unwrap(),
+            (5, 0),
+            "/Helv stays bound to the background's own font"
+        );
+        assert!(
+            fonts.has(b"Helv2"),
+            "the drawn font takes a free name instead"
+        );
+        assert!(
+            contains_window(&pdf, b"/Helv2 "),
+            "the drawn stream selects the name it was registered under"
+        );
+    }
+
+    #[test]
+    fn a_contents_reference_to_an_array_expands_to_its_streams() {
+        let base = build_base(
+            |_| {},
+            |page| {
+                page.contents(Ref::new(6));
+                let mut res = page.insert(Name(b"Resources")).dict();
+                res.insert(Name(b"Font"))
+                    .dict()
+                    .pair(Name(b"F1"), Ref::new(5));
+            },
+            // The `/Contents` reference names an array object, not a stream.
+            |pdf| {
+                pdf.indirect(Ref::new(6))
+                    .array()
+                    .items([Ref::new(4), Ref::new(7)]);
+                pdf.stream(Ref::new(7), b"0.75 w 72 690 200 20 re S");
+            },
+        );
+
+        let pdf = flatten(base, &[text_field("FullName", "Ada Lovelace")]).expect("flatten ok");
+
+        let doc = PdfDoc::load_mem(&pdf).expect("lopdf reparse: structurally valid");
+        let (_, page_id) = doc.get_pages().into_iter().next().expect("one page");
+        let contents = doc
+            .get_dictionary(page_id)
+            .unwrap()
+            .get(b"Contents")
+            .unwrap()
+            .as_array()
+            .expect("/Contents is an array")
+            .clone();
+        assert_eq!(
+            contents.len(),
+            3,
+            "the referenced array's elements plus the drawn stream"
+        );
+        for item in &contents {
+            let id = item.as_reference().expect("/Contents element is a reference");
+            assert!(
+                doc.get_object(id).unwrap().as_stream().is_ok(),
+                "every /Contents element resolves to a stream"
+            );
+        }
+    }
+
     #[test]
     fn flatten_produces_no_acroform() {
         let pdf = flatten_ok(&[text_field("FullName", "Ada Lovelace")]);
@@ -382,7 +714,7 @@ mod tests {
     fn build_content_stream_transcodes_non_ascii_to_winansi() {
         let value = "Caf\u{e9} \u{2014} Se\u{f1}or \u{2019}A\u{2019}";
         let spec = text_field("FullName", value);
-        let stream = build_content_stream(&[&spec]);
+        let stream = build_content_stream(&[&spec], &default_names());
 
         // WinAnsi: é→0xE9, —→0x97, ñ→0xF1, ’→0x92.
         let want: &[u8] = &[
@@ -408,7 +740,7 @@ mod tests {
     #[test]
     fn flatten_checked_checkbox_emits_zapfdingbats_glyph() {
         let spec = checkbox_field("Agree", true);
-        let stream = build_content_stream(&[&spec]);
+        let stream = build_content_stream(&[&spec], &default_names());
         let text = String::from_utf8_lossy(&stream);
 
         assert!(

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -287,7 +287,8 @@ fn scaled_render_settings(scale: f32) -> RenderSettings {
 }
 
 /// Satisfies standard Type1 font queries from hayro's embedded font data:
-/// required for the flat PDF's `Helv` and `ZaDb` content streams.
+/// required for the Helvetica and ZapfDingbats the flat PDF's content streams
+/// draw with.
 fn standard_font_settings() -> InterpreterSettings {
     InterpreterSettings {
         font_resolver: Arc::new(|query| match query {

--- a/crates/backends/pdfform/src/typography.rs
+++ b/crates/backends/pdfform/src/typography.rs
@@ -4,11 +4,19 @@
 //! flatten path must commit to a concrete font and size. Keeping that decision
 //! here is what makes preview and flattening agree exactly.
 
-/// Base-14 Helvetica, registered as `/Helv`, for text and choice values.
+/// Base-14 Helvetica, for text and choice values.
 pub(crate) const TEXT_FONT: &str = "Helvetica";
 
-/// Base-14 ZapfDingbats, registered as `/ZaDb`, for the checkbox check glyph.
+/// Base-14 ZapfDingbats, for the checkbox check glyph.
 pub(crate) const CHECK_FONT: &str = "ZapfDingbats";
+
+/// Preferred `/Font` resource name for [`TEXT_FONT`], shared with the `/DA` the
+/// stamp path writes. A page already binding it gets a derived name instead.
+pub(crate) const TEXT_FONT_RESOURCE: &str = quillmark_pdf::FormFont::Helvetica.resource_name();
+
+/// Preferred `/Font` resource name for [`CHECK_FONT`], the AcroForm spelling for
+/// ZapfDingbats.
+pub(crate) const CHECK_FONT_RESOURCE: &str = "ZaDb";
 
 pub(crate) const MIN_SIZE: f32 = 4.0;
 pub(crate) const MAX_SIZE: f32 = 12.0;

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -128,12 +128,13 @@ pub enum FormFont {
 }
 
 impl FormFont {
-    /// The `/DR` `/Font` key a `/DA` names this face by.
-    pub(crate) fn resource_name(self) -> &'static [u8] {
+    /// The `/DR` `/Font` key a `/DA` names this face by, and the name a drawn
+    /// content stream selects it with.
+    pub const fn resource_name(self) -> &'static str {
         match self {
-            Self::Helvetica => b"Helv",
-            Self::Times => b"TiRo",
-            Self::Courier => b"Cour",
+            Self::Helvetica => "Helv",
+            Self::Times => "TiRo",
+            Self::Courier => "Cour",
         }
     }
 

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -513,7 +513,7 @@ fn is_pdf_delim(c: u8) -> bool {
     )
 }
 
-pub(crate) fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
+pub fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
     let s = skip_ws(s);
     let mut i = 0;
     while i < s.len() && s[i].is_ascii_digit() {

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -55,7 +55,7 @@ fn field_appearance(spec: &FieldSpec) -> Vec<u8> {
         .filter(|s| s.is_finite() && *s > 0.0)
         .unwrap_or(0.0);
     let mut da = b"/".to_vec();
-    da.extend_from_slice(spec.font.resource_name());
+    da.extend_from_slice(spec.font.resource_name().as_bytes());
     da.extend_from_slice(format!(" {size} Tf 0 g").as_bytes());
     da
 }
@@ -201,7 +201,7 @@ pub fn stamp(
                 let mut dr = form.insert(Name(b"DR")).dict();
                 let mut font_dict = dr.insert(Name(b"Font")).dict();
                 for (font, &fid) in fonts.iter().zip(&font_ids) {
-                    font_dict.pair(Name(font.resource_name()), Ref::new(fid as i32));
+                    font_dict.pair(Name(font.resource_name().as_bytes()), Ref::new(fid as i32));
                 }
             }
             form.finish();


### PR DESCRIPTION
A page without an inline `/Resources` inherits one from an ancestor `/Pages` node. The flatten rewrite appended a fresh `/Resources` holding only its two fonts, and a page's own dict replaces the inherited one outright, so every name the background stream selects stopped resolving. The effective dict is now resolved by climbing `/Parent` (capped, revisit-safe), copied inline onto the page and extended there. The same dereference lets an indirect `/Resources` or `/Font` be injected instead of refused, so those two hard errors are gone.

Appending `/Helv` into a `/Font` dict that already binds it wrote the key twice, and a last-wins parser then read the flatten font for the background's own `Helv` too. The drawn fonts now take names free in that page's font dict (`Helv2` where `Helv` is taken), and the per-page content stream emits the names it registered. `FormFont::resource_name` in `quillmark-pdf` becomes a `pub const fn` returning `&str` so pdfform reuses the `Helv` spelling.

A `/Contents` that references an *array* object was wrapped rather than expanded, leaving an array as the first element of the `/Contents` array. A bare reference is dereferenced first: an array splices its elements, a stream wraps as before, so `OnNonArray` keeps its meaning for the stamp path.

`pdf-writer` is added as a pdfform dev-dependency to hand-build the page-tree shapes the fixtures do not carry.

Closes #1396

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5g4qzyhdacWWtiusFrTsh

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5g4qzyhdacWWtiusFrTsh)_