### PR TITLE
fix(core): keep a mis-shaped container value raw in the resolved view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@
   document-level pair rather than a `store` / `load` pair. The old names are
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
+- fix(core): **`Quill::resolve` keeps a mis-shaped container value raw rather
+  than blanking it under the document's own label.** A seed the render
+  coercion cannot conform — `rows: abc` on an `array`, `addr: 5` on a typed
+  dictionary, a list where a variant container belongs — was rebuilt from the
+  schema anyway, so the row showed an empty container still tagged
+  `authored`. The container arms now compose an absent or already-shaped seed
+  only, and anything else falls through to the keep-raw path
+  `conform_card_render` documents. The render gate refuses the shape, so the
+  plate is unchanged.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -566,7 +566,7 @@ fn compose(
     seed_rung: FieldSource,
 ) -> (QuillValue, FieldSource) {
     match (&field.r#type, &field.properties, &field.items) {
-        (FieldType::Object, Some(props), _) => {
+        (FieldType::Object, Some(props), _) if composes_as(seed, serde_json::Value::is_object) => {
             let obj = seed.and_then(|v| v.as_json().as_object());
             let mut out = serde_json::Map::new();
             let rung = compose_members(obj, props, seed_rung, &mut out);
@@ -582,7 +582,7 @@ fn compose(
             }
             (QuillValue::from_json(serde_json::Value::Object(out)), rung)
         }
-        (FieldType::Array, _, Some(items)) => {
+        (FieldType::Array, _, Some(items)) if composes_as(seed, serde_json::Value::is_array) => {
             let arr = seed
                 .and_then(|v| v.as_json().as_array().cloned())
                 .unwrap_or_default();
@@ -600,6 +600,19 @@ fn compose(
             None => (blank(field), FieldSource::Blank),
         },
     }
+}
+
+/// Whether `seed` composes as the container `field` declares: absent, so the
+/// blank container is the whole answer, or already that shape.
+///
+/// A present seed of another shape (`rows: abc` on an `array`, `addr: 5` on a
+/// typed dictionary) is kept raw by the scalar arm instead, as
+/// [`conform_card_render`] keeps it: [`resolve_value_sourced`] reports the seed's
+/// own rung, so a rebuilt container would carry the document's label over content
+/// the document never wrote. The gate refuses the shape
+/// (`validation::type_mismatch`), so only the ungated views meet it.
+fn composes_as(seed: Option<&QuillValue>, shape: fn(&serde_json::Value) -> bool) -> bool {
+    seed.is_none_or(|v| shape(v.as_json()))
 }
 
 /// Resolve every declared member of a namespace over its slice of `seed` into
@@ -656,6 +669,15 @@ fn resolve_variant_sourced(
     field: &FieldSchema,
 ) -> (QuillValue, FieldSource) {
     let present = value.filter(|v| !v.as_json().is_null());
+    // A present seed that is neither the container nor a bare member name is
+    // kept raw, as any mis-shaped container is ([`composes_as`]): the rung is
+    // the document's, and a blank world under it would read as an answer the
+    // document gave.
+    if let Some(raw) =
+        present.filter(|v| !v.as_json().is_object() && v.as_json().as_str().is_none())
+    {
+        return (raw.clone(), FieldSource::Authored);
+    }
     let authored = present.map(|v| v.as_json());
     // Coercion normalizes to the container, so the authored discriminant is the
     // `value` key. A bare scalar that bypassed coercion (a serde-built payload)

--- a/crates/core/src/quill/resolved.rs
+++ b/crates/core/src/quill/resolved.rs
@@ -346,6 +346,62 @@ card_kinds:
         assert_eq!(status.value.as_json(), &serde_json::json!("draft"));
     }
 
+    const CONTAINERS: &str = r#"
+quill:
+  name: shape_test
+  version: "1.0"
+  backend: typst
+  description: Container-shape tests
+main:
+  fields:
+    counts:
+      type: array
+      items:
+        type: integer
+    address:
+      type: object
+      properties:
+        street: { type: string }
+"#;
+
+    fn shape_doc(fields: &str) -> Document {
+        parse(&format!(
+            "~~~card-yaml\n$quill: shape_test@1.0\n$kind: main\n{fields}~~~\n"
+        ))
+    }
+
+    #[test]
+    fn an_array_field_blanks_only_where_the_document_left_it_out() {
+        let quill = quill_from_yaml(CONTAINERS);
+
+        // `abc` conforms to no `integer[]`, so it reaches the ladder raw. The row
+        // is the document's own text under the document's own label, not `[]`.
+        let raw = quill.resolve(&shape_doc("counts: abc\n"));
+        let r = row(&raw.main.fields, "counts");
+        assert_eq!(r.source, FieldSource::Authored);
+        assert_eq!(r.value.as_json(), &serde_json::json!("abc"));
+
+        let absent = quill.resolve(&shape_doc(""));
+        let r = row(&absent.main.fields, "counts");
+        assert_eq!(r.source, FieldSource::Blank);
+        assert_eq!(r.value.as_json(), &serde_json::json!([]));
+    }
+
+    #[test]
+    fn a_typed_dict_blanks_only_where_the_document_left_it_out() {
+        let quill = quill_from_yaml(CONTAINERS);
+
+        let raw = quill.resolve(&shape_doc("address: 5\n"));
+        let r = row(&raw.main.fields, "address");
+        assert_eq!(r.source, FieldSource::Authored);
+        assert_eq!(r.value.as_json(), &serde_json::json!(5));
+
+        let absent = quill.resolve(&shape_doc(""));
+        let r = row(&absent.main.fields, "address");
+        assert_eq!(r.source, FieldSource::Blank);
+        assert_eq!(r.value.as_json(), &serde_json::json!({ "street": "" }));
+    }
+
     // ── Byte-for-byte with the render projection ─────────────────────────────
     // Both projections cut the one shared ladder (`ladder_sourced`), but over
     // separately-conformed input: the render gate's fallible conform vs the

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -475,6 +475,25 @@ fn resolve_reports_the_container_as_one_cell_matching_the_plate() {
     assert_eq!(row.source, crate::quill::resolved::FieldSource::Default);
 }
 
+/// A value the container cannot be built from stays raw, as a mis-shaped
+/// `array` or typed dictionary does: `resolve()` labels the row Authored, and a
+/// blank world under that label would read as an answer the document gave.
+#[test]
+fn a_mis_shaped_container_value_stays_raw() {
+    let quill = quill();
+    let document = doc("classification: [CUI, SECRET]\n");
+    let row = quill
+        .resolve(&document)
+        .main
+        .fields
+        .into_iter()
+        .find(|f| f.name == "classification")
+        .expect("classification row");
+
+    assert_eq!(row.source, crate::quill::resolved::FieldSource::Authored);
+    assert_eq!(row.value.as_json(), &json!(["CUI", "SECRET"]));
+}
+
 /// The container is a namespace like any other: its rung is the strongest that
 /// contributed, so a cell the document wrote lifts a container whose
 /// discriminant came from the schema.


### PR DESCRIPTION
`conform_card_render` documents that a value Render coercion cannot conform is kept raw and that the ladder reads it Authored. `compose` honored that for scalars only: its typed-dictionary arm read the seed through `as_object()` and rebuilt from `properties`, its array arm took `as_array().cloned().unwrap_or_default()`, and `resolve_variant_sourced` read the container through `as_object()`. A present seed of another shape (`rows: abc` on an `array<integer>`, `addr: 5` on a typed dict, a list where a variant container belongs) was discarded and rebuilt from the schema, while `resolve_value_sourced` reported the rung its non-null seed supplied. `Quill::resolve` then showed a clean empty container under the document's own label.

Each container arm now composes an absent or already-shaped seed only; anything else falls through to the keep-raw scalar arm, whose `Blank` composed rung joins the seed's own. The variant returns the raw value Authored before it picks a member. An absent seed still composes the blank container.

The render plate cannot reach the branch: `validate_value` type-checks the two containers over the Render-conformed value and `validate_variant` reports a non-object, non-member-scalar as a type mismatch, so `coerce_and_validate` refuses every mis-shaped container before `compile_data` cuts the ladder. A wrong-shape `default:` cannot reach it either, since a typed dictionary refuses a `default:` outright and an `array`'s literal is judged as written at load.

One widening beyond the two container types the issue names: the variant guard also keeps a bare number or bool seed raw where it previously fell to the schema `default:`. That shape only arises on a payload that bypassed coercion (`conform_variant` normalizes `classification: 5` to `{value: "5"}`), so no gated path changes.

Closes #1407

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5g4qzyhdacWWtiusFrTsh

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5g4qzyhdacWWtiusFrTsh)_