### PR TITLE
fix: integrate the five triage fixes (#1450–#1454)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@
   document-level pair rather than a `store` / `load` pair. The old names are
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
+- fix(pdf): **the object index skips literal strings, `%`-comments and stream
+  bodies, so `N G obj` bytes carried as content cannot shadow the real object.**
+  The scan accepted any `<id> <gen> obj` at a token boundary and a later
+  occurrence overwrites an earlier one, so a header spelled inside a string value
+  (`/Subject (see 4 0 obj)`) or inside raw stream data displaced the real
+  object's offset, and every read of that object parsed from the false position.
+  `find_endobj_end` skips stream bodies too: `endobj` bytes in stream data
+  truncated the object body.
 
 ## v0.112.0 - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,12 @@
   the background uses rebinds it under a last-wins parser. A `/Contents`
   reference naming an *array* object expands to its elements instead of being
   wrapped, which had left an array as an element of the `/Contents` array.
+- refactor(pdf): **one ancestor chain per page.** `PdfUpdate::resolve_pages`
+  returns `Vec<Page>` rather than page ids: each `Page` carries its `/Pages`
+  ancestors from the `/Kids` walk and resolves any inheritable attribute
+  through `Page::inherited_attribute`. Flatten reads `/Resources` through it
+  instead of climbing `/Parent` on its own, so rotation, media box and
+  resources answer from the same chain under the same cycle and depth guards.
 - fix(core): **`Quill::resolve` keeps a mis-shaped container value raw rather
   than blanking it under the document's own label.** A seed the render
   coercion cannot conform — `rows: abc` on an `array`, `addr: 5` on a typed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,14 @@
   document-level pair rather than a `store` / `load` pair. The old names are
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
+- fix(pdf): **an inheritable page attribute resolves along the page's own
+  ancestor chain, not the root `/Pages` node alone.** `/Rotate` and `/MediaBox`
+  were read from the page dict and then from the root, so a base whose
+  intermediate `/Pages` node carries `/Rotate 90` passed the rotation guard and
+  every stamped widget landed a quarter turn off, and a page inheriting its
+  `/MediaBox` from an intermediate node was flipped against the root's page
+  height. The `/Kids` walk carries each page's ancestor ids, nearest first, and
+  both readers consult the page dict then that chain (ISO 32000-1 §7.7.3.4).
 
 ## v0.112.0 - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@
   document-level pair rather than a `store` / `load` pair. The old names are
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
+- fix(pdfform): **flatten keeps the background's resources and its own
+  `/Contents`.** `/Resources` is inheritable, so writing a fresh one onto a page
+  that carried none shadowed the ancestor's dict and unbound every name the
+  background stream selects; the effective dict is now resolved up `/Parent`,
+  inlined onto the page and extended there. The drawn fonts take names free in
+  that dict (`Helv2` where `Helv` is taken), since a second binding for a name
+  the background uses rebinds it under a last-wins parser. A `/Contents`
+  reference naming an *array* object expands to its elements instead of being
+  wrapped, which had left an array as an element of the `/Contents` array.
 
 ## v0.112.0 - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,16 @@
   document-level pair rather than a `store` / `load` pair. The old names are
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
+- fix(content): **a U+2028 or U+2029 in document text becomes a space.**
+  Typst's lexer reads both as line breaks, so one mid-paragraph reopens
+  `at_start` and the characters behind it are read as a block marker:
+  `"intro\u{2028}- item"` rendered a bullet, `- item` on its own line. No
+  escape reaches them — a `\` before whitespace is Typst's own linebreak — so
+  the separators join `\r` and the bidi controls as characters the content
+  forbids, refused by `validate` and replaced at every text ingress:
+  `from_plaintext`, markdown import, and an `Op::Insert` through
+  `apply_text_delta`. A space rather than a drop, both being Unicode
+  whitespace, so the words either side stay parted.
 
 ## v0.112.0 - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,15 @@
   document-level pair rather than a `store` / `load` pair. The old names are
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
+- fix(core): **`Quill::resolve` keeps a mis-shaped container value raw rather
+  than blanking it under the document's own label.** A seed the render
+  coercion cannot conform — `rows: abc` on an `array`, `addr: 5` on a typed
+  dictionary, a list where a variant container belongs — was rebuilt from the
+  schema anyway, so the row showed an empty container still tagged
+  `authored`. The container arms now compose an absent or already-shaped seed
+  only, and anything else falls through to the keep-raw path
+  `conform_card_render` documents. The render gate refuses the shape, so the
+  plate is unchanged.
 
 ## v0.112.0 - 2026-09-01
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2335,6 +2335,7 @@ dependencies = [
  "hayro",
  "hayro-svg",
  "lopdf",
+ "pdf-writer",
  "quillmark",
  "quillmark-content",
  "quillmark-core",

--- a/crates/backends/pdfform/Cargo.toml
+++ b/crates/backends/pdfform/Cargo.toml
@@ -32,3 +32,5 @@ quillmark-fixtures = { workspace = true }
 # an unpublishable cycle; cargo strips path-only dev-deps at packaging.
 quillmark = { path = "../../quillmark" }
 lopdf = { workspace = true }
+# Builds the page-tree shapes the flatten tests need but no fixture carries.
+pdf-writer = { workspace = true }

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -9,12 +9,10 @@
 //! true of any background with balanced `q`/`Q` and no dangling `cm`. Backs the
 //! SVG/PNG raster outputs only; the AcroForm PDF deliverable is stamped.
 
-use std::collections::HashSet;
-
 use quillmark_pdf::{
     reader::{
         extract_outer_dict, find_dict_value, parse_indirect_ref, splice_dict_value, ObjectIndex,
-        UpdatedObject,
+        Page, UpdatedObject,
     },
     writer::{
         alloc_id, append_refs_to_array_key, dict_object, pdf_escape, winansi_encode, OnNonArray,
@@ -55,8 +53,8 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
     let idx = ObjectIndex::new(&pdf);
     let mut up = PdfUpdate::begin(&idx, None)?;
 
-    let page_ids = up.resolve_pages(&idx, fields)?;
-    let page_count = page_ids.len();
+    let pages = up.resolve_pages(&idx, fields)?;
+    let page_count = pages.len();
 
     // Helvetica and ZapfDingbats are among the 14 standard PDF fonts every
     // conforming reader provides, so neither is embedded.
@@ -80,11 +78,12 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
             continue;
         }
 
-        let page_obj_id = page_ids[page_idx];
+        let page = &pages[page_idx];
+        let page_obj_id = page.id;
         let what = format!("page object {page_obj_id}");
         let pg_dict = idx.dict(page_obj_id, CODE_PARSE, &what)?;
 
-        let resources = resolve_resources(&idx, pg_dict)?;
+        let resources = resolve_resources(&idx, page)?;
         let font_inner: &[u8] = match &resources {
             Some(res) => font_dict(res)?.map_or(&[], |f| f.inner),
             None => &[],
@@ -310,34 +309,16 @@ fn referenced_array_inner<'a>(idx: &ObjectIndex<'a>, value: &[u8]) -> Option<&'a
 
 /// The page's effective `/Resources` inner bytes, with an indirect `/Resources`
 /// or `/Font` replaced by an inline copy of the referenced dict. `/Resources` is
-/// inheritable (ISO 32000-1 §7.7.3.4), so a page carrying none draws with the
-/// nearest ancestor's, found by climbing `/Parent`. `None` when no node on that
-/// chain carries one.
-fn resolve_resources<'a>(
-    idx: &ObjectIndex<'a>,
-    pg_dict: &'a [u8],
-) -> Result<Option<Vec<u8>>, PdfError> {
-    // Deeper than any real page tree; a chain that long or that revisits a node
-    // is malformed, not a resource to inherit.
-    const MAX_ANCESTORS: usize = 64;
-
-    let mut node = pg_dict;
-    let mut seen = HashSet::new();
-    for _ in 0..MAX_ANCESTORS {
-        if let Some(value) = find_dict_value(node, "Resources") {
-            let inner = inline_dict(idx, value, "page /Resources")?;
-            return inline_font_dict(idx, inner).map(Some);
-        }
-        let Some((parent_id, _)) = find_dict_value(node, "Parent").and_then(parse_indirect_ref)
-        else {
-            return Ok(None);
-        };
-        if !seen.insert(parent_id) {
-            return Ok(None);
-        }
-        node = idx.dict(parent_id, CODE_PARSE, &format!("page tree node {parent_id}"))?;
-    }
-    Ok(None)
+/// inheritable, so a page carrying none draws with the nearest ancestor's.
+/// `None` when no node on the chain carries one; the first present value is
+/// taken, so one that fails to parse is an error rather than a step past.
+fn resolve_resources(idx: &ObjectIndex, page: &Page) -> Result<Option<Vec<u8>>, PdfError> {
+    page.inherited_attribute(idx, "Resources", |value| {
+        Some(inline_dict(idx, value, "page /Resources"))
+    })
+    .transpose()?
+    .map(|inner| inline_font_dict(idx, inner))
+    .transpose()
 }
 
 /// A dict-valued entry as inline bytes: an inline dict is copied as is, an
@@ -594,6 +575,45 @@ mod tests {
             fonts.has(b"Helv") && fonts.has(b"ZaDb"),
             "the drawn fonts are injected beside it"
         );
+    }
+
+    #[test]
+    fn resources_inherit_along_the_kids_chain_without_a_parent_link() {
+        // The same tree as `build_base`, minus the page's `/Parent`: the ancestor
+        // chain is the `/Kids` walk's, the one `/Rotate` and `/MediaBox` resolve
+        // along, so a missing back-link cannot detach the page from its resources.
+        let letter = Rect::new(0.0, 0.0, 612.0, 792.0);
+        let mut pdf = Pdf::new();
+        pdf.catalog(Ref::new(1)).pages(Ref::new(2));
+        {
+            let mut pages = pdf.pages(Ref::new(2));
+            pages.kids([Ref::new(3)]).count(1).media_box(letter);
+            pages
+                .insert(Name(b"Resources"))
+                .dict()
+                .insert(Name(b"Font"))
+                .dict()
+                .pair(Name(b"F1"), Ref::new(5));
+        }
+        pdf.page(Ref::new(3)).media_box(letter).contents(Ref::new(4));
+        pdf.stream(Ref::new(4), b"BT /F1 12 Tf 72 700 Td (background) Tj ET");
+        pdf.indirect(Ref::new(5))
+            .dict()
+            .pair(Name(b"Type"), Name(b"Font"))
+            .pair(Name(b"Subtype"), Name(b"Type1"))
+            .pair(Name(b"BaseFont"), Name(b"Helvetica"));
+        let base = pdf.finish();
+
+        let pdf = flatten(base, &[text_field("FullName", "Ada Lovelace")]).expect("flatten ok");
+
+        let fonts = page_resources(&pdf)
+            .get(b"Font")
+            .unwrap()
+            .as_dict()
+            .unwrap()
+            .clone();
+        assert!(fonts.has(b"F1"), "the background's font binding survives");
+        assert!(fonts.has(b"Helv"), "the drawn font is injected beside it");
     }
 
     #[test]

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -9,8 +9,13 @@
 //! true of any background with balanced `q`/`Q` and no dangling `cm`. Backs the
 //! SVG/PNG raster outputs only; the AcroForm PDF deliverable is stamped.
 
+use std::collections::HashSet;
+
 use quillmark_pdf::{
-    reader::{extract_outer_dict, find_dict_value, splice_dict_value, ObjectIndex, UpdatedObject},
+    reader::{
+        extract_outer_dict, find_dict_value, parse_indirect_ref, splice_dict_value, ObjectIndex,
+        UpdatedObject,
+    },
     writer::{
         alloc_id, append_refs_to_array_key, dict_object, pdf_escape, winansi_encode, OnNonArray,
     },
@@ -75,17 +80,30 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
             continue;
         }
 
-        let stream_id = alloc_id(&mut up.next_id)?;
-        up.objects.push(content_stream_object(
-            stream_id,
-            &build_content_stream(page_fields),
-        ));
-
         let page_obj_id = page_ids[page_idx];
         let what = format!("page object {page_obj_id}");
         let pg_dict = idx.dict(page_obj_id, CODE_PARSE, &what)?;
 
-        let new_pg = rewrite_page_for_flatten(pg_dict, helv_id, zadb_id, stream_id)?;
+        let resources = resolve_resources(&idx, pg_dict)?;
+        let font_inner: &[u8] = match &resources {
+            Some(res) => font_dict(res)?.map_or(&[], |f| f.inner),
+            None => &[],
+        };
+        let names = FontNames::free_in(font_inner);
+
+        let stream_id = alloc_id(&mut up.next_id)?;
+        up.objects.push(content_stream_object(
+            stream_id,
+            &build_content_stream(page_fields, &names),
+        ));
+
+        let new_pg = rewrite_page_for_flatten(
+            &idx,
+            pg_dict,
+            resources.as_deref(),
+            &[(&names.text, helv_id), (&names.check, zadb_id)],
+            stream_id,
+        )?;
         up.objects.push(dict_object(page_obj_id, &new_pg));
     }
 
@@ -100,7 +118,40 @@ fn has_drawable_value(spec: &FieldSpec) -> bool {
     }
 }
 
-fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
+/// The `/Font` resource names one page's flatten stream selects. Chosen per page
+/// because they must be free in that page's own `/Font` dict.
+struct FontNames {
+    text: String,
+    check: String,
+}
+
+impl FontNames {
+    fn free_in(font_inner: &[u8]) -> Self {
+        Self {
+            text: free_font_name(font_inner, typography::TEXT_FONT_RESOURCE),
+            check: free_font_name(font_inner, typography::CHECK_FONT_RESOURCE),
+        }
+    }
+}
+
+/// `preferred` when it is unbound in `font_inner`, else the first free
+/// `<preferred><n>`. Binding a name the background's own stream selects would
+/// rebind it there too: a dict carrying the key twice resolves last-wins.
+fn free_font_name(font_inner: &[u8], preferred: &str) -> String {
+    if find_dict_value(font_inner, preferred).is_none() {
+        return preferred.to_string();
+    }
+    let mut n = 2;
+    loop {
+        let name = format!("{preferred}{n}");
+        if find_dict_value(font_inner, &name).is_none() {
+            return name;
+        }
+        n += 1;
+    }
+}
+
+fn build_content_stream(fields: &[&FieldSpec], names: &FontNames) -> Vec<u8> {
     let mut out = Vec::new();
     for spec in fields {
         let [x0, y0, x1, y1] = spec.rect;
@@ -113,7 +164,7 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
                 // ZapfDingbats check glyphs are roughly square; centre in the box.
                 let x_pos = x0 + (w - size * typography::CHECK_GLYPH_WIDTH_FACTOR) * 0.5;
                 let y_pos = y0 + (h - size) * 0.5;
-                write_zadb_char(&mut out, x_pos, y_pos, size);
+                write_check_char(&mut out, &names.check, x_pos, y_pos, size);
             }
             FieldType::Text { .. } => {
                 if let Some(value) = &spec.value {
@@ -121,7 +172,7 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
                     let x_pos = x0 + typography::TEXT_INSET;
                     let y_top = y1 - size - typography::TEXT_TOP_INSET;
                     let lines: Vec<&str> = value.lines().collect();
-                    write_text_block(&mut out, &lines, x_pos, y_top, size, spec.rect);
+                    write_text_block(&mut out, &names.text, &lines, x_pos, y_top, size, spec.rect);
                 }
             }
             FieldType::Choice { .. } => {
@@ -129,7 +180,15 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
                     let size = typography::value_size(h);
                     let x_pos = x0 + typography::TEXT_INSET;
                     let y_pos = y0 + (h - size) * 0.5;
-                    write_text_block(&mut out, &[value.as_str()], x_pos, y_pos, size, spec.rect);
+                    write_text_block(
+                        &mut out,
+                        &names.text,
+                        &[value.as_str()],
+                        x_pos,
+                        y_pos,
+                        size,
+                        spec.rect,
+                    );
                 }
             }
         }
@@ -137,10 +196,18 @@ fn build_content_stream(fields: &[&FieldSpec]) -> Vec<u8> {
     out
 }
 
-/// Draw `lines` in `/Helv`, clipped to `clip` so an over-long value cannot paint
-/// over neighbouring content. Bytes are transcoded to WinAnsi to match the
-/// font's `/Encoding /WinAnsiEncoding`.
-fn write_text_block(out: &mut Vec<u8>, lines: &[&str], x: f32, y: f32, size: f32, clip: [f32; 4]) {
+/// Draw `lines` in the page's text font, clipped to `clip` so an over-long value
+/// cannot paint over neighbouring content. Bytes are transcoded to WinAnsi to
+/// match the font's `/Encoding /WinAnsiEncoding`.
+fn write_text_block(
+    out: &mut Vec<u8>,
+    font: &str,
+    lines: &[&str],
+    x: f32,
+    y: f32,
+    size: f32,
+    clip: [f32; 4],
+) {
     if lines.is_empty() {
         return;
     }
@@ -156,7 +223,7 @@ fn write_text_block(out: &mut Vec<u8>, lines: &[&str], x: f32, y: f32, size: f32
     out.push(b' ');
     push_f32(out, cy1 - cy0);
     out.extend_from_slice(b" re W n\n");
-    out.extend_from_slice(b"BT\n/Helv ");
+    out.extend_from_slice(format!("BT\n/{font} ").as_bytes());
     push_f32(out, size);
     out.extend_from_slice(b" Tf\n");
     push_f32(out, x);
@@ -178,8 +245,8 @@ fn write_text_block(out: &mut Vec<u8>, lines: &[&str], x: f32, y: f32, size: f32
 
 /// Draw ZapfDingbats glyph 0x34 (`'4'`), the filled check mark — the same glyph
 /// the AcroForm stamp path declares via `/MK /CA (4)`.
-fn write_zadb_char(out: &mut Vec<u8>, x: f32, y: f32, size: f32) {
-    out.extend_from_slice(b"q\nBT\n/ZaDb ");
+fn write_check_char(out: &mut Vec<u8>, font: &str, x: f32, y: f32, size: f32) {
+    out.extend_from_slice(format!("q\nBT\n/{font} ").as_bytes());
     push_f32(out, size);
     out.extend_from_slice(b" Tf\n");
     push_f32(out, x);
@@ -189,90 +256,189 @@ fn write_zadb_char(out: &mut Vec<u8>, x: f32, y: f32, size: f32) {
 }
 
 fn rewrite_page_for_flatten(
+    idx: &ObjectIndex,
     pg_dict: &[u8],
-    helv_id: u32,
-    zadb_id: u32,
+    resources: Option<&[u8]>,
+    fonts: &[(&str, u32)],
     stream_id: u32,
 ) -> Result<Vec<u8>, PdfError> {
-    // A page `/Contents` is legitimately a bare stream reference, so the
-    // flatten stream wraps it rather than refusing it.
-    let with_stream = append_refs_to_array_key(
+    let with_stream = append_content_stream(idx, pg_dict, stream_id)?;
+    add_font_resources(&with_stream, resources, fonts)
+}
+
+/// Append the flatten stream to the page `/Contents`. A `/Contents` naming an
+/// *array* object expands to that array's elements: wrapping the reference would
+/// leave an array as an element of the `/Contents` array, which is not a content
+/// stream. A reference to a stream is legitimate and wraps.
+fn append_content_stream(
+    idx: &ObjectIndex,
+    pg_dict: &[u8],
+    stream_id: u32,
+) -> Result<Vec<u8>, PdfError> {
+    if let Some(value) = find_dict_value(pg_dict, "Contents")
+        && let Some(inner) = referenced_array_inner(idx, value)
+    {
+        let merged = format!("[{} {stream_id} 0 R]", String::from_utf8_lossy(inner).trim());
+        return Ok(splice_dict_value(
+            pg_dict,
+            b"/Contents",
+            value,
+            merged.as_bytes(),
+        ));
+    }
+    append_refs_to_array_key(
         pg_dict,
         "Contents",
         &[stream_id],
         CODE_PARSE,
         OnNonArray::Wrap,
-    )?;
-    add_font_resources(&with_stream, &[("Helv", helv_id), ("ZaDb", zadb_id)])
+    )
 }
 
-/// Inject `/<name> <font_id> 0 R` for each of `fonts` into the page's
-/// `/Resources /Font` dict, creating intermediate dicts as needed. An indirect
-/// `/Resources` or `/Font` is an error rather than a skip: a `Tf` name resolves
-/// only through the page's `/Font` subdictionary, so an uninjected name draws
-/// nothing.
-fn add_font_resources(pg_dict: &[u8], fonts: &[(&str, u32)]) -> Result<Vec<u8>, PdfError> {
+/// The elements of the array object `value` references, or `None` when `value`
+/// is not a reference or names an object that is not an array.
+fn referenced_array_inner<'a>(idx: &ObjectIndex<'a>, value: &[u8]) -> Option<&'a [u8]> {
+    let (id, _) = parse_indirect_ref(value.trim_ascii())?;
+    let (start, end) = idx.object_bytes(id)?;
+    let body = &idx.bytes()[start..end];
+    // The `<id> <gen> obj` header holds only digits, so the first `obj` is it.
+    let after_header = body.windows(3).position(|w| w == b"obj")? + 3;
+    let inner = body[after_header..].trim_ascii().strip_prefix(b"[")?;
+    let close = inner.iter().rposition(|&b| b == b']')?;
+    Some(&inner[..close])
+}
+
+/// The page's effective `/Resources` inner bytes, with an indirect `/Resources`
+/// or `/Font` replaced by an inline copy of the referenced dict. `/Resources` is
+/// inheritable (ISO 32000-1 §7.7.3.4), so a page carrying none draws with the
+/// nearest ancestor's, found by climbing `/Parent`. `None` when no node on that
+/// chain carries one.
+fn resolve_resources<'a>(
+    idx: &ObjectIndex<'a>,
+    pg_dict: &'a [u8],
+) -> Result<Option<Vec<u8>>, PdfError> {
+    // Deeper than any real page tree; a chain that long or that revisits a node
+    // is malformed, not a resource to inherit.
+    const MAX_ANCESTORS: usize = 64;
+
+    let mut node = pg_dict;
+    let mut seen = HashSet::new();
+    for _ in 0..MAX_ANCESTORS {
+        if let Some(value) = find_dict_value(node, "Resources") {
+            let inner = inline_dict(idx, value, "page /Resources")?;
+            return inline_font_dict(idx, inner).map(Some);
+        }
+        let Some((parent_id, _)) = find_dict_value(node, "Parent").and_then(parse_indirect_ref)
+        else {
+            return Ok(None);
+        };
+        if !seen.insert(parent_id) {
+            return Ok(None);
+        }
+        node = idx.dict(parent_id, CODE_PARSE, &format!("page tree node {parent_id}"))?;
+    }
+    Ok(None)
+}
+
+/// A dict-valued entry as inline bytes: an inline dict is copied as is, an
+/// indirect reference is dereferenced through `idx`. References nested in the
+/// copy stay valid — they resolve against the same file.
+fn inline_dict(idx: &ObjectIndex, value: &[u8], what: &str) -> Result<Vec<u8>, PdfError> {
+    let trimmed = value.trim_ascii();
+    if trimmed.starts_with(b"<<") {
+        return extract_outer_dict(trimmed)
+            .map(<[u8]>::to_vec)
+            .ok_or_else(|| PdfError::new(CODE_PARSE, format!("{what} dict not parseable")));
+    }
+    let (id, _) = parse_indirect_ref(trimmed).ok_or_else(|| {
+        PdfError::new(
+            CODE_PARSE,
+            format!("{what} is neither a dict nor an indirect reference"),
+        )
+    })?;
+    Ok(idx
+        .dict(id, CODE_PARSE, &format!("{what} object {id}"))?
+        .to_vec())
+}
+
+/// `res_inner` with an indirect `/Font` replaced by an inline copy, so the font
+/// dict can be read by name and extended.
+fn inline_font_dict(idx: &ObjectIndex, res_inner: Vec<u8>) -> Result<Vec<u8>, PdfError> {
+    let inlined = match find_dict_value(&res_inner, "Font") {
+        Some(font_val) if !font_val.trim_ascii().starts_with(b"<<") => {
+            let mut value = b"<< ".to_vec();
+            value.extend_from_slice(&inline_dict(idx, font_val, "page /Resources /Font")?);
+            value.extend_from_slice(b" >>");
+            Some(splice_dict_value(&res_inner, b"/Font", font_val, &value))
+        }
+        _ => None,
+    };
+    Ok(inlined.unwrap_or(res_inner))
+}
+
+/// The `/Font` subdictionary of a resolved `/Resources` dict, which
+/// [`resolve_resources`] has already inlined.
+struct FontDict<'a> {
+    /// The value span, locating the entry for a splice.
+    value: &'a [u8],
+    inner: &'a [u8],
+}
+
+fn font_dict(res_inner: &[u8]) -> Result<Option<FontDict<'_>>, PdfError> {
+    let Some(value) = find_dict_value(res_inner, "Font") else {
+        return Ok(None);
+    };
+    let inner = extract_outer_dict(value)
+        .ok_or_else(|| PdfError::new(CODE_PARSE, "page /Resources /Font dict not parseable"))?;
+    Ok(Some(FontDict { value, inner }))
+}
+
+/// Write `resources`, extended with `/<name> <font_id> 0 R` for each of `fonts`,
+/// as the page's own inline `/Resources`, creating intermediate dicts as needed.
+/// `resources` is the page's *effective* dict, possibly inherited: a page's own
+/// `/Resources` shadows the inherited one outright, so the copy has to carry the
+/// ancestor's entries forward or the background loses its names.
+fn add_font_resources(
+    pg_dict: &[u8],
+    resources: Option<&[u8]>,
+    fonts: &[(&str, u32)],
+) -> Result<Vec<u8>, PdfError> {
     let entries = fonts
         .iter()
         .map(|(name, font_id)| format!("/{name} {font_id} 0 R"))
         .collect::<Vec<_>>()
         .join(" ");
 
-    match find_dict_value(pg_dict, "Resources") {
+    let new_res_inner: Vec<u8> = match resources {
+        None => format!("/Font << {entries} >>").into_bytes(),
+        Some(res_inner) => match font_dict(res_inner)? {
+            None => {
+                let mut out = res_inner.to_vec();
+                out.extend_from_slice(format!(" /Font << {entries} >>").as_bytes());
+                out
+            }
+            Some(font) => {
+                let mut new_font_val = b"<< ".to_vec();
+                new_font_val.extend_from_slice(font.inner);
+                new_font_val.extend_from_slice(format!(" {entries} >>").as_bytes());
+                splice_dict_value(res_inner, b"/Font", font.value, &new_font_val)
+            }
+        },
+    };
+
+    let mut new_res_val = b"<< ".to_vec();
+    new_res_val.extend_from_slice(&new_res_inner);
+    new_res_val.extend_from_slice(b" >>");
+
+    Ok(match find_dict_value(pg_dict, "Resources") {
+        Some(res_val) => splice_dict_value(pg_dict, b"/Resources", res_val, &new_res_val),
         None => {
             let mut out = pg_dict.to_vec();
-            out.extend_from_slice(format!(" /Resources << /Font << {entries} >> >>").as_bytes());
-            Ok(out)
+            out.extend_from_slice(b" /Resources ");
+            out.extend_from_slice(&new_res_val);
+            out
         }
-        Some(res_val) => {
-            if !res_val.trim_ascii().starts_with(b"<<") {
-                // Indirect /Resources ref: cannot inject the named font, and the
-                // emitted `/Helv`/`/ZaDb` Tf operators would not resolve.
-                return Err(PdfError::new(
-                    CODE_PARSE,
-                    "page /Resources is an indirect reference; flatten requires inline resources",
-                ));
-            }
-            let res_inner = extract_outer_dict(res_val)
-                .ok_or_else(|| PdfError::new(CODE_PARSE, "page /Resources dict not parseable"))?;
-
-            let new_res_inner: Vec<u8> = match find_dict_value(res_inner, "Font") {
-                None => {
-                    let mut out = res_inner.to_vec();
-                    out.extend_from_slice(format!(" /Font << {entries} >>").as_bytes());
-                    out
-                }
-                Some(font_val) => {
-                    if !font_val.trim_ascii().starts_with(b"<<") {
-                        return Err(PdfError::new(
-                            CODE_PARSE,
-                            "page /Resources /Font is an indirect reference; flatten requires \
-                             an inline /Font dict",
-                        ));
-                    }
-                    let font_inner = extract_outer_dict(font_val).ok_or_else(|| {
-                        PdfError::new(CODE_PARSE, "page /Resources /Font dict not parseable")
-                    })?;
-                    let mut new_font_val = b"<< ".to_vec();
-                    new_font_val.extend_from_slice(font_inner);
-                    new_font_val.extend_from_slice(format!(" {entries} >>").as_bytes());
-
-                    splice_dict_value(res_inner, b"/Font", font_val, &new_font_val)
-                }
-            };
-
-            let mut new_res_val = b"<< ".to_vec();
-            new_res_val.extend_from_slice(&new_res_inner);
-            new_res_val.extend_from_slice(b" >>");
-
-            Ok(splice_dict_value(
-                pg_dict,
-                b"/Resources",
-                res_val,
-                &new_res_val,
-            ))
-        }
-    }
+    })
 }
 
 /// Build a base-14 Type1 font object. Symbol fonts pass `encoding: None` to keep
@@ -309,6 +475,7 @@ fn push_f32(out: &mut Vec<u8>, v: f32) {
 mod tests {
     use super::*;
     use lopdf::Document as PdfDoc;
+    use pdf_writer::{Name, Pdf, Rect, Ref};
     use quillmark_pdf::CHECKBOX_ON_STATE;
 
     /// Single-page US-Letter background, no AcroForm and no annots.
@@ -347,6 +514,171 @@ mod tests {
         haystack.windows(needle.len()).any(|w| w == needle)
     }
 
+    fn default_names() -> FontNames {
+        FontNames::free_in(b"")
+    }
+
+    /// The `/Resources` dict of the flattened PDF's only page.
+    fn page_resources(pdf: &[u8]) -> lopdf::Dictionary {
+        let doc = PdfDoc::load_mem(pdf).expect("lopdf reparse: structurally valid");
+        let (_, page_id) = doc.get_pages().into_iter().next().expect("one page");
+        doc.get_dictionary(page_id)
+            .expect("page dict")
+            .get(b"Resources")
+            .expect("page carries its own /Resources")
+            .as_dict()
+            .expect("/Resources is a dict")
+            .clone()
+    }
+
+    /// One US-Letter page whose object ids are 1 catalog, 2 `/Pages`, 3 page,
+    /// 4 a background content stream, 5 the font it selects. `on_pages` and
+    /// `on_page` write the entries under test onto the tree node and the page;
+    /// `extra` adds further objects.
+    fn build_base(
+        on_pages: impl FnOnce(&mut pdf_writer::writers::Pages),
+        on_page: impl FnOnce(&mut pdf_writer::writers::Page),
+        extra: impl FnOnce(&mut Pdf),
+    ) -> Vec<u8> {
+        let letter = Rect::new(0.0, 0.0, 612.0, 792.0);
+        let mut pdf = Pdf::new();
+        pdf.catalog(Ref::new(1)).pages(Ref::new(2));
+        {
+            let mut pages = pdf.pages(Ref::new(2));
+            pages.kids([Ref::new(3)]).count(1).media_box(letter);
+            on_pages(&mut pages);
+        }
+        {
+            let mut page = pdf.page(Ref::new(3));
+            page.parent(Ref::new(2)).media_box(letter);
+            on_page(&mut page);
+        }
+        pdf.stream(Ref::new(4), b"BT /F1 12 Tf 72 700 Td (background) Tj ET");
+        pdf.indirect(Ref::new(5))
+            .dict()
+            .pair(Name(b"Type"), Name(b"Font"))
+            .pair(Name(b"Subtype"), Name(b"Type1"))
+            .pair(Name(b"BaseFont"), Name(b"Helvetica"));
+        extra(&mut pdf);
+        pdf.finish()
+    }
+
+    #[test]
+    fn resources_inherited_from_the_page_tree_reach_the_flattened_page() {
+        let base = build_base(
+            |pages| {
+                let mut res = pages.insert(Name(b"Resources")).dict();
+                res.insert(Name(b"ProcSet"))
+                    .array()
+                    .items([Name(b"PDF"), Name(b"Text")]);
+                res.insert(Name(b"Font"))
+                    .dict()
+                    .pair(Name(b"F1"), Ref::new(5));
+            },
+            |page| {
+                page.contents(Ref::new(4));
+            },
+            |_| {},
+        );
+
+        let pdf = flatten(base, &[text_field("FullName", "Ada Lovelace")]).expect("flatten ok");
+
+        let res = page_resources(&pdf);
+        assert!(
+            res.has(b"ProcSet"),
+            "the inherited /Resources entries survive the page's own dict"
+        );
+        let fonts = res.get(b"Font").unwrap().as_dict().unwrap();
+        assert!(fonts.has(b"F1"), "the background's font binding survives");
+        assert!(
+            fonts.has(b"Helv") && fonts.has(b"ZaDb"),
+            "the drawn fonts are injected beside it"
+        );
+    }
+
+    #[test]
+    fn a_font_name_the_page_already_binds_keeps_its_own_font() {
+        let base = build_base(
+            |_| {},
+            |page| {
+                page.contents(Ref::new(4));
+                let mut res = page.insert(Name(b"Resources")).dict();
+                res.insert(Name(b"Font"))
+                    .dict()
+                    .pair(Name(b"Helv"), Ref::new(5));
+            },
+            |_| {},
+        );
+
+        let pdf = flatten(base, &[text_field("FullName", "Ada Lovelace")]).expect("flatten ok");
+
+        let fonts = page_resources(&pdf)
+            .get(b"Font")
+            .unwrap()
+            .as_dict()
+            .unwrap()
+            .clone();
+        assert_eq!(
+            fonts.get(b"Helv").unwrap().as_reference().unwrap(),
+            (5, 0),
+            "/Helv stays bound to the background's own font"
+        );
+        assert!(
+            fonts.has(b"Helv2"),
+            "the drawn font takes a free name instead"
+        );
+        assert!(
+            contains_window(&pdf, b"/Helv2 "),
+            "the drawn stream selects the name it was registered under"
+        );
+    }
+
+    #[test]
+    fn a_contents_reference_to_an_array_expands_to_its_streams() {
+        let base = build_base(
+            |_| {},
+            |page| {
+                page.contents(Ref::new(6));
+                let mut res = page.insert(Name(b"Resources")).dict();
+                res.insert(Name(b"Font"))
+                    .dict()
+                    .pair(Name(b"F1"), Ref::new(5));
+            },
+            // The `/Contents` reference names an array object, not a stream.
+            |pdf| {
+                pdf.indirect(Ref::new(6))
+                    .array()
+                    .items([Ref::new(4), Ref::new(7)]);
+                pdf.stream(Ref::new(7), b"0.75 w 72 690 200 20 re S");
+            },
+        );
+
+        let pdf = flatten(base, &[text_field("FullName", "Ada Lovelace")]).expect("flatten ok");
+
+        let doc = PdfDoc::load_mem(&pdf).expect("lopdf reparse: structurally valid");
+        let (_, page_id) = doc.get_pages().into_iter().next().expect("one page");
+        let contents = doc
+            .get_dictionary(page_id)
+            .unwrap()
+            .get(b"Contents")
+            .unwrap()
+            .as_array()
+            .expect("/Contents is an array")
+            .clone();
+        assert_eq!(
+            contents.len(),
+            3,
+            "the referenced array's elements plus the drawn stream"
+        );
+        for item in &contents {
+            let id = item.as_reference().expect("/Contents element is a reference");
+            assert!(
+                doc.get_object(id).unwrap().as_stream().is_ok(),
+                "every /Contents element resolves to a stream"
+            );
+        }
+    }
+
     #[test]
     fn flatten_produces_no_acroform() {
         let pdf = flatten_ok(&[text_field("FullName", "Ada Lovelace")]);
@@ -382,7 +714,7 @@ mod tests {
     fn build_content_stream_transcodes_non_ascii_to_winansi() {
         let value = "Caf\u{e9} \u{2014} Se\u{f1}or \u{2019}A\u{2019}";
         let spec = text_field("FullName", value);
-        let stream = build_content_stream(&[&spec]);
+        let stream = build_content_stream(&[&spec], &default_names());
 
         // WinAnsi: é→0xE9, —→0x97, ñ→0xF1, ’→0x92.
         let want: &[u8] = &[
@@ -408,7 +740,7 @@ mod tests {
     #[test]
     fn flatten_checked_checkbox_emits_zapfdingbats_glyph() {
         let spec = checkbox_field("Agree", true);
-        let stream = build_content_stream(&[&spec]);
+        let stream = build_content_stream(&[&spec], &default_names());
         let text = String::from_utf8_lossy(&stream);
 
         assert!(

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -287,7 +287,8 @@ fn scaled_render_settings(scale: f32) -> RenderSettings {
 }
 
 /// Satisfies standard Type1 font queries from hayro's embedded font data:
-/// required for the flat PDF's `Helv` and `ZaDb` content streams.
+/// required for the Helvetica and ZapfDingbats the flat PDF's content streams
+/// draw with.
 fn standard_font_settings() -> InterpreterSettings {
     InterpreterSettings {
         font_resolver: Arc::new(|query| match query {

--- a/crates/backends/pdfform/src/typography.rs
+++ b/crates/backends/pdfform/src/typography.rs
@@ -4,11 +4,19 @@
 //! flatten path must commit to a concrete font and size. Keeping that decision
 //! here is what makes preview and flattening agree exactly.
 
-/// Base-14 Helvetica, registered as `/Helv`, for text and choice values.
+/// Base-14 Helvetica, for text and choice values.
 pub(crate) const TEXT_FONT: &str = "Helvetica";
 
-/// Base-14 ZapfDingbats, registered as `/ZaDb`, for the checkbox check glyph.
+/// Base-14 ZapfDingbats, for the checkbox check glyph.
 pub(crate) const CHECK_FONT: &str = "ZapfDingbats";
+
+/// Preferred `/Font` resource name for [`TEXT_FONT`], shared with the `/DA` the
+/// stamp path writes. A page already binding it gets a derived name instead.
+pub(crate) const TEXT_FONT_RESOURCE: &str = quillmark_pdf::FormFont::Helvetica.resource_name();
+
+/// Preferred `/Font` resource name for [`CHECK_FONT`], the AcroForm spelling for
+/// ZapfDingbats.
+pub(crate) const CHECK_FONT_RESOURCE: &str = "ZaDb";
 
 pub(crate) const MIN_SIZE: f32 = 4.0;
 pub(crate) const MAX_SIZE: f32 = 12.0;

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -1,10 +1,10 @@
 //! Markdown import (cold): `normalize → pulldown → content`.
 //!
 //! Input is normalized by [`crate::normalize::normalize_markdown`] (CRLF→LF,
-//! bidi strip, HTML comment-fence repair) so the content invariants hold by
-//! construction, then parsed with `pulldown_cmark` (CommonMark + strikethrough
-//! + pipe tables) and walked into a [`Content`]. This is the one place the
-//! `<u>` allowlist runs.
+//! bidi controls dropped, U+2028/U+2029 spaced, HTML comment-fence repair) so
+//! the content invariants hold by construction, then parsed with
+//! `pulldown_cmark` (CommonMark + strikethrough + pipe tables) and walked into
+//! a [`Content`]. This is the one place the `<u>` allowlist runs.
 //!
 //! ## Canonicalizations (documented, not bugs)
 //!
@@ -78,7 +78,7 @@ pub fn from_markdown(markdown: &str) -> Result<Normalized, ImportError> {
 /// [`from_markdown`]. Every character is content, never syntax: `*hi*` is four
 /// literal chars, not emphasis. With [`crate::export::to_plaintext`] it pins the
 /// fixed point `to_plaintext(from_plaintext(s)) == s` for any `s` free of `\r`,
-/// bidi controls, and [`ISLAND_SLOT`].
+/// bidi controls, U+2028/U+2029 line separators, and [`ISLAND_SLOT`].
 ///
 /// Line structure is **derived, not stored**: a lone `\n` between two non-empty
 /// segments is a within-paragraph break ([`Line::continues`] `true`); a blank
@@ -89,7 +89,8 @@ pub fn from_plaintext(s: &str) -> Normalized {
     // through untouched.
     let text: String = s
         .chars()
-        .filter(|&c| c != '\r' && c != ISLAND_SLOT && !crate::normalize::is_bidi_char(c))
+        .filter(|&c| c != ISLAND_SLOT)
+        .filter_map(crate::normalize::admit_char)
         .collect();
     // One line per `\n`-separated segment. A single streaming pass carries the
     // prior segment's non-emptiness, so line 0 is `false` and no intermediate
@@ -126,17 +127,19 @@ struct Inline {
 }
 
 impl Inline {
-    /// Append inline text, stripping characters the content forbids: `\r` and a
-    /// stray [`ISLAND_SLOT`] are dropped; a stray `\n` becomes a space, real
-    /// line boundaries going through [`Self::push_raw`]. Admitting a bare slot
-    /// char would break the slot-count invariant.
+    /// Append inline text under the [`crate::normalize::admit_char`] contract,
+    /// with a stray [`ISLAND_SLOT`] dropped and a stray `\n` spaced, real line
+    /// boundaries going through [`Self::push_raw`]. Admitting a bare slot char
+    /// would break the slot-count invariant.
     fn push_text(&mut self, s: &str) {
         for c in s.chars() {
             let c = match c {
-                '\r' => continue,
                 ISLAND_SLOT => continue,
                 '\n' => ' ',
-                other => other,
+                other => match crate::normalize::admit_char(other) {
+                    Some(c) => c,
+                    None => continue,
+                },
             };
             self.text.push(c);
             self.pos += 1;
@@ -632,9 +635,13 @@ impl Builder {
     fn push_code_line(&mut self, seg: &str) {
         for c in seg.chars() {
             match c {
-                '\r' | '\n' => continue,
+                '\n' => continue,
                 ISLAND_SLOT => continue,
-                other => self.inline.push_raw(other),
+                other => {
+                    if let Some(c) = crate::normalize::admit_char(other) {
+                        self.inline.push_raw(c);
+                    }
+                }
             }
         }
     }
@@ -951,6 +958,21 @@ mod tests {
         let rt = imp_plain(&format!("a{ISLAND_SLOT}b"));
         assert_eq!(rt.text, "ab", "the reserved island slot is dropped");
         assert_eq!(rt.islands.len(), 0);
+    }
+
+    #[test]
+    fn line_separators_are_spaced_at_every_text_ingress() {
+        for sep in ['\u{2028}', '\u{2029}'] {
+            let src = format!("intro{sep}- item");
+            assert_eq!(imp_plain(&src).text, "intro - item", "plaintext {sep:?}");
+            assert_eq!(imp(&src).text, "intro - item", "markdown {sep:?}");
+        }
+
+        let held = Content::new("intro\u{2028}- item".into(), vec![Line::new(LineKind::Para)]);
+        assert_eq!(
+            held.validate(),
+            Err(crate::model::Invariant::LineSeparator('\u{2028}'))
+        );
     }
 
     #[test]

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -6,7 +6,7 @@
 //! encoded: the model stores only the resulting range, so the stored form is
 //! identical whatever the editor did.
 
-use crate::normalize::is_bidi_char;
+use crate::normalize::{is_bidi_char, is_line_separator};
 use serde_json::Value as JsonValue;
 use std::borrow::Cow;
 
@@ -24,9 +24,10 @@ pub const ISLAND_SLOT: char = '\u{FFFC}';
 /// One content field as a content: the text plus the structure that rides on it.
 ///
 /// Invariants (established once by import normalization, checked by
-/// [`Content::validate`]): the text holds no `\r` and no bidi controls; the
-/// count of [`ISLAND_SLOT`] equals `islands.len()`; `lines.len()` equals the
-/// number of `\n`-separated segments; marks are normalized (sorted, unioned).
+/// [`Content::validate`]): the text holds no `\r`, no bidi controls, and no
+/// U+2028/U+2029 line separators; the count of [`ISLAND_SLOT`] equals
+/// `islands.len()`; `lines.len()` equals the number of `\n`-separated segments;
+/// marks are normalized (sorted, unioned).
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct Content {
@@ -781,6 +782,9 @@ pub enum Invariant {
     CarriageReturn,
     /// A bidi formatting control in the text.
     BidiControl(char),
+    /// A U+2028/U+2029 line separator in the text, which a downstream lexer
+    /// reads as a line break.
+    LineSeparator(char),
     /// `island_slot_count != islands.len()`.
     IslandSlotMismatch { slots: usize, islands: usize },
     /// `lines.len() != newline_segment_count`.
@@ -1089,6 +1093,9 @@ impl Content {
             }
             if is_bidi_char(c) {
                 return Err(Invariant::BidiControl(c));
+            }
+            if is_line_separator(c) {
+                return Err(Invariant::LineSeparator(c));
             }
             if c == ISLAND_SLOT {
                 slots += 1;

--- a/crates/content/src/normalize.rs
+++ b/crates/content/src/normalize.rs
@@ -20,14 +20,37 @@ pub(crate) fn is_bidi_char(c: char) -> bool {
     )
 }
 
-/// Removes the Unicode bidi formatting controls, which sit adjacent to `**`/`_`
-/// and defeat delimiter recognition.
-fn strip_bidi_formatting(s: &str) -> String {
-    if !s.chars().any(is_bidi_char) {
+/// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR, which Typst's lexer
+/// reads as line breaks: one mid-paragraph reopens `at_start`, so what follows
+/// it is read as a block marker the author never wrote.
+#[inline]
+pub(crate) fn is_line_separator(c: char) -> bool {
+    matches!(c, '\u{2028}' | '\u{2029}')
+}
+
+/// What the content admits `c` as, `None` dropping it. A `\r` is dropped
+/// because it pairs with a `\n` that stays; a line separator becomes a space,
+/// both being Unicode whitespace, so dropping one would join the words it parts.
+/// No downstream escape can neutralize a separator — a `\` before whitespace is
+/// Typst's own linebreak — so the content refuses it.
+#[inline]
+pub(crate) fn admit_char(c: char) -> Option<char> {
+    match c {
+        '\r' => None,
+        c if is_bidi_char(c) => None,
+        c if is_line_separator(c) => Some(' '),
+        c => Some(c),
+    }
+}
+
+/// Apply [`admit_char`] across `s`: the bidi controls sit adjacent to `**`/`_`
+/// and defeat delimiter recognition, the separators spell block structure.
+fn admit_chars(s: &str) -> String {
+    if !s.chars().any(|c| admit_char(c) != Some(c)) {
         return s.to_string();
     }
 
-    s.chars().filter(|c| !is_bidi_char(*c)).collect()
+    s.chars().filter_map(admit_char).collect()
 }
 
 /// Inserts a newline after `-->` when followed by non-whitespace content.
@@ -110,11 +133,11 @@ fn fix_html_comment_fences(s: &str) -> String {
     result
 }
 
-/// Applies all markdown normalizations in order: CRLF → LF, bidi strip,
-/// HTML comment fence repair.
+/// Applies all markdown normalizations in order: CRLF → LF, bidi controls
+/// dropped and U+2028/U+2029 spaced, HTML comment fence repair.
 pub fn normalize_markdown(markdown: &str) -> String {
     let cleaned = normalize_line_endings(markdown);
-    let cleaned = strip_bidi_formatting(&cleaned);
+    let cleaned = admit_chars(&cleaned);
     fix_html_comment_fences(&cleaned)
 }
 
@@ -145,11 +168,13 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_strip_bidi_formatting_cases() {
+    fn bidi_controls_are_dropped_and_separators_spaced() {
         let cases: &[(&str, &str)] = &[
             ("hello world", "hello world"),
             ("", ""),
             ("**bold** text", "**bold** text"),
+            ("intro\u{2028}- item", "intro - item"),
+            ("intro\u{2029}= Heading", "intro = Heading"),
             ("he\u{202D}llo", "hello"),
             ("**asdf** or \u{202D}**(1234**", "**asdf** or **(1234**"),
             ("a\u{200E}b\u{200F}c", "abc"),
@@ -167,7 +192,7 @@ mod tests {
         ];
 
         for (input, expected) in cases {
-            assert_eq!(strip_bidi_formatting(input), *expected, "input: {:?}", input);
+            assert_eq!(admit_chars(input), *expected, "input: {:?}", input);
         }
     }
 

--- a/crates/content/src/normalize.rs
+++ b/crates/content/src/normalize.rs
@@ -1,6 +1,8 @@
 //! Markdown-string preprocessing run before parsing, at the
 //! [`from_markdown`](crate::import::from_markdown) boundary.
 
+/// The Unicode bidi formatting controls, which sit adjacent to `**`/`_` and
+/// defeat delimiter recognition.
 #[inline]
 pub(crate) fn is_bidi_char(c: char) -> bool {
     matches!(
@@ -43,8 +45,6 @@ pub(crate) fn admit_char(c: char) -> Option<char> {
     }
 }
 
-/// Apply [`admit_char`] across `s`: the bidi controls sit adjacent to `**`/`_`
-/// and defeat delimiter recognition, the separators spell block structure.
 fn admit_chars(s: &str) -> String {
     if !s.chars().any(|c| admit_char(c) != Some(c)) {
         return s.to_string();

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -7,7 +7,7 @@ use crate::model::{
     line_kind_mismatch, Container, Island, Line, LineKind, LineKindMismatch, Mark, MarkKind,
     Content, Usv, ISLAND_SLOT,
 };
-use crate::normalize::is_bidi_char;
+use crate::normalize::admit_char;
 use crate::usv::char_to_byte;
 use std::borrow::Cow;
 
@@ -405,9 +405,10 @@ impl Content {
     /// *deletes* a slot drops the corresponding [`Island`]; a delta that
     /// *inserts* a raw slot is rejected ([`ApplyError::IslandSlotInInsert`]).
     ///
-    /// Inserted text is sanitized first: `\r` and Unicode bidi controls (the
-    /// chars [`Content::validate`] forbids) are stripped, mirroring what
-    /// `import` applies at the string boundary.
+    /// Inserted text is sanitized first, mirroring what `import` applies at the
+    /// string boundary: `\r` and Unicode bidi controls are stripped, and a
+    /// U+2028/U+2029 line separator becomes a space — the chars
+    /// [`Content::validate`] forbids.
     pub fn apply_text_delta(&mut self, delta: &Delta) -> Result<(), ApplyError> {
         self.apply_text_delta_inner(delta)?;
         self.normalize();
@@ -836,18 +837,14 @@ fn ranges_overlap(a0: Usv, a1: Usv, b0: Usv, b1: Usv) -> bool {
     a0 < b1 && b0 < a1
 }
 
-/// A char `validate()` rejects. A raw [`ISLAND_SLOT`] is refused separately.
-fn insert_forbidden(c: char) -> bool {
-    c == '\r' || is_bidi_char(c)
-}
-
-/// Drop [`insert_forbidden`] chars from every `Op::Insert`, borrowing the delta
-/// through untouched when none carries one.
+/// Put every `Op::Insert` under the [`admit_char`] contract — the chars
+/// `validate()` rejects, dropped or spaced — borrowing the delta through
+/// untouched when none carries one. A raw [`ISLAND_SLOT`] is refused separately.
 fn sanitize_inserts(delta: &Delta) -> Cow<'_, Delta> {
     let needs_cleaning = delta
         .ops
         .iter()
-        .any(|op| matches!(op, Op::Insert(s) if s.chars().any(insert_forbidden)));
+        .any(|op| matches!(op, Op::Insert(s) if s.chars().any(|c| admit_char(c) != Some(c))));
     if !needs_cleaning {
         return Cow::Borrowed(delta);
     }
@@ -855,7 +852,7 @@ fn sanitize_inserts(delta: &Delta) -> Cow<'_, Delta> {
         .ops
         .iter()
         .map(|op| match op {
-            Op::Insert(s) => Op::Insert(s.chars().filter(|c| !insert_forbidden(*c)).collect()),
+            Op::Insert(s) => Op::Insert(s.chars().filter_map(admit_char).collect()),
             other => other.clone(),
         })
         .collect();
@@ -1736,6 +1733,20 @@ mod tests {
         };
         rt.apply_text_delta(&d).unwrap();
         assert_eq!(rt.text, "ab");
+        assert_eq!(rt.validate(), Ok(()));
+    }
+
+    #[test]
+    fn insert_line_separator_is_spaced() {
+        // A space keeps the words apart without minting the line break Typst
+        // would read, and which would make `- item` a bullet.
+        let mut rt = from_markdown("ab").unwrap();
+        let d = Delta {
+            ops: vec![Op::Retain(2), Op::Insert("\u{2028}- item".into())],
+        };
+        rt.apply_text_delta(&d).unwrap();
+        assert_eq!(rt.text, "ab - item");
+        assert_eq!(rt.lines.len(), 1);
         assert_eq!(rt.validate(), Ok(()));
     }
 

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -813,13 +813,18 @@ fn pad_row(v: &mut Value, cols: usize) {
     }
 }
 
-/// De-newline a cell's text (each `\n`/`\r` → a space, 1:1 so mark offsets hold)
-/// and re-normalize its marks. Writes back into the cell's **own** object rather
-/// than minting a fresh one, so a key this build does not recognize survives.
+/// Every char a downstream lexer reads as a line break, the U+2028/U+2029
+/// separators included. A cell is one line.
+const CELL_BREAKS: &[char] = &['\n', '\r', '\u{2028}', '\u{2029}'];
+
+/// De-newline a cell's text (each line break → a space, 1:1 so mark offsets
+/// hold) and re-normalize its marks. Writes back into the cell's **own** object
+/// rather than minting a fresh one, so a key this build does not recognize
+/// survives.
 fn canon_cell(cell: &mut Value) {
     let (text, marks) = parse_cell(cell);
-    let text = if text.contains(['\n', '\r']) {
-        text.replace(['\n', '\r'], " ")
+    let text = if text.contains(CELL_BREAKS) {
+        text.replace(CELL_BREAKS, " ")
     } else {
         text
     };
@@ -870,7 +875,7 @@ pub(crate) fn table_shape_error(props: &Value) -> Option<Invariant> {
     }
     for (i, cell) in table_cell_values(props).enumerate() {
         let text = cell.get("text").and_then(Value::as_str).unwrap_or_default();
-        if text.contains('\n') || text.contains('\r') {
+        if text.contains(CELL_BREAKS) {
             return Some(Invariant::TableCellNewline { cell: i });
         }
     }

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -602,8 +602,8 @@ fn compose(
     }
 }
 
-/// Whether `seed` composes as the container `field` declares: absent, so the
-/// blank container is the whole answer, or already that shape.
+/// Whether `seed` composes as the container: absent, so the blank container is
+/// the whole answer, or already of `shape`.
 ///
 /// A present seed of another shape (`rows: abc` on an `array`, `addr: 5` on a
 /// typed dictionary) is kept raw by the scalar arm instead, as

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -566,7 +566,7 @@ fn compose(
     seed_rung: FieldSource,
 ) -> (QuillValue, FieldSource) {
     match (&field.r#type, &field.properties, &field.items) {
-        (FieldType::Object, Some(props), _) => {
+        (FieldType::Object, Some(props), _) if composes_as(seed, serde_json::Value::is_object) => {
             let obj = seed.and_then(|v| v.as_json().as_object());
             let mut out = serde_json::Map::new();
             let rung = compose_members(obj, props, seed_rung, &mut out);
@@ -582,7 +582,7 @@ fn compose(
             }
             (QuillValue::from_json(serde_json::Value::Object(out)), rung)
         }
-        (FieldType::Array, _, Some(items)) => {
+        (FieldType::Array, _, Some(items)) if composes_as(seed, serde_json::Value::is_array) => {
             let arr = seed
                 .and_then(|v| v.as_json().as_array().cloned())
                 .unwrap_or_default();
@@ -600,6 +600,19 @@ fn compose(
             None => (blank(field), FieldSource::Blank),
         },
     }
+}
+
+/// Whether `seed` composes as the container `field` declares: absent, so the
+/// blank container is the whole answer, or already that shape.
+///
+/// A present seed of another shape (`rows: abc` on an `array`, `addr: 5` on a
+/// typed dictionary) is kept raw by the scalar arm instead, as
+/// [`conform_card_render`] keeps it: [`resolve_value_sourced`] reports the seed's
+/// own rung, so a rebuilt container would carry the document's label over content
+/// the document never wrote. The gate refuses the shape
+/// (`validation::type_mismatch`), so only the ungated views meet it.
+fn composes_as(seed: Option<&QuillValue>, shape: fn(&serde_json::Value) -> bool) -> bool {
+    seed.is_none_or(|v| shape(v.as_json()))
 }
 
 /// Resolve every declared member of a namespace over its slice of `seed` into
@@ -656,6 +669,15 @@ fn resolve_variant_sourced(
     field: &FieldSchema,
 ) -> (QuillValue, FieldSource) {
     let present = value.filter(|v| !v.as_json().is_null());
+    // A present seed that is neither the container nor a bare member name is
+    // kept raw, as any mis-shaped container is ([`composes_as`]): the rung is
+    // the document's, and a blank world under it would read as an answer the
+    // document gave.
+    if let Some(raw) =
+        present.filter(|v| !v.as_json().is_object() && v.as_json().as_str().is_none())
+    {
+        return (raw.clone(), FieldSource::Authored);
+    }
     let authored = present.map(|v| v.as_json());
     // Coercion normalizes to the container, so the authored discriminant is the
     // `value` key. A bare scalar that bypassed coercion (a serde-built payload)

--- a/crates/core/src/quill/resolved.rs
+++ b/crates/core/src/quill/resolved.rs
@@ -346,6 +346,62 @@ card_kinds:
         assert_eq!(status.value.as_json(), &serde_json::json!("draft"));
     }
 
+    const CONTAINERS: &str = r#"
+quill:
+  name: shape_test
+  version: "1.0"
+  backend: typst
+  description: Container-shape tests
+main:
+  fields:
+    counts:
+      type: array
+      items:
+        type: integer
+    address:
+      type: object
+      properties:
+        street: { type: string }
+"#;
+
+    fn shape_doc(fields: &str) -> Document {
+        parse(&format!(
+            "~~~card-yaml\n$quill: shape_test@1.0\n$kind: main\n{fields}~~~\n"
+        ))
+    }
+
+    #[test]
+    fn an_array_field_blanks_only_where_the_document_left_it_out() {
+        let quill = quill_from_yaml(CONTAINERS);
+
+        // `abc` conforms to no `integer[]`, so it reaches the ladder raw. The row
+        // is the document's own text under the document's own label, not `[]`.
+        let raw = quill.resolve(&shape_doc("counts: abc\n"));
+        let r = row(&raw.main.fields, "counts");
+        assert_eq!(r.source, FieldSource::Authored);
+        assert_eq!(r.value.as_json(), &serde_json::json!("abc"));
+
+        let absent = quill.resolve(&shape_doc(""));
+        let r = row(&absent.main.fields, "counts");
+        assert_eq!(r.source, FieldSource::Blank);
+        assert_eq!(r.value.as_json(), &serde_json::json!([]));
+    }
+
+    #[test]
+    fn a_typed_dict_blanks_only_where_the_document_left_it_out() {
+        let quill = quill_from_yaml(CONTAINERS);
+
+        let raw = quill.resolve(&shape_doc("address: 5\n"));
+        let r = row(&raw.main.fields, "address");
+        assert_eq!(r.source, FieldSource::Authored);
+        assert_eq!(r.value.as_json(), &serde_json::json!(5));
+
+        let absent = quill.resolve(&shape_doc(""));
+        let r = row(&absent.main.fields, "address");
+        assert_eq!(r.source, FieldSource::Blank);
+        assert_eq!(r.value.as_json(), &serde_json::json!({ "street": "" }));
+    }
+
     // ── Byte-for-byte with the render projection ─────────────────────────────
     // Both projections cut the one shared ladder (`ladder_sourced`), but over
     // separately-conformed input: the render gate's fallible conform vs the

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -475,6 +475,25 @@ fn resolve_reports_the_container_as_one_cell_matching_the_plate() {
     assert_eq!(row.source, crate::quill::resolved::FieldSource::Default);
 }
 
+/// A value the container cannot be built from stays raw, as a mis-shaped
+/// `array` or typed dictionary does: `resolve()` labels the row Authored, and a
+/// blank world under that label would read as an answer the document gave.
+#[test]
+fn a_mis_shaped_container_value_stays_raw() {
+    let quill = quill();
+    let document = doc("classification: [CUI, SECRET]\n");
+    let row = quill
+        .resolve(&document)
+        .main
+        .fields
+        .into_iter()
+        .find(|f| f.name == "classification")
+        .expect("classification row");
+
+    assert_eq!(row.source, crate::quill::resolved::FieldSource::Authored);
+    assert_eq!(row.value.as_json(), &json!(["CUI", "SECRET"]));
+}
+
 /// The container is a namespace like any other: its rung is the strongest that
 /// contributed, so a cell the document wrote lifts a container whose
 /// discriminant came from the schema.

--- a/crates/fuzz/src/convert_fuzz.rs
+++ b/crates/fuzz/src/convert_fuzz.rs
@@ -1,4 +1,6 @@
 use proptest::prelude::*;
+use quillmark_content::export::to_plaintext;
+use quillmark_content::import::from_plaintext;
 use quillmark_typst::emit::{escape_markup, escape_string};
 use typst::syntax::SyntaxKind;
 
@@ -26,11 +28,13 @@ const ALLOWED_LEAVES: &[SyntaxKind] = &[
     SyntaxKind::SmartQuote,
 ];
 
-/// A `--` or a `...` never lands by chance in a draw over all of Unicode, so
-/// the second alphabet is Typst's special characters alone.
+/// A `--`, a `...`, or a separator ahead of a block marker never lands by
+/// chance in a draw over all of Unicode. The second alphabet is what does land
+/// one: Typst's special characters, the U+2028/U+2029 separators it reads as
+/// line breaks, and the markers and space that open a block behind one.
 fn escaper_input() -> impl Strategy<Value = String> {
     prop_oneof![
-        r#"[-.?/~*_#\[\]{}$<>@'"0-9a-c \\`]{0,40}"#,
+        r#"[-.?/~*_#+=\[\]{}$<>@'"0-9a-c \\`\x{2028}\x{2029}]{0,40}"#,
         "\\PC*",
     ]
 }
