### PR TITLE
fix(core): report an unclosed root `~~~` block as unclosed, and accept `~~~yaml` as an opener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- fix(core): **an unclosed root `~~~` block is reported as unclosed.** A
+  document that opens with `~~~` and `$quill` but never closes the fence drew
+  the generic `parse::missing_quill` text, telling the author to open a block
+  they had already opened while the scanner's unclosed-fence signal was
+  dropped. That signal now reaches the diagnostic: the message names the
+  opener's line, the field to close after, and — for a `~~` run or an indented
+  `~~~` — the line that failed to close it. A root opener carrying a foreign
+  info string (`~~~metadata`) is named the same way.
+- feat(core): **`~~~yaml` opens a card-yaml block**, a second non-canonical
+  alias beside `~~~card-yaml`; both re-emit as bare `~~~`. A YAML *code* block
+  in prose is a backtick fence (```` ```yaml ````), unchanged.
 - feat(core): **the values form: `reader.values()` reads a document as plain
   values and `writer.set_values(values)` writes them back.** A document has
   three forms: *stored* (verbatim, quill-free), *values* (stored with every

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -9,7 +9,7 @@ use crate::error::ParseError;
 use crate::value::QuillValue;
 use crate::Diagnostic;
 
-use super::fences::find_metadata_blocks;
+use super::fences::{find_metadata_blocks, RootFault};
 use super::meta::{extract_meta_items, meta_key};
 use super::payload::{Payload, PayloadItem};
 use quillmark_content::Normalized;
@@ -22,10 +22,52 @@ fn import_body_or_parse_error(md: &str) -> Result<Normalized, ParseError> {
 use super::prescan::{prescan_fence_content, CommentPathSegment, NestedComment, PreItem};
 use super::{Card, Document};
 
-/// A `MissingQuill` message naming the specific malformation. LLM authors hit
-/// one recurring shape: a bare YAML mapping with `$quill:` at the top and no
-/// fences, where naming the concrete edit converges faster than generic advice.
-fn missing_block_message(markdown: &str) -> String {
+/// A `MissingQuill` message naming the specific malformation. LLM authors hit a
+/// few recurring shapes — a bare YAML mapping with no fences, an opener whose
+/// closer is missing or misspelt — where naming the concrete edit converges
+/// faster than generic advice. `root_fault` is what the fence scanner saw at the
+/// root position, so a document that *does* open correctly is never told to open
+/// correctly.
+fn missing_block_message(markdown: &str, root_fault: Option<&RootFault>) -> String {
+    match root_fault {
+        Some(RootFault::Unclosed {
+            opener_line,
+            near_closer,
+            last_field,
+        }) => {
+            let mut msg = format!(
+                "Root card-yaml block opened at line {} is never closed.",
+                opener_line + 1
+            );
+            if let Some((line, text)) = near_closer {
+                msg.push_str(&format!(
+                    " The line `{}` at line {} does not close it: a closing fence is at \
+                     column zero and at least as long as the opener.",
+                    text,
+                    line + 1
+                ));
+            }
+            msg.push_str(" Add a line containing exactly `~~~` (three tildes, no info string) ");
+            match last_field {
+                Some(key) => msg.push_str(&format!("after the last field (`{}`), ", key)),
+                None => msg.push_str("after the last field, "),
+            }
+            msg.push_str("before the prose body.");
+            return msg;
+        }
+        Some(RootFault::InfoString { opener_line, info }) => {
+            return format!(
+                "Root card-yaml block opener at line {} is `~~~{}`, which opens an ordinary \
+                 code block. The card-yaml opener carries no info string: drop `{}` and open \
+                 with a bare `~~~` (the `card-yaml` and `yaml` info strings are also accepted).",
+                opener_line + 1,
+                info,
+                info
+            );
+        }
+        None => {}
+    }
+
     let trimmed = markdown.trim_start();
 
     if trimmed.starts_with("$quill:") || trimmed.starts_with("quill:") {
@@ -205,11 +247,13 @@ pub(super) fn decompose_with_warnings(
     }
 
     // The first block is the document root; the rest are composable cards.
-    let (mut blocks, warnings) = find_metadata_blocks(markdown)?;
+    let scan = find_metadata_blocks(markdown)?;
+    let mut blocks = scan.blocks;
+    let warnings = scan.warnings;
 
     if blocks.is_empty() {
         return Err(crate::error::ParseError::MissingQuill(
-            missing_block_message(markdown),
+            missing_block_message(markdown, scan.root_fault.as_ref()),
         ));
     }
 

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -1,17 +1,18 @@
 //! Line-oriented fence scanner for card-yaml blocks.
 //!
 //! A column-zero `~~~` fence (three or more tildes) with an empty info string,
-//! or the non-canonical `card-yaml` alias, opens a card-yaml block. Openers
-//! inside an ordinary CommonMark fenced code block are literal content, so a
-//! backtick fence (or a `~~~` fence carrying a language) writes one in prose.
+//! or one of the non-canonical `card-yaml` / `yaml` aliases, opens a card-yaml
+//! block. Openers inside an ordinary CommonMark fenced code block are literal
+//! content, so a backtick fence (or a `~~~` fence carrying a language) writes
+//! one in prose.
 
 use crate::error::ParseError;
 use crate::{Diagnostic, Severity};
 
 use super::assemble::MetadataBlock;
 
-/// Accepted on input as a non-canonical alias; never emitted.
-const CARD_YAML_INFO: &str = "card-yaml";
+/// Accepted on input as non-canonical aliases; never emitted.
+const CARD_YAML_INFO: [&str; 2] = ["card-yaml", "yaml"];
 
 pub(super) struct Lines<'a> {
     pub(super) source: &'a str,
@@ -115,7 +116,7 @@ fn card_yaml_opener_run(line: &str) -> Option<usize> {
     match code_fence_on_line(line, None) {
         Some((b'~', run, false)) => {
             let info = code_fence_info(line, run);
-            (info.is_empty() || info == CARD_YAML_INFO).then_some(run)
+            (info.is_empty() || CARD_YAML_INFO.contains(&info)).then_some(run)
         }
         _ => None,
     }
@@ -171,7 +172,54 @@ fn has_paired_dash_with_yaml_keys(lines: &Lines<'_>, opener_k: usize) -> bool {
     false
 }
 
-pub(super) type FenceScan = (Vec<MetadataBlock>, Vec<Diagnostic>);
+/// What the scanner saw where the root block should have been, when the line it
+/// found there produced no block. Carried out of the scan so the `MissingQuill`
+/// message names the malformation instead of describing the shape the author
+/// already wrote.
+pub(super) enum RootFault {
+    /// A card-yaml opener declaring `$quill` that nothing closes.
+    Unclosed {
+        opener_line: usize,
+        /// The first all-tilde line below the opener: a run too short to close
+        /// it, or an indented one.
+        near_closer: Option<(usize, String)>,
+        /// The last top-level key of the payload the author wrote.
+        last_field: Option<String>,
+    },
+    /// A tilde fence declaring `$quill` whose info string opens a code block.
+    InfoString { opener_line: usize, info: String },
+}
+
+pub(super) struct FenceScan {
+    pub(super) blocks: Vec<MetadataBlock>,
+    pub(super) warnings: Vec<Diagnostic>,
+    pub(super) root_fault: Option<RootFault>,
+}
+
+/// The payload lines of a would-be block at `opener_k`: down to the first blank
+/// line, which is where an author who forgot the closer stopped writing YAML.
+fn payload_lines<'a>(lines: &'a Lines<'a>, opener_k: usize) -> impl Iterator<Item = usize> + 'a {
+    ((opener_k + 1)..lines.len()).take_while(|&j| !lines.is_blank(j))
+}
+
+fn declares_quill_beneath(lines: &Lines<'_>, opener_k: usize) -> bool {
+    payload_lines(lines, opener_k).any(|j| lines.line_text(j).trim_start().starts_with("$quill:"))
+}
+
+fn last_field_key(lines: &Lines<'_>, opener_k: usize) -> Option<String> {
+    payload_lines(lines, opener_k)
+        .map(|j| lines.line_text(j))
+        .filter(|text| !text.starts_with(' '))
+        .filter_map(|text| super::prescan::key_end(text).map(|end| text[..end].to_string()))
+        .last()
+}
+
+fn near_closer_below(lines: &Lines<'_>, opener_k: usize) -> Option<(usize, String)> {
+    ((opener_k + 1)..lines.len()).find_map(|j| {
+        let trimmed = lines.line_text(j).trim();
+        (!trimmed.is_empty() && trimmed.bytes().all(|b| b == b'~')).then(|| (j, trimmed.to_string()))
+    })
+}
 
 /// Find all card-yaml metadata blocks. A block requires a blank line above it,
 /// so body round-tripping stays stable.
@@ -179,6 +227,7 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
     let lines = Lines::new(markdown);
     let mut blocks: Vec<MetadataBlock> = Vec::new();
     let mut warnings: Vec<Diagnostic> = Vec::new();
+    let mut root_fault: Option<RootFault> = None;
     // (char, run_len, opener_line_index) of an open ordinary code fence.
     let mut open_code_fence: Option<(u8, usize, usize)> = None;
 
@@ -237,6 +286,13 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
                 // Per CommonMark an unclosed `~~~` fence is an ordinary code
                 // block running to EOF, so delegate rather than erroring. The
                 // end-of-document check below surfaces the warning.
+                if blocks.is_empty() && root_fault.is_none() && declares_quill_beneath(&lines, k) {
+                    root_fault = Some(RootFault::Unclosed {
+                        opener_line: k,
+                        near_closer: near_closer_below(&lines, k),
+                        last_field: last_field_key(&lines, k),
+                    });
+                }
                 open_code_fence = Some((b'~', open_run, k));
                 k += 1;
                 continue;
@@ -316,6 +372,18 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
 
         // Any other fence opener is an ordinary fenced code block.
         if let Some((ch, run_len, _)) = code_fence_on_line(text, None) {
+            if ch == b'~'
+                && blocks.is_empty()
+                && root_fault.is_none()
+                && !text.starts_with(' ')
+                && (0..k).all(|i| lines.is_blank(i))
+                && declares_quill_beneath(&lines, k)
+            {
+                root_fault = Some(RootFault::InfoString {
+                    opener_line: k,
+                    info: code_fence_info(text, run_len).to_string(),
+                });
+            }
             open_code_fence = Some((ch, run_len, k));
         }
         k += 1;
@@ -345,5 +413,9 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
         );
     }
 
-    Ok((blocks, warnings))
+    Ok(FenceScan {
+        blocks,
+        warnings,
+        root_fault,
+    })
 }

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -63,6 +63,72 @@ fn test_missing_block_with_bare_yaml_calls_out_missing_fence() {
 }
 
 #[test]
+fn test_unclosed_root_fence_names_the_missing_closer_not_the_missing_block() {
+    let markdown =
+        "~~~\n$quill: usaf_memo@0.3.0\n$kind: main\nsubject: Memo\nfont_size: 12\n\nThe body.\n";
+    let err = decompose(markdown).unwrap_err();
+    let msg = err.to_string();
+    assert_eq!(
+        err.to_diagnostic().code.as_deref(),
+        Some("parse::missing_quill")
+    );
+    assert!(
+        msg.contains("Root card-yaml block opened at line 1 is never closed"),
+        "got: {msg}"
+    );
+    assert!(
+        msg.contains("after the last field (`font_size`)"),
+        "got: {msg}"
+    );
+    assert!(
+        !msg.contains("The document must open with"),
+        "the generic advice restates what the author already wrote: {msg}"
+    );
+}
+
+#[test]
+fn test_two_tilde_closer_is_named_as_the_failed_closer() {
+    let markdown = "~~~\n$quill: usaf_memo@0.3.0\n$kind: main\ntitle: Memo\n~~\n\nThe body.\n";
+    let msg = decompose(markdown).unwrap_err().to_string();
+    assert!(
+        msg.contains("Root card-yaml block opened at line 1 is never closed"),
+        "got: {msg}"
+    );
+    assert!(
+        msg.contains("The line `~~` at line 5 does not close it"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn test_indented_closer_is_named_as_the_failed_closer() {
+    let markdown = "~~~\n$quill: usaf_memo@0.3.0\n$kind: main\ntitle: Memo\n  ~~~\n\nBody.\n";
+    let msg = decompose(markdown).unwrap_err().to_string();
+    assert!(
+        msg.contains("The line `~~~` at line 5 does not close it"),
+        "got: {msg}"
+    );
+}
+
+#[test]
+fn test_unclosed_root_fence_without_quill_keeps_the_generic_message() {
+    let markdown = "~~~\ntitle: Memo\n\nThe body.\n";
+    let msg = decompose(markdown).unwrap_err().to_string();
+    assert!(msg.contains("Missing required root"), "got: {msg}");
+}
+
+#[test]
+fn test_root_opener_with_foreign_info_string_names_the_info_string() {
+    let markdown = "~~~metadata\n$quill: usaf_memo@0.3.0\n$kind: main\n~~~\n\nBody.\n";
+    let msg = decompose(markdown).unwrap_err().to_string();
+    assert!(
+        msg.contains("opener at line 1 is `~~~metadata`"),
+        "got: {msg}"
+    );
+    assert!(msg.contains("drop `metadata`"), "got: {msg}");
+}
+
+#[test]
 fn test_dash_root_block_parses_equivalent_to_card_yaml() {
     let dash_md = "---\n$quill: test_quill\n$kind: main\ntitle: Test\n---\n\nBody.";
     let canonical_md = "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\nBody.";
@@ -135,7 +201,10 @@ fn test_tilde_opener_with_dash_closer_falls_through() {
     let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: T\n---\n\nBody.";
     let err = decompose(markdown).unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("Missing required root"), "got: {msg}");
+    assert!(
+        msg.contains("opened at line 1 is never closed"),
+        "got: {msg}"
+    );
 }
 
 #[test]
@@ -238,12 +307,12 @@ author: Test Author
 
 Content without closing fence";
 
-    let result = decompose(markdown);
-    assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .to_string()
-        .contains("Missing required root"));
+    let msg = decompose(markdown).unwrap_err().to_string();
+    assert!(
+        msg.contains("Root card-yaml block opened at line 1 is never closed"),
+        "got: {msg}"
+    );
+    assert!(msg.contains("after the last field (`author`)"), "got: {msg}");
 }
 
 #[test]

--- a/crates/core/src/document/tests/card_fence_tests.rs
+++ b/crates/core/src/document/tests/card_fence_tests.rs
@@ -76,6 +76,47 @@ fn legacy_card_yaml_info_string_normalizes_to_bare_tilde() {
 }
 
 #[test]
+fn yaml_info_string_opens_a_card_yaml_block() {
+    let src = "~~~yaml\n$quill: q\n$kind: main\ntitle: Hi\n~~~\n\nBody.\n\n~~~yaml\n$kind: note\nname: N\n~~~\n";
+    let doc = Document::parse(src).unwrap().document;
+    assert_eq!(doc.quill_reference().name, "q");
+    assert_eq!(
+        doc.main().payload().get("title").unwrap().as_str(),
+        Some("Hi")
+    );
+    assert_eq!(doc.main().body_markdown(), "Body.");
+    assert_eq!(doc.cards().len(), 1);
+    assert_eq!(doc.cards()[0].kind(), Some("note"));
+}
+
+#[test]
+fn yaml_info_string_normalizes_to_bare_tilde() {
+    let src = "~~~yaml\n$quill: q\n$kind: main\n~~~\n";
+    let emitted = Document::parse(src).unwrap().document.to_markdown();
+    assert_eq!(emitted, "~~~\n$quill: q\n$kind: main\n~~~\n");
+}
+
+#[test]
+fn backtick_yaml_fence_stays_an_ordinary_code_block() {
+    let src = "~~~\n$quill: q\n$kind: main\n~~~\n\n```yaml\n$quill: not_a_card\n```\n";
+    let doc = Document::parse(src).unwrap().document;
+    assert_eq!(doc.cards().len(), 0);
+    assert!(doc.main().body_markdown().contains("$quill: not_a_card"));
+}
+
+#[test]
+fn dash_yaml_line_is_not_a_fence() {
+    let src = "~~~\n$quill: q\n$kind: main\n~~~\n\n---yaml\nkey: value\n---\n";
+    let doc = Document::parse(src).unwrap().document;
+    assert_eq!(doc.cards().len(), 0);
+    assert!(
+        doc.main().body_markdown().contains("---yaml"),
+        "body: {:?}",
+        doc.main().body_markdown()
+    );
+}
+
+#[test]
 fn longer_tilde_run_still_opens_a_card() {
     let src = "~~~\n$quill: q\n$kind: main\n~~~\n\n~~~~\n$kind: note\nname: Widget\n~~~~\n";
     let doc = Document::parse(src).unwrap().document;

--- a/crates/core/src/document/tests/fence_conformance_tests.rs
+++ b/crates/core/src/document/tests/fence_conformance_tests.rs
@@ -42,9 +42,10 @@ fn trim_fence(s: &str) -> &str {
 /// `None` when conformant, and when our scanner rejects the input outright:
 /// error paths are out of scope for this cross-check.
 fn nonconformance(md: &str) -> Option<String> {
-    let Ok((blocks, _warnings)) = find_metadata_blocks(md) else {
+    let Ok(scan) = find_metadata_blocks(md) else {
         return None;
     };
+    let blocks = scan.blocks;
     let pd = pulldown_fence_spans(md);
 
     for b in &blocks {

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -13,9 +13,10 @@ This document is the authoritative syntax standard.
 
 Every valid CommonMark 0.31.2 document parses to the same block / inline
 structure under this spec, *except* for the deviations declared in §6.2
-(raw HTML), §3.2 (a column-zero bare `~~~` block with a blank line above it
-is a card-yaml block, not an ordinary fenced code block; an indented `~~~`
-is not a card-yaml opener), and §3.2.1
+(raw HTML), §3.2 (a column-zero bare `~~~` block with a blank line above it,
+or one carrying the `card-yaml` / `yaml` info string, is a card-yaml block,
+not an ordinary fenced code block; an indented `~~~` is not a card-yaml
+opener), and §3.2.1
 (root-block `---` alias: a `---` at document start followed by a matching
 `---` is interpreted as a YAML-frontmatter root block, not a thematic
 break / setext underline). Additionally, this spec defines:
@@ -79,8 +80,8 @@ is that block's prose body.
 A card-yaml block has three parts, in order:
 
 1. **Opening fence**: exactly `~~~` (three tildes, no info string; see §3.2).
-   The `~~~card-yaml` info string is also accepted (non-canonical alias) on
-   input.
+   The `~~~card-yaml` and `~~~yaml` info strings are also accepted
+   (non-canonical aliases) on input.
 2. **YAML payload**: a standard YAML mapping containing both system
    metadata (`$`-prefixed reserved keys; see §3.3) and the block's data
    fields (see §3.4).
@@ -98,16 +99,16 @@ the next opening fence or EOF.
   per CommonMark's fenced-code-block rule. (Exception: the root-block `---`
   alias in §3.2.1.)
 - **Info string.** The canonical opening fence carries **no info string**: a
-  bare `~~~`. The info string `~~~card-yaml` is accepted on input and parses
-  identically, but is non-canonical: `toMarkdown` (§9) always emits the bare
-  `~~~` form. No other info string opens a card-yaml block: a
+  bare `~~~`. The info strings `~~~card-yaml` and `~~~yaml` are accepted on
+  input and parse identically, but are non-canonical: `toMarkdown` (§9) always
+  emits the bare `~~~` form. No other info string opens a card-yaml block: a
   `~~~` fence carrying any other info string (e.g. a language) is an ordinary
   CommonMark fenced code block.
 - **Escape hatch.** Because every column-zero `~~~` block is a card-yaml block,
   write a literal fenced *code* block in prose with a **backtick fence**
-  (```` ``` ````). A `~~~` fence carrying a language info string is also an
-  ordinary code block. There is no "longer tilde run" escape: more tildes
-  still open a card.
+  (```` ``` ````), including a YAML one (```` ```yaml ````). A `~~~` fence
+  carrying any other language info string is also an ordinary code block.
+  There is no "longer tilde run" escape: more tildes still open a card.
 - **Indentation.** Both fences are at column zero: **no leading spaces**.
   An indented opener (1–3 spaces) is *not* a card-yaml opener: it is
   delegated to CommonMark as an ordinary fenced code block, exactly like an
