### PR TITLE
fix(content): a line separator in document text becomes a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@
   document-level pair rather than a `store` / `load` pair. The old names are
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
+- fix(content): **a U+2028 or U+2029 in document text becomes a space.**
+  Typst's lexer reads both as line breaks, so one mid-paragraph reopens
+  `at_start` and the characters behind it are read as a block marker:
+  `"intro\u{2028}- item"` rendered a bullet, `- item` on its own line. No
+  escape reaches them — a `\` before whitespace is Typst's own linebreak — so
+  the separators join `\r` and the bidi controls as characters the content
+  forbids, refused by `validate` and replaced at every text ingress:
+  `from_plaintext`, markdown import, and an `Op::Insert` through
+  `apply_text_delta`. A space rather than a drop, both being Unicode
+  whitespace, so the words either side stay parted.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -1,10 +1,10 @@
 //! Markdown import (cold): `normalize → pulldown → content`.
 //!
 //! Input is normalized by [`crate::normalize::normalize_markdown`] (CRLF→LF,
-//! bidi strip, HTML comment-fence repair) so the content invariants hold by
-//! construction, then parsed with `pulldown_cmark` (CommonMark + strikethrough
-//! + pipe tables) and walked into a [`Content`]. This is the one place the
-//! `<u>` allowlist runs.
+//! bidi controls dropped, U+2028/U+2029 spaced, HTML comment-fence repair) so
+//! the content invariants hold by construction, then parsed with
+//! `pulldown_cmark` (CommonMark + strikethrough + pipe tables) and walked into
+//! a [`Content`]. This is the one place the `<u>` allowlist runs.
 //!
 //! ## Canonicalizations (documented, not bugs)
 //!
@@ -78,7 +78,7 @@ pub fn from_markdown(markdown: &str) -> Result<Normalized, ImportError> {
 /// [`from_markdown`]. Every character is content, never syntax: `*hi*` is four
 /// literal chars, not emphasis. With [`crate::export::to_plaintext`] it pins the
 /// fixed point `to_plaintext(from_plaintext(s)) == s` for any `s` free of `\r`,
-/// bidi controls, and [`ISLAND_SLOT`].
+/// bidi controls, U+2028/U+2029 line separators, and [`ISLAND_SLOT`].
 ///
 /// Line structure is **derived, not stored**: a lone `\n` between two non-empty
 /// segments is a within-paragraph break ([`Line::continues`] `true`); a blank
@@ -89,7 +89,8 @@ pub fn from_plaintext(s: &str) -> Normalized {
     // through untouched.
     let text: String = s
         .chars()
-        .filter(|&c| c != '\r' && c != ISLAND_SLOT && !crate::normalize::is_bidi_char(c))
+        .filter(|&c| c != ISLAND_SLOT)
+        .filter_map(crate::normalize::admit_char)
         .collect();
     // One line per `\n`-separated segment. A single streaming pass carries the
     // prior segment's non-emptiness, so line 0 is `false` and no intermediate
@@ -126,17 +127,19 @@ struct Inline {
 }
 
 impl Inline {
-    /// Append inline text, stripping characters the content forbids: `\r` and a
-    /// stray [`ISLAND_SLOT`] are dropped; a stray `\n` becomes a space, real
-    /// line boundaries going through [`Self::push_raw`]. Admitting a bare slot
-    /// char would break the slot-count invariant.
+    /// Append inline text under the [`crate::normalize::admit_char`] contract,
+    /// with a stray [`ISLAND_SLOT`] dropped and a stray `\n` spaced, real line
+    /// boundaries going through [`Self::push_raw`]. Admitting a bare slot char
+    /// would break the slot-count invariant.
     fn push_text(&mut self, s: &str) {
         for c in s.chars() {
             let c = match c {
-                '\r' => continue,
                 ISLAND_SLOT => continue,
                 '\n' => ' ',
-                other => other,
+                other => match crate::normalize::admit_char(other) {
+                    Some(c) => c,
+                    None => continue,
+                },
             };
             self.text.push(c);
             self.pos += 1;
@@ -632,9 +635,13 @@ impl Builder {
     fn push_code_line(&mut self, seg: &str) {
         for c in seg.chars() {
             match c {
-                '\r' | '\n' => continue,
+                '\n' => continue,
                 ISLAND_SLOT => continue,
-                other => self.inline.push_raw(other),
+                other => {
+                    if let Some(c) = crate::normalize::admit_char(other) {
+                        self.inline.push_raw(c);
+                    }
+                }
             }
         }
     }
@@ -951,6 +958,21 @@ mod tests {
         let rt = imp_plain(&format!("a{ISLAND_SLOT}b"));
         assert_eq!(rt.text, "ab", "the reserved island slot is dropped");
         assert_eq!(rt.islands.len(), 0);
+    }
+
+    #[test]
+    fn line_separators_are_spaced_at_every_text_ingress() {
+        for sep in ['\u{2028}', '\u{2029}'] {
+            let src = format!("intro{sep}- item");
+            assert_eq!(imp_plain(&src).text, "intro - item", "plaintext {sep:?}");
+            assert_eq!(imp(&src).text, "intro - item", "markdown {sep:?}");
+        }
+
+        let held = Content::new("intro\u{2028}- item".into(), vec![Line::new(LineKind::Para)]);
+        assert_eq!(
+            held.validate(),
+            Err(crate::model::Invariant::LineSeparator('\u{2028}'))
+        );
     }
 
     #[test]

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -6,7 +6,7 @@
 //! encoded: the model stores only the resulting range, so the stored form is
 //! identical whatever the editor did.
 
-use crate::normalize::is_bidi_char;
+use crate::normalize::{is_bidi_char, is_line_separator};
 use serde_json::Value as JsonValue;
 use std::borrow::Cow;
 
@@ -24,9 +24,10 @@ pub const ISLAND_SLOT: char = '\u{FFFC}';
 /// One content field as a content: the text plus the structure that rides on it.
 ///
 /// Invariants (established once by import normalization, checked by
-/// [`Content::validate`]): the text holds no `\r` and no bidi controls; the
-/// count of [`ISLAND_SLOT`] equals `islands.len()`; `lines.len()` equals the
-/// number of `\n`-separated segments; marks are normalized (sorted, unioned).
+/// [`Content::validate`]): the text holds no `\r`, no bidi controls, and no
+/// U+2028/U+2029 line separators; the count of [`ISLAND_SLOT`] equals
+/// `islands.len()`; `lines.len()` equals the number of `\n`-separated segments;
+/// marks are normalized (sorted, unioned).
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct Content {
@@ -781,6 +782,9 @@ pub enum Invariant {
     CarriageReturn,
     /// A bidi formatting control in the text.
     BidiControl(char),
+    /// A U+2028/U+2029 line separator in the text, which a downstream lexer
+    /// reads as a line break.
+    LineSeparator(char),
     /// `island_slot_count != islands.len()`.
     IslandSlotMismatch { slots: usize, islands: usize },
     /// `lines.len() != newline_segment_count`.
@@ -1089,6 +1093,9 @@ impl Content {
             }
             if is_bidi_char(c) {
                 return Err(Invariant::BidiControl(c));
+            }
+            if is_line_separator(c) {
+                return Err(Invariant::LineSeparator(c));
             }
             if c == ISLAND_SLOT {
                 slots += 1;

--- a/crates/content/src/normalize.rs
+++ b/crates/content/src/normalize.rs
@@ -20,14 +20,37 @@ pub(crate) fn is_bidi_char(c: char) -> bool {
     )
 }
 
-/// Removes the Unicode bidi formatting controls, which sit adjacent to `**`/`_`
-/// and defeat delimiter recognition.
-fn strip_bidi_formatting(s: &str) -> String {
-    if !s.chars().any(is_bidi_char) {
+/// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR, which Typst's lexer
+/// reads as line breaks: one mid-paragraph reopens `at_start`, so what follows
+/// it is read as a block marker the author never wrote.
+#[inline]
+pub(crate) fn is_line_separator(c: char) -> bool {
+    matches!(c, '\u{2028}' | '\u{2029}')
+}
+
+/// What the content admits `c` as, `None` dropping it. A `\r` is dropped
+/// because it pairs with a `\n` that stays; a line separator becomes a space,
+/// both being Unicode whitespace, so dropping one would join the words it parts.
+/// No downstream escape can neutralize a separator — a `\` before whitespace is
+/// Typst's own linebreak — so the content refuses it.
+#[inline]
+pub(crate) fn admit_char(c: char) -> Option<char> {
+    match c {
+        '\r' => None,
+        c if is_bidi_char(c) => None,
+        c if is_line_separator(c) => Some(' '),
+        c => Some(c),
+    }
+}
+
+/// Apply [`admit_char`] across `s`: the bidi controls sit adjacent to `**`/`_`
+/// and defeat delimiter recognition, the separators spell block structure.
+fn admit_chars(s: &str) -> String {
+    if !s.chars().any(|c| admit_char(c) != Some(c)) {
         return s.to_string();
     }
 
-    s.chars().filter(|c| !is_bidi_char(*c)).collect()
+    s.chars().filter_map(admit_char).collect()
 }
 
 /// Inserts a newline after `-->` when followed by non-whitespace content.
@@ -110,11 +133,11 @@ fn fix_html_comment_fences(s: &str) -> String {
     result
 }
 
-/// Applies all markdown normalizations in order: CRLF → LF, bidi strip,
-/// HTML comment fence repair.
+/// Applies all markdown normalizations in order: CRLF → LF, bidi controls
+/// dropped and U+2028/U+2029 spaced, HTML comment fence repair.
 pub fn normalize_markdown(markdown: &str) -> String {
     let cleaned = normalize_line_endings(markdown);
-    let cleaned = strip_bidi_formatting(&cleaned);
+    let cleaned = admit_chars(&cleaned);
     fix_html_comment_fences(&cleaned)
 }
 
@@ -145,11 +168,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_strip_bidi_formatting_cases() {
+    fn bidi_controls_are_dropped_and_separators_spaced() {
         let cases: &[(&str, &str)] = &[
             ("hello world", "hello world"),
             ("", ""),
             ("**bold** text", "**bold** text"),
+            ("intro\u{2028}- item", "intro - item"),
+            ("intro\u{2029}= Heading", "intro = Heading"),
             ("he\u{202D}llo", "hello"),
             ("**asdf** or \u{202D}**(1234**", "**asdf** or **(1234**"),
             ("a\u{200E}b\u{200F}c", "abc"),
@@ -167,7 +192,7 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            assert_eq!(strip_bidi_formatting(input), *expected, "input: {:?}", input);
+            assert_eq!(admit_chars(input), *expected, "input: {:?}", input);
         }
     }
 

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -7,7 +7,7 @@ use crate::model::{
     line_kind_mismatch, Container, Island, Line, LineKind, LineKindMismatch, Mark, MarkKind,
     Content, Usv, ISLAND_SLOT,
 };
-use crate::normalize::is_bidi_char;
+use crate::normalize::admit_char;
 use crate::usv::char_to_byte;
 use std::borrow::Cow;
 
@@ -405,9 +405,10 @@ impl Content {
     /// *deletes* a slot drops the corresponding [`Island`]; a delta that
     /// *inserts* a raw slot is rejected ([`ApplyError::IslandSlotInInsert`]).
     ///
-    /// Inserted text is sanitized first: `\r` and Unicode bidi controls (the
-    /// chars [`Content::validate`] forbids) are stripped, mirroring what
-    /// `import` applies at the string boundary.
+    /// Inserted text is sanitized first, mirroring what `import` applies at the
+    /// string boundary: `\r` and Unicode bidi controls are stripped, and a
+    /// U+2028/U+2029 line separator becomes a space — the chars
+    /// [`Content::validate`] forbids.
     pub fn apply_text_delta(&mut self, delta: &Delta) -> Result<(), ApplyError> {
         self.apply_text_delta_inner(delta)?;
         self.normalize();
@@ -836,18 +837,14 @@ fn ranges_overlap(a0: Usv, a1: Usv, b0: Usv, b1: Usv) -> bool {
     a0 < b1 && b0 < a1
 }
 
-/// A char `validate()` rejects. A raw [`ISLAND_SLOT`] is refused separately.
-fn insert_forbidden(c: char) -> bool {
-    c == '\r' || is_bidi_char(c)
-}
-
-/// Drop [`insert_forbidden`] chars from every `Op::Insert`, borrowing the delta
-/// through untouched when none carries one.
+/// Put every `Op::Insert` under the [`admit_char`] contract — the chars
+/// `validate()` rejects, dropped or spaced — borrowing the delta through
+/// untouched when none carries one. A raw [`ISLAND_SLOT`] is refused separately.
 fn sanitize_inserts(delta: &Delta) -> Cow<'_, Delta> {
     let needs_cleaning = delta
         .ops
         .iter()
-        .any(|op| matches!(op, Op::Insert(s) if s.chars().any(insert_forbidden)));
+        .any(|op| matches!(op, Op::Insert(s) if s.chars().any(|c| admit_char(c) != Some(c))));
     if !needs_cleaning {
         return Cow::Borrowed(delta);
     }
@@ -855,7 +852,7 @@ fn sanitize_inserts(delta: &Delta) -> Cow<'_, Delta> {
         .ops
         .iter()
         .map(|op| match op {
-            Op::Insert(s) => Op::Insert(s.chars().filter(|c| !insert_forbidden(*c)).collect()),
+            Op::Insert(s) => Op::Insert(s.chars().filter_map(admit_char).collect()),
             other => other.clone(),
         })
         .collect();
@@ -1736,6 +1733,20 @@ mod tests {
         };
         rt.apply_text_delta(&d).unwrap();
         assert_eq!(rt.text, "ab");
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    #[test]
+    fn insert_line_separator_is_spaced() {
+        // A space keeps the words apart without minting the line break Typst
+        // would read, and which would make `- item` a bullet.
+        let mut rt = from_markdown("ab").unwrap();
+        let d = Delta {
+            ops: vec![Op::Retain(2), Op::Insert("\u{2028}- item".into())],
+        };
+        rt.apply_text_delta(&d).unwrap();
+        assert_eq!(rt.text, "ab - item");
+        assert_eq!(rt.lines.len(), 1);
         assert_eq!(rt.validate(), Ok(()));
     }
 

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -813,13 +813,18 @@ fn pad_row(v: &mut Value, cols: usize) {
     }
 }
 
-/// De-newline a cell's text (each `\n`/`\r` → a space, 1:1 so mark offsets hold)
-/// and re-normalize its marks. Writes back into the cell's **own** object rather
-/// than minting a fresh one, so a key this build does not recognize survives.
+/// Every char a downstream lexer reads as a line break, the U+2028/U+2029
+/// separators included. A cell is one line.
+const CELL_BREAKS: &[char] = &['\n', '\r', '\u{2028}', '\u{2029}'];
+
+/// De-newline a cell's text (each line break → a space, 1:1 so mark offsets
+/// hold) and re-normalize its marks. Writes back into the cell's **own** object
+/// rather than minting a fresh one, so a key this build does not recognize
+/// survives.
 fn canon_cell(cell: &mut Value) {
     let (text, marks) = parse_cell(cell);
-    let text = if text.contains(['\n', '\r']) {
-        text.replace(['\n', '\r'], " ")
+    let text = if text.contains(CELL_BREAKS) {
+        text.replace(CELL_BREAKS, " ")
     } else {
         text
     };
@@ -870,7 +875,7 @@ pub(crate) fn table_shape_error(props: &Value) -> Option<Invariant> {
     }
     for (i, cell) in table_cell_values(props).enumerate() {
         let text = cell.get("text").and_then(Value::as_str).unwrap_or_default();
-        if text.contains('\n') || text.contains('\r') {
+        if text.contains(CELL_BREAKS) {
             return Some(Invariant::TableCellNewline { cell: i });
         }
     }

--- a/crates/fuzz/src/convert_fuzz.rs
+++ b/crates/fuzz/src/convert_fuzz.rs
@@ -1,4 +1,6 @@
 use proptest::prelude::*;
+use quillmark_content::export::to_plaintext;
+use quillmark_content::import::from_plaintext;
 use quillmark_typst::emit::{escape_markup, escape_string};
 use typst::syntax::SyntaxKind;
 
@@ -26,11 +28,13 @@ const ALLOWED_LEAVES: &[SyntaxKind] = &[
     SyntaxKind::SmartQuote,
 ];
 
-/// A `--` or a `...` never lands by chance in a draw over all of Unicode, so
-/// the second alphabet is Typst's special characters alone.
+/// A `--`, a `...`, or a separator ahead of a block marker never lands by
+/// chance in a draw over all of Unicode. The second alphabet is what does land
+/// one: Typst's special characters, the U+2028/U+2029 separators it reads as
+/// line breaks, and the markers and space that open a block behind one.
 fn escaper_input() -> impl Strategy<Value = String> {
     prop_oneof![
-        r#"[-.?/~*_#\[\]{}$<>@'"0-9a-c \\`]{0,40}"#,
+        r#"[-.?/~*_#+=\[\]{}$<>@'"0-9a-c \\`\x{2028}\x{2029}]{0,40}"#,
         "\\PC*",
     ]
 }