@@ -91,10 +95,12 @@ proptest! {
 
     #[test]
     fn fuzz_escape_markup_survives_the_typst_parser(s in escaper_input()) {
-        // Typst also reads U+2028 / U+2029 as line breaks, which no escape can
-        // neutralize (`\` before whitespace is its linebreak). The content layer
-        // admits them, so they are not this function's to answer.
-        let s: String = s.chars().filter(|&c| c != '\u{2028}' && c != '\u{2029}').collect();
+        // The escaper answers for the text a content holds, so the draw enters
+        // through the content ingress, which spaces the U+2028/U+2029
+        // separators: Typst reads one as a line break that reopens `at_start`,
+        // and no escape neutralizes it (a `\` before whitespace is its own
+        // linebreak).
+        let s = to_plaintext(&from_plaintext(&s));
         // Past `at_start`, whose markers are the emitter's guard, not the escaper's.
         let (text, kinds) = resolve(&format!("x{}", escape_markup(&s)));
 

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -128,12 +128,13 @@ pub enum FormFont {
 }
 
 impl FormFont {
-    /// The `/DR` `/Font` key a `/DA` names this face by.
-    pub(crate) fn resource_name(self) -> &'static [u8] {
+    /// The `/DR` `/Font` key a `/DA` names this face by, and the name a drawn
+    /// content stream selects it with.
+    pub const fn resource_name(self) -> &'static str {
         match self {
-            Self::Helvetica => b"Helv",
-            Self::Times => b"TiRo",
-            Self::Courier => b"Cour",
+            Self::Helvetica => "Helv",
+            Self::Times => "TiRo",
+            Self::Courier => "Cour",
         }
     }
 

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -601,18 +601,27 @@ pub(crate) fn open_trailer<'a>(
     Ok((xref_offset, trailer, catalog_id))
 }
 
-/// Flatten the catalog's `/Pages` tree into page object ids in document order.
-/// The walk is capped to prevent runaway on a pathological PDF.
-pub(crate) fn resolve_page_ids(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec<u32>, PdfError> {
+/// A page object and the `/Pages` nodes it descends from, nearest ancestor
+/// first: the chain an inheritable attribute resolves along.
+#[derive(Debug)]
+pub(crate) struct Page {
+    pub(crate) id: u32,
+    ancestors: Vec<u32>,
+}
+
+/// Flatten the catalog's `/Pages` tree into its page objects in document order,
+/// each carrying its ancestor chain. The walk is capped to prevent runaway on a
+/// pathological PDF.
+pub(crate) fn walk_page_tree(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec<Page>, PdfError> {
     let root_pages_id = root_pages_id(idx, catalog_id)?;
 
     const MAX_NODES: usize = 100_000;
     let mut out = Vec::new();
-    let mut stack = vec![root_pages_id];
+    let mut stack = vec![(root_pages_id, Vec::<u32>::new())];
     // A node reached twice is a cyclic or shared-node `/Pages` tree: a `/Kids`
     // self-cycle would otherwise walk until MAX_NODES.
     let mut seen: HashSet<u32> = HashSet::new();
-    while let Some(node_id) = stack.pop() {
+    while let Some((node_id, ancestors)) = stack.pop() {
         if !seen.insert(node_id) {
             return Err(err(
                 CODE_PARSE,
@@ -629,17 +638,40 @@ pub(crate) fn resolve_page_ids(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec
         if typ.starts_with("/Pages") {
             let kids = find_dict_value(dict, "Kids")
                 .ok_or_else(|| err(CODE_PARSE, "/Pages node missing /Kids"))?;
+            let mut kid_ancestors = Vec::with_capacity(ancestors.len() + 1);
+            kid_ancestors.push(node_id);
+            kid_ancestors.extend_from_slice(&ancestors);
             let mut kid_ids: Vec<u32> = parse_ref_array(kids)
                 .into_iter()
                 .map(|(id, _)| id)
                 .collect();
             kid_ids.reverse();
-            stack.extend(kid_ids);
+            stack.extend(kid_ids.into_iter().map(|id| (id, kid_ancestors.clone())));
         } else {
-            out.push(node_id);
+            out.push(Page {
+                id: node_id,
+                ancestors,
+            });
         }
     }
     Ok(out)
+}
+
+/// The inheritable attribute `key` of `page`, `parse`d from the page dict, else
+/// from the nearest ancestor `/Pages` node carrying a parseable one
+/// (ISO 32000-1 §7.7.3.4).
+fn inherited_attribute<T>(
+    idx: &ObjectIndex,
+    page: &Page,
+    key: &str,
+    parse: impl Fn(&[u8]) -> Option<T>,
+) -> Option<T> {
+    std::iter::once(page.id)
+        .chain(page.ancestors.iter().copied())
+        .find_map(|id| {
+            let dict = idx.dict(id, CODE_PARSE, "page node").ok()?;
+            parse(find_dict_value(dict, key)?)
+        })
 }
 
 /// The catalog's root `/Pages` node id.
@@ -652,32 +684,24 @@ fn root_pages_id(idx: &ObjectIndex, catalog_id: u32) -> Result<u32, PdfError> {
 }
 
 /// Reject a page with a non-zero `/Rotate`, its own value or the one inherited
-/// from the root `/Pages`. The stamp and flatten paths write geometry in
-/// unrotated user space and do not compensate, so a rotated base page would
-/// display every widget away from its intended box.
-pub(crate) fn assert_unrotated_pages(
+/// from its nearest ancestor `/Pages` node. The stamp and flatten paths write
+/// geometry in unrotated user space and do not compensate, so a rotated base
+/// page would display every widget away from its intended box.
+pub(crate) fn assert_unrotated_pages<'p>(
     idx: &ObjectIndex,
-    catalog_id: u32,
-    page_ids: &[u32],
+    pages: impl IntoIterator<Item = &'p Page>,
 ) -> Result<(), PdfError> {
-    let read_rotate = |id: u32| -> Option<i64> {
-        let dict = idx.dict(id, CODE_PARSE, "page").ok()?;
-        let raw = find_dict_value(dict, "Rotate")?;
-        std::str::from_utf8(raw.trim_ascii())
-            .ok()?
-            .trim()
-            .parse::<i64>()
-            .ok()
-    };
-    let inherited = root_pages_id(idx, catalog_id).ok().and_then(read_rotate);
-    for &page_id in page_ids {
-        let rotate = read_rotate(page_id).or(inherited).unwrap_or(0);
+    let parse_rotate =
+        |raw: &[u8]| -> Option<i64> { std::str::from_utf8(raw.trim_ascii()).ok()?.parse().ok() };
+    for page in pages {
+        let rotate = inherited_attribute(idx, page, "Rotate", parse_rotate).unwrap_or(0);
         if rotate.rem_euclid(360) != 0 {
             return Err(err(
                 "pdf::rotated_page",
                 format!(
-                    "page object {page_id} has /Rotate {rotate}; the stamp spine only \
-                     handles unrotated pages"
+                    "page object {} has /Rotate {rotate}; the stamp spine only \
+                     handles unrotated pages",
+                    page.id
                 ),
             ));
         }
@@ -743,32 +767,27 @@ fn normalize_rect(mb: [f32; 4]) -> [f32; 4] {
 }
 
 /// The `/MediaBox` of every page, normalized to `[x0, y0, x1, y1]`, in document
-/// order, falling back to the root `/Pages` node's when a page declares none.
-/// The full rect rather than width/height, so a caller flipping page-relative
-/// top-left geometry can honour a non-zero page origin.
+/// order, taken from the nearest ancestor `/Pages` node carrying one when a page
+/// declares none. The full rect rather than width/height, so a caller flipping
+/// page-relative top-left geometry can honour a non-zero page origin.
 pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
     let (_, _, catalog_id) = open_trailer(pdf, CODE_PARSE)?;
+    media_boxes_of(&ObjectIndex::new(pdf), catalog_id)
+}
 
-    let idx = ObjectIndex::new(pdf);
-    let inherited = root_pages_media_box(&idx, catalog_id);
-    let page_ids = resolve_page_ids(&idx, catalog_id)?;
-    let mut out = Vec::with_capacity(page_ids.len());
-    for id in page_ids {
-        let dict = idx.dict(id, CODE_PARSE, &format!("page node {id}"))?;
-        let mb = find_dict_value(dict, "MediaBox")
-            .and_then(parse_rect_array)
-            .or(inherited)
-            .ok_or_else(|| err(CODE_PARSE, format!("page {id} has no resolvable /MediaBox")))?;
+fn media_boxes_of(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec<[f32; 4]>, PdfError> {
+    let pages = walk_page_tree(idx, catalog_id)?;
+    let mut out = Vec::with_capacity(pages.len());
+    for page in &pages {
+        let mb = inherited_attribute(idx, page, "MediaBox", parse_rect_array).ok_or_else(|| {
+            err(
+                CODE_PARSE,
+                format!("page {} has no resolvable /MediaBox", page.id),
+            )
+        })?;
         out.push(normalize_rect(mb));
     }
     Ok(out)
-}
-
-/// The root `/Pages` node's `/MediaBox`, if present: the value pages inherit.
-fn root_pages_media_box(idx: &ObjectIndex, catalog_id: u32) -> Option<[f32; 4]> {
-    let pages_id = root_pages_id(idx, catalog_id).ok()?;
-    let dict = idx.dict(pages_id, CODE_PARSE, "root /Pages node").ok()?;
-    find_dict_value(dict, "MediaBox").and_then(parse_rect_array)
 }
 
 #[cfg(test)]
@@ -953,23 +972,57 @@ mod tests {
     fn page_tree_cycle_is_rejected() {
         let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                     2 0 obj\n<< /Type /Pages /Kids [2 0 R] /Count 1 >>\nendobj\n";
-        let e = resolve_page_ids(&ObjectIndex::new(pdf), 1).expect_err("cycle rejected");
+        let e = walk_page_tree(&ObjectIndex::new(pdf), 1).expect_err("cycle rejected");
         assert_eq!(e.code, CODE_PARSE);
         assert!(e.message.contains("revisits"), "{}", e.message);
     }
 
     #[test]
     fn rotated_page_is_rejected() {
-        // /Rotate inherited from the root /Pages node.
         let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                     2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 /Rotate 90 >>\nendobj\n\
                     3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
-        let e = assert_unrotated_pages(&ObjectIndex::new(pdf), 1, &[3])
-            .expect_err("rotated page rejected");
+        let idx = ObjectIndex::new(pdf);
+        let pages = walk_page_tree(&idx, 1).expect("page tree walks");
+        let e = assert_unrotated_pages(&idx, &pages).expect_err("rotated page rejected");
         assert_eq!(e.code, "pdf::rotated_page");
         let flat = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                      2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\
                      3 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
-        assert!(assert_unrotated_pages(&ObjectIndex::new(flat), 1, &[3]).is_ok());
+        let flat_idx = ObjectIndex::new(flat);
+        let flat_pages = walk_page_tree(&flat_idx, 1).expect("page tree walks");
+        assert!(assert_unrotated_pages(&flat_idx, &flat_pages).is_ok());
+    }
+
+    #[test]
+    fn rotate_resolves_to_the_nearest_ancestor_carrying_it() {
+        let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+                    2 0 obj\n<< /Type /Pages /Kids [5 0 R] /Count 2 >>\nendobj\n\
+                    5 0 obj\n<< /Type /Pages /Parent 2 0 R /Kids [3 0 R 4 0 R] /Count 2 \
+                    /Rotate 90 >>\nendobj\n\
+                    3 0 obj\n<< /Type /Page /Parent 5 0 R >>\nendobj\n\
+                    4 0 obj\n<< /Type /Page /Parent 5 0 R /Rotate 0 >>\nendobj\n";
+        let idx = ObjectIndex::new(pdf);
+        let pages = walk_page_tree(&idx, 1).expect("page tree walks");
+        let e = assert_unrotated_pages(&idx, &pages[..1])
+            .expect_err("an intermediate /Pages node's /Rotate reaches its pages");
+        assert_eq!(e.code, "pdf::rotated_page");
+        assert!(
+            assert_unrotated_pages(&idx, &pages[1..]).is_ok(),
+            "a page's own /Rotate 0 outranks its ancestor's 90"
+        );
+    }
+
+    #[test]
+    fn media_box_resolves_to_the_nearest_ancestor_carrying_it() {
+        let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+                    2 0 obj\n<< /Type /Pages /Kids [5 0 R 4 0 R] /Count 2 \
+                    /MediaBox [0 0 612 792] >>\nendobj\n\
+                    5 0 obj\n<< /Type /Pages /Parent 2 0 R /Kids [3 0 R] /Count 1 \
+                    /MediaBox [0 0 200 400] >>\nendobj\n\
+                    3 0 obj\n<< /Type /Page /Parent 5 0 R >>\nendobj\n\
+                    4 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
+        let boxes = media_boxes_of(&ObjectIndex::new(pdf), 1).expect("media boxes resolve");
+        assert_eq!(boxes, [[0.0, 0.0, 200.0, 400.0], [0.0, 0.0, 612.0, 792.0]]);
     }
 }

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -636,9 +636,30 @@ pub(crate) fn open_trailer<'a>(
 /// A page object and the `/Pages` nodes it descends from, nearest ancestor
 /// first: the chain an inheritable attribute resolves along.
 #[derive(Debug)]
-pub(crate) struct Page {
-    pub(crate) id: u32,
+pub struct Page {
+    pub id: u32,
     ancestors: Vec<u32>,
+}
+
+impl Page {
+    /// The inheritable attribute `key`, `parse`d from the page dict, else from
+    /// the nearest ancestor `/Pages` node carrying a parseable one
+    /// (ISO 32000-1 §7.7.3.4). `parse` returning `None` keeps the search
+    /// climbing, so a caller that wants the first *present* value wraps its
+    /// result in `Some`.
+    pub fn inherited_attribute<T>(
+        &self,
+        idx: &ObjectIndex,
+        key: &str,
+        parse: impl Fn(&[u8]) -> Option<T>,
+    ) -> Option<T> {
+        std::iter::once(self.id)
+            .chain(self.ancestors.iter().copied())
+            .find_map(|id| {
+                let dict = idx.dict(id, CODE_PARSE, "page node").ok()?;
+                parse(find_dict_value(dict, key)?)
+            })
+    }
 }
 
 /// Flatten the catalog's `/Pages` tree into its page objects in document order,
@@ -689,23 +710,6 @@ pub(crate) fn walk_page_tree(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec<P
     Ok(out)
 }
 
-/// The inheritable attribute `key` of `page`, `parse`d from the page dict, else
-/// from the nearest ancestor `/Pages` node carrying a parseable one
-/// (ISO 32000-1 §7.7.3.4).
-fn inherited_attribute<T>(
-    idx: &ObjectIndex,
-    page: &Page,
-    key: &str,
-    parse: impl Fn(&[u8]) -> Option<T>,
-) -> Option<T> {
-    std::iter::once(page.id)
-        .chain(page.ancestors.iter().copied())
-        .find_map(|id| {
-            let dict = idx.dict(id, CODE_PARSE, "page node").ok()?;
-            parse(find_dict_value(dict, key)?)
-        })
-}
-
 /// The catalog's root `/Pages` node id.
 fn root_pages_id(idx: &ObjectIndex, catalog_id: u32) -> Result<u32, PdfError> {
     let cat_dict = idx.dict(catalog_id, CODE_PARSE, "catalog")?;
@@ -726,7 +730,9 @@ pub(crate) fn assert_unrotated_pages<'p>(
     let parse_rotate =
         |raw: &[u8]| -> Option<i64> { std::str::from_utf8(raw.trim_ascii()).ok()?.parse().ok() };
     for page in pages {
-        let rotate = inherited_attribute(idx, page, "Rotate", parse_rotate).unwrap_or(0);
+        let rotate = page
+            .inherited_attribute(idx, "Rotate", parse_rotate)
+            .unwrap_or(0);
         if rotate.rem_euclid(360) != 0 {
             return Err(err(
                 "pdf::rotated_page",
@@ -811,12 +817,14 @@ fn media_boxes_of(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec<[f32; 4]>, P
     let pages = walk_page_tree(idx, catalog_id)?;
     let mut out = Vec::with_capacity(pages.len());
     for page in &pages {
-        let mb = inherited_attribute(idx, page, "MediaBox", parse_rect_array).ok_or_else(|| {
-            err(
-                CODE_PARSE,
-                format!("page {} has no resolvable /MediaBox", page.id),
-            )
-        })?;
+        let mb = page
+            .inherited_attribute(idx, "MediaBox", parse_rect_array)
+            .ok_or_else(|| {
+                err(
+                    CODE_PARSE,
+                    format!("page {} has no resolvable /MediaBox", page.id),
+                )
+            })?;
         out.push(normalize_rect(mb));
     }
     Ok(out)

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -174,7 +174,9 @@ pub(crate) fn append_incremental_update(
 /// A header is `<id> <generation> obj` at a token boundary, so `19 0 obj` is not
 /// found inside `519 0 obj`, at any generation (re-saved PDFs carry non-zero
 /// ones). A later occurrence overwrites an earlier one, so a lookup answers with
-/// the live copy.
+/// the live copy. Literal strings, `%`-comments and stream bodies are skipped, so
+/// header bytes inside a string value or inside stream data cannot shadow the
+/// real object.
 pub struct ObjectIndex<'a> {
     pdf: &'a [u8],
     starts: HashMap<u32, usize>,
@@ -183,13 +185,19 @@ pub struct ObjectIndex<'a> {
 impl<'a> ObjectIndex<'a> {
     pub fn new(pdf: &'a [u8]) -> Self {
         let mut starts = HashMap::new();
-        for i in 0..pdf.len() {
-            if !pdf[i].is_ascii_digit() || !(i == 0 || matches!(pdf[i - 1], b'\n' | b'\r' | b' ')) {
+        let mut i = 0;
+        while i < pdf.len() {
+            if let Some(ni) = skip_stream_body(pdf, i).or_else(|| skip_string_or_comment(pdf, i)) {
+                i = ni;
                 continue;
             }
-            if let Some(id) = obj_header_id(&pdf[i..]) {
+            if pdf[i].is_ascii_digit()
+                && (i == 0 || matches!(pdf[i - 1], b'\n' | b'\r' | b' '))
+                && let Some(id) = obj_header_id(&pdf[i..])
+            {
                 starts.insert(id, i);
             }
+            i += 1;
         }
         Self { pdf, starts }
     }
@@ -268,13 +276,14 @@ fn obj_header_id(rest: &[u8]) -> Option<u32> {
 }
 
 /// The index just past the `endobj` closing the body at `from`. Literal
-/// `( … )` strings and `%`-comments are skipped so those bytes inside a string
-/// value or comment cannot truncate the object early.
+/// `( … )` strings, `%`-comments and stream bodies are skipped so those bytes
+/// inside a string value, a comment or stream data cannot truncate the object
+/// early.
 fn find_endobj_end(pdf: &[u8], from: usize) -> Option<usize> {
     let needle = b"endobj";
     let mut i = from;
     while i < pdf.len() {
-        if let Some(ni) = skip_string_or_comment(pdf, i) {
+        if let Some(ni) = skip_stream_body(pdf, i).or_else(|| skip_string_or_comment(pdf, i)) {
             i = ni;
             continue;
         }
@@ -391,6 +400,29 @@ fn skip_string_or_comment(b: &[u8], i: usize) -> Option<usize> {
         }
         _ => None,
     }
+}
+
+/// If `b[i]` opens a stream body — the `stream` keyword at a token boundary,
+/// followed by CRLF or LF per ISO 32000 §7.3.8 — the index just past the
+/// `endstream` closing it, so raw stream data is never read as structure. `None`
+/// when `b[i]` opens no stream, and when no `endstream` follows: a truncated
+/// stream is then scanned as ordinary bytes rather than swallowing the rest of
+/// the file.
+fn skip_stream_body(b: &[u8], i: usize) -> Option<usize> {
+    const OPEN: &[u8] = b"stream";
+    const CLOSE: &[u8] = b"endstream";
+    if !b[i..].starts_with(OPEN) || !(i == 0 || is_pdf_delim(b[i - 1])) {
+        return None;
+    }
+    let after_kw = i + OPEN.len();
+    let body = match b.get(after_kw)? {
+        b'\n' => after_kw + 1,
+        b'\r' if b.get(after_kw + 1) == Some(&b'\n') => after_kw + 2,
+        _ => return None,
+    };
+    (body..b.len().saturating_sub(CLOSE.len() - 1))
+        .find(|&j| b[j..].starts_with(CLOSE))
+        .map(|j| j + CLOSE.len())
 }
 
 /// The index after the last byte of the value beginning at `start`, whose
@@ -947,6 +979,39 @@ mod tests {
         let dict = extract_outer_dict(&pdf[s..e]).expect("dict parses");
         let title = find_dict_value(dict, "Title").expect("/Title");
         assert_eq!(title.trim_ascii(), b"(My endobj report)");
+    }
+
+    #[test]
+    fn obj_header_inside_string_does_not_shadow_object() {
+        let pdf = b"%PDF\n4 0 obj\n<< /V (real) >>\nendobj\n\
+                    5 0 obj\n<< /Subject (see 4 0 obj for the rest) >>\nendobj\n";
+        let dict = ObjectIndex::new(pdf).dict(4, CODE_PARSE, "obj").unwrap();
+        assert_eq!(find_dict_value(dict, "V").unwrap().trim_ascii(), b"(real)");
+    }
+
+    #[test]
+    fn obj_header_inside_stream_body_does_not_shadow_object() {
+        let pdf = b"%PDF\n4 0 obj\n<< /V (real) >>\nendobj\n\
+                    5 0 obj\n<< /Length 13 >>\nstream\n4 0 obj junk\nendstream\nendobj\n";
+        let dict = ObjectIndex::new(pdf).dict(4, CODE_PARSE, "obj").unwrap();
+        assert_eq!(find_dict_value(dict, "V").unwrap().trim_ascii(), b"(real)");
+    }
+
+    #[test]
+    fn object_after_a_stream_body_is_indexed() {
+        // The stream's unbalanced `(` would otherwise run the string skipper to EOF.
+        let pdf = b"%PDF\n5 0 obj\n<< /Length 12 >>\nstream\n(unbalanced\nendstream\nendobj\n\
+                    6 0 obj\n<< /V (after) >>\nendobj\n";
+        let dict = ObjectIndex::new(pdf).dict(6, CODE_PARSE, "obj").unwrap();
+        assert_eq!(find_dict_value(dict, "V").unwrap().trim_ascii(), b"(after)");
+    }
+
+    #[test]
+    fn endobj_inside_stream_body_does_not_truncate_object() {
+        let pdf = b"%PDF\n5 0 obj\n<< /Length 9 >>\nstream\nendobj x\nendstream\nendobj\n";
+        let idx = ObjectIndex::new(pdf);
+        let (s, e) = idx.object_bytes(5).expect("found object 5");
+        assert!(pdf[s..e].ends_with(b"endstream\nendobj"));
     }
 
     #[test]

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -513,7 +513,7 @@ fn is_pdf_delim(c: u8) -> bool {
     )
 }
 
-pub(crate) fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
+pub fn parse_indirect_ref(s: &[u8]) -> Option<(u32, u16)> {
     let s = skip_ws(s);
     let mut i = 0;
     while i < s.len() && s[i].is_ascii_digit() {

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -146,8 +146,8 @@ pub fn stamp(
             ));
         }
 
-        let page_ids = up.resolve_pages(&idx, fields)?;
-        let page_count = page_ids.len();
+        let pages = up.resolve_pages(&idx, fields)?;
+        let page_count = pages.len();
 
         let fonts = fonts_used(fields);
         let font_ids: Vec<u32> = fonts
@@ -164,7 +164,7 @@ pub fn stamp(
         let mut widgets_by_page: Vec<Vec<u32>> = vec![Vec::new(); page_count];
         for (spec, &wid) in fields.iter().zip(&widget_ids) {
             widgets_by_page[spec.page].push(wid);
-            let page_ref = Ref::new(page_ids[spec.page] as i32);
+            let page_ref = Ref::new(pages[spec.page].id as i32);
             up.objects.push(UpdatedObject {
                 id: wid,
                 bytes: write_widget_object(spec, Ref::new(wid as i32), page_ref),
@@ -222,7 +222,7 @@ pub fn stamp(
             if widget_refs.is_empty() {
                 continue;
             }
-            let page_obj_id = page_ids[page_idx];
+            let page_obj_id = pages[page_idx].id;
             let what = format!("page node {page_obj_id}");
             let pg_dict = idx.dict(page_obj_id, CODE_PARSE, &what)?;
             up.objects.push(dict_object(

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -55,7 +55,7 @@ fn field_appearance(spec: &FieldSpec) -> Vec<u8> {
         .filter(|s| s.is_finite() && *s > 0.0)
         .unwrap_or(0.0);
     let mut da = b"/".to_vec();
-    da.extend_from_slice(spec.font.resource_name());
+    da.extend_from_slice(spec.font.resource_name().as_bytes());
     da.extend_from_slice(format!(" {size} Tf 0 g").as_bytes());
     da
 }
@@ -201,7 +201,7 @@ pub fn stamp(
                 let mut dr = form.insert(Name(b"DR")).dict();
                 let mut font_dict = dr.insert(Name(b"Font")).dict();
                 for (font, &fid) in fonts.iter().zip(&font_ids) {
-                    font_dict.pair(Name(font.resource_name()), Ref::new(fid as i32));
+                    font_dict.pair(Name(font.resource_name().as_bytes()), Ref::new(fid as i32));
                 }
             }
             form.finish();

--- a/crates/quillmark-pdf/src/update.rs
+++ b/crates/quillmark-pdf/src/update.rs
@@ -6,7 +6,7 @@
 use crate::error::PdfError;
 use crate::reader::{
     append_incremental_update, assert_unrotated_pages, err, find_dict_value, open_trailer,
-    parse_indirect_ref, walk_page_tree, ObjectIndex, UpdatedObject,
+    parse_indirect_ref, walk_page_tree, ObjectIndex, Page, UpdatedObject,
 };
 use crate::writer::apply_producer_stamp;
 use crate::FieldSpec;
@@ -71,13 +71,15 @@ impl PdfUpdate {
         })
     }
 
-    /// Resolve the base's page object ids, bounds-checking every field's `page`
-    /// so a spec targeting a non-existent page errors rather than panicking later.
+    /// Resolve the base's pages in document order, each carrying the ancestor
+    /// chain its inheritable attributes resolve along, bounds-checking every
+    /// field's `page` so a spec targeting a non-existent page errors rather than
+    /// panicking later.
     pub fn resolve_pages(
         &self,
         idx: &ObjectIndex,
         fields: &[FieldSpec],
-    ) -> Result<Vec<u32>, PdfError> {
+    ) -> Result<Vec<Page>, PdfError> {
         let pages = walk_page_tree(idx, self.catalog_id)?;
         let page_count = pages.len();
         let mut checked = vec![false; page_count];
@@ -104,7 +106,7 @@ impl PdfUpdate {
         // Geometry is written in unrotated user space, so a rotated target page
         // would mis-place every field.
         assert_unrotated_pages(idx, targeted)?;
-        Ok(pages.iter().map(|page| page.id).collect())
+        Ok(pages)
     }
 
     /// Serialize the accumulated objects onto `pdf` via one incremental-update

--- a/crates/quillmark-pdf/src/update.rs
+++ b/crates/quillmark-pdf/src/update.rs
@@ -6,7 +6,7 @@
 use crate::error::PdfError;
 use crate::reader::{
     append_incremental_update, assert_unrotated_pages, err, find_dict_value, open_trailer,
-    parse_indirect_ref, resolve_page_ids, ObjectIndex, UpdatedObject,
+    parse_indirect_ref, walk_page_tree, ObjectIndex, UpdatedObject,
 };
 use crate::writer::apply_producer_stamp;
 use crate::FieldSpec;
@@ -78,8 +78,8 @@ impl PdfUpdate {
         idx: &ObjectIndex,
         fields: &[FieldSpec],
     ) -> Result<Vec<u32>, PdfError> {
-        let page_ids = resolve_page_ids(idx, self.catalog_id)?;
-        let page_count = page_ids.len();
+        let pages = walk_page_tree(idx, self.catalog_id)?;
+        let page_count = pages.len();
         let mut checked = vec![false; page_count];
         let mut targeted = Vec::new();
         for spec in fields {
@@ -97,14 +97,14 @@ impl PdfUpdate {
             }
             // A targeted page is overwritten and referenced as gen 0, so a
             // non-zero-generation page would be silently corrupted.
-            idx.assert_overwrite_gen_zero(page_ids[spec.page], "page")?;
+            idx.assert_overwrite_gen_zero(pages[spec.page].id, "page")?;
             checked[spec.page] = true;
-            targeted.push(page_ids[spec.page]);
+            targeted.push(&pages[spec.page]);
         }
         // Geometry is written in unrotated user space, so a rotated target page
         // would mis-place every field.
-        assert_unrotated_pages(idx, self.catalog_id, &targeted)?;
-        Ok(page_ids)
+        assert_unrotated_pages(idx, targeted)?;
+        Ok(pages.iter().map(|page| page.id).collect())
     }
 
     /// Serialize the accumulated objects onto `pdf` via one incremental-update

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -426,7 +426,12 @@ Before CommonMark parsing, each body region is normalized:
 2. **Bidi control stripping.** Remove U+061C, U+200E, U+200F,
    U+202A–U+202E, U+2066–U+2069. These invisible characters can
    desynchronize delimiter runs when copy-pasted from bidi-aware sources.
-3. **HTML comment fence repair.** If `-->` is followed by non-whitespace
+3. **Line-separator spacing.** Replace U+2028 (LINE SEPARATOR) and U+2029
+   (PARAGRAPH SEPARATOR) with a single U+0020 space. CommonMark reads
+   neither as a line ending, but a backend lexer may, in which case the
+   text after one is read as a block marker the author never wrote. Both
+   are Unicode whitespace, so a space keeps the words they part apart.
+4. **HTML comment fence repair.** If `-->` is followed by non-whitespace
    text on the same line, insert a newline after `-->` so the trailing
    text reaches the paragraph parser instead of being consumed by the
    CommonMark HTML-block rule (type 2).


### PR DESCRIPTION
Supersedes and closes #1450, #1451, #1452, #1453 and #1454, merged in order onto their shared base (`3b9ecc3`) with one merge commit each, plus a dense-prose pass and one refactor that unifies a seam the two PDF PRs each crossed on their own. The changelog carries the entries via its union merge.

## What it carries

- **#1450 fix(pdf):** `ObjectIndex` skips literal strings, `%`-comments and stream bodies, so `N G obj` bytes carried as content cannot shadow the real object; `find_endobj_end` skips stream bodies too. Closes #1410.
- **#1451 fix(pdf):** `/Rotate` and `/MediaBox` resolve along the page's ancestor chain, nearest first (ISO 32000-1 §7.7.3.4), not the page dict then the root `/Pages` alone. `walk_page_tree` replaces `resolve_page_ids`. Closes #1395.
- **#1452 fix(pdfform):** flatten resolves the page's effective `/Resources`, extends an inline copy, takes font names free in that dict, and expands a `/Contents` reference to an array object into its elements. `FormFont::resource_name` becomes `pub const fn -> &str`; `parse_indirect_ref` becomes `pub`. Closes #1396.
- **#1453 fix(core):** `Quill::resolve` keeps a mis-shaped container seed raw (Authored) instead of rebuilding a blank container under the document's label. Closes #1407.
- **#1454 fix(content):** U+2028/U+2029 become a space at every text ingress and `validate` refuses them (`Invariant::LineSeparator`); the escaper fuzz draws through `from_plaintext`. Closes #1441.

## refactor(pdf): one ancestor chain per page

#1451 built each page's `/Pages` ancestor chain from the `/Kids` walk for rotation and media box. #1452, written in parallel, needed `/Resources` (inheritable under the same spec clause) and climbed `/Parent` links instead, with its own depth cap and revisit guard, because `resolve_pages` handed pdfform only bare page ids. Two routes up the same tree can disagree on a malformed file, and two guards are two invariants to keep aligned.

Now, in one commit on top of the merges:

- `reader::Page` is public, with `pub id` and `Page::inherited_attribute(idx, key, parse)`, the helper #1451 introduced, as a method.
- `PdfUpdate::resolve_pages` returns `Vec<Page>` rather than `Vec<u32>`. Stamp and flatten read `.id`.
- Flatten's `resolve_resources` takes a `&Page` and reads `/Resources` through `inherited_attribute`; the `/Parent` climb, its cap and its `HashSet` are gone. A `/Resources` that is present but unparseable stays an error rather than a step past, as before.
- New test: a page with no `/Parent` link still inherits the tree node's `/Resources`, pinning the chain to the `/Kids` walk.

## Dense-prose pass

- `composes_as` doc named a `field` parameter the function does not take; it now names `shape`.
- `admit_chars` carried the bidi and separator reasons its two predicates already own; the bidi reason moves onto `is_bidi_char`, which had none, and the loop's doc goes.

## Verification

- `cargo test --workspace` green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --locked --workspace` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RoZ3PTRpZRoji1frheXZ1m