@@ -143,7 +144,7 @@ with the same payload.
   CommonMark as a thematic break or setext-heading underline.
 - **Matched fences.** Within a single block, opener and closer must agree:
   a `---` opener requires a `---` closer, and a `~~~` opener (bare or
-  `~~~card-yaml`) requires a `~~~` closer. Mixed forms (`---` … `~~~`,
+  `~~~card-yaml` / `~~~yaml`) requires a `~~~` closer. Mixed forms (`---` … `~~~`,
   `~~~` … `---`) leave the opener unclosed, so it falls through to CommonMark
   (code block to EOF, or a thematic break for a lone `---`) rather than being
   recognised as a block.
@@ -285,7 +286,8 @@ the surface syntax accepted on the `$quill` line.
 ## 4. Block Detection
 
 A single detector runs over the line stream. A `~~~` line: a bare `~~~`, or
-`~~~card-yaml`, opens a card-yaml block **iff** all of the following hold:
+`~~~card-yaml` / `~~~yaml`, opens a card-yaml block **iff** all of the
+following hold:
 
 **D0: Column zero.** The `~~~` opener has no leading spaces.
 
@@ -467,8 +469,9 @@ order), and a `~~~` closer. The root block must declare `$quill`;
 canonical emission also writes `$kind: main` on the root, synthesising
 it when the input omitted the line (see §3.3). Composable cards must
 declare `$kind: <kind>`. A document round-trips to this canonical