@@ -91,10 +95,12 @@ proptest! {
 
     #[test]
     fn fuzz_escape_markup_survives_the_typst_parser(s in escaper_input()) {
-        // Typst also reads U+2028 / U+2029 as line breaks, which no escape can
-        // neutralize (`\` before whitespace is its linebreak). The content layer
-        // admits them, so they are not this function's to answer.
-        let s: String = s.chars().filter(|&c| c != '\u{2028}' && c != '\u{2029}').collect();
+        // The escaper answers for the text a content holds, so the draw enters
+        // through the content ingress, which spaces the U+2028/U+2029
+        // separators: Typst reads one as a line break that reopens `at_start`,
+        // and no escape neutralizes it (a `\` before whitespace is its own
+        // linebreak).
+        let s = to_plaintext(&from_plaintext(&s));
         // Past `at_start`, whose markers are the emitter's guard, not the escaper's.
         let (text, kinds) = resolve(&format!("x{}", escape_markup(&s)));
 

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -426,7 +426,12 @@ Before CommonMark parsing, each body region is normalized:
 2. **Bidi control stripping.** Remove U+061C, U+200E, U+200F,
    U+202A–U+202E, U+2066–U+2069. These invisible characters can
    desynchronize delimiter runs when copy-pasted from bidi-aware sources.
-3. **HTML comment fence repair.** If `-->` is followed by non-whitespace
+3. **Line-separator spacing.** Replace U+2028 (LINE SEPARATOR) and U+2029
+   (PARAGRAPH SEPARATOR) with a single U+0020 space. CommonMark reads
+   neither as a line ending, but a backend lexer may, in which case the
+   text after one is read as a block marker the author never wrote. Both
+   are Unicode whitespace, so a space keeps the words they part apart.
+4. **HTML comment fence repair.** If `-->` is followed by non-whitespace
    text on the same line, insert a newline after `-->` so the trailing
    text reaches the paragraph parser instead of being consumed by the
    CommonMark HTML-block rule (type 2).


### PR DESCRIPTION
Typst's lexer reads U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH SEPARATOR) as line breaks. One inside a paragraph reopens `at_start` mid-run, so the characters behind it are read as a block marker the author never wrote: `"intro\u{2028}- item"` rendered a bullet, `"intro\u{2028}= Heading"` a heading. The escaper cannot answer for them, since a `\` before whitespace is Typst's own linebreak token, so this is a content-layer invariant like the existing `\r` and bidi-control ones.

A single `admit_char` in `normalize` now carries that contract, mapping a char to what the content admits: `\r` and bidi controls drop, a separator becomes U+0020. A space rather than a drop, because both separators are Unicode whitespace and dropping one would join the words it parts. Every text ingress runs it (`from_plaintext`, `normalize_markdown` ahead of the parser, `Inline` and code lines inside import, and `Op::Insert` through `apply_text_delta`), and `validate` refuses a hand-built content holding one with the new `Invariant::LineSeparator`. A table cell, which is one line, spaces them alongside its newlines. `Invariant` is `#[non_exhaustive]` and nothing matches on it, so no binding or backend changes.

The escaper's `fuzz_escape_markup_survives_the_typst_parser` filtered the two characters out of its draw. The draw now enters through `from_plaintext`, and the alphabet carries the separators beside the block markers that follow one (`+`, `=`), so the property fails if the content layer stops neutralizing them. With the ingress bypassed it fails at the default case count with `"\u{2028}=\u{2028}"` lowering to a heading leaf.

`prose/references/markdown-spec.md` §7 gains the normalization step, since it enumerates the markdown normalizations normatively.

Closes #1441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U5g4qzyhdacWWtiusFrTsh

---
_Generated by [Claude Code](https://claude.ai/code/session_01U5g4qzyhdacWWtiusFrTsh)_