-shape: fence markers and YAML quoting are normalised; the `~~~card-yaml`
-alias and the `---`-fenced root alias (§3.2.1) both re-emit as bare `~~~`.
+shape: fence markers and YAML quoting are normalised; the `~~~card-yaml` and
+`~~~yaml` aliases and the `---`-fenced root alias (§3.2.1) all re-emit as
+bare `~~~`.
 `!must_fill` tags and YAML comments
 (own-line and inline, including those adjacent to `$` lines) survive the
 round-trip.
@@ -516,6 +519,9 @@ Parse errors include:
   unclosed root fence: an unclosed `~~~` opener or a `---` opener with no
   matching `---` closer is delegated to CommonMark (§4) rather than erroring
   on its own, but with no closed root block the document still fails here.
+  When the document *does* open with a `~~~` declaring `$quill`, the message
+  names that opener's line and the missing closer (and the failed closer
+  line, for a `~~` run or an indented `~~~`) rather than the generic shape.
 - A `---` line in composable position (after the root block) that pairs
   with a later `---` and holds YAML-key content between: composable
   cards must use `~~~` fences (§3.2.1).


### PR DESCRIPTION
## What

A document that opens with `~~~` and `$quill: …` but never closes the fence — or closes it with `~~`, or with an indented `~~~` — drew the generic `parse::missing_quill` text telling the author to open a block they had already opened. The scanner knew what actually happened (`fences.rs` sets `open_code_fence` and builds a `parse::unclosed_code_block` warning naming the opener line), but `MissingQuill` fires first and that signal was thrown away before the diagnostic.

**The signal now reaches the message.** `find_metadata_blocks` returns a `FenceScan { blocks, warnings, root_fault }`, where `RootFault` records what the scanner saw at the root position when it produced no block:

- `Unclosed` — a card-yaml opener declaring `$quill` that nothing closes, plus the first all-tilde line that failed to close it (a `~~` run, or an indented `~~~`) and the last top-level key of the payload the author wrote.
- `InfoString` — a document-start tilde fence declaring `$quill` whose info string opens an ordinary code block (`~~~metadata`).

`assemble::missing_block_message` takes the fault and renders it; with no fault it falls through to the existing bare-YAML and generic branches unchanged.

Before:

```
Missing required root card-yaml block. The document must open with a `~~~` block
declaring `$quill: <name>` (and `$kind: main`) as the first two lines, closed by a
line containing exactly `~~~`.
```

After (unclosed):

```
Root card-yaml block opened at line 1 is never closed. Add a line containing exactly
`~~~` (three tildes, no info string) after the last field (`font_size`), before the
prose body.
```

After (`~~` typo closer, and the same shape for an indented `~~~`):

```
Root card-yaml block opened at line 1 is never closed. The line `~~` at line 5 does not
close it: a closing fence is at column zero and at least as long as the opener. Add a
line containing exactly `~~~` … 
```

The error code stays `parse::missing_quill`.

**`~~~yaml` is now a card-yaml opener alias**, per the maintainer follow-up on the issue: it joins `~~~card-yaml` in `CARD_YAML_INFO`, parses identically, and re-emits as bare `~~~` like the existing alias (neither emits a warning today). A YAML *code* block in prose is a backtick fence (` ```yaml `), and `---yaml` is untouched — a `---` line with trailing text was never a dash fence and still falls through to CommonMark.

## Why

From the PR #1449 traces: 601 `missing_quill` results were documents that started with `~~~` and `$quill` and had exactly one fence line, 34 opened with `~~~yaml`, 9 more were `~~~yaml` plus a correct closer. The old message named the one thing the author already had and never named the line they were missing.

## Tests

New in `assemble_tests.rs`: unclosed root fence names the closer (and not the generic advice), `~~` closer and indented `~~~` closer are each named as the failed closer, an unclosed fence with no `$quill` beneath keeps the generic message, and a foreign info string (`~~~metadata`) is named. New in `card_fence_tests.rs`: `~~~yaml` opens root and composable blocks, normalizes to bare `~~~` on emit, a ` ```yaml ` fence stays an ordinary code block, and `---yaml` stays body prose. Two existing tests that asserted the generic "Missing required root" text for an unclosed opener now assert the specific message.

`cargo test --workspace` passes (63 test binaries, 0 failures), including `spec_conformance_probe::unclosed_code_block_emits_warning` and the pulldown cross-check in `fence_conformance_tests`. `markdown-spec.md` §1/§3.1/§3.2/§4/§9/§10 and `CHANGELOG.md` updated.

Closes #1457

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Z4QwKJsurUYYwPXKjue8K


---
_Generated by [Claude Code](https://claude.ai/code/session_019Z4QwKJsurUYYwPXKjue8K)_