### PR TITLE
fix(core): put card-yaml parse failures on one line-number system

### DIFF
--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -19,7 +19,7 @@ use quillmark_content::Normalized;
 fn import_body_or_parse_error(md: &str) -> Result<Normalized, ParseError> {
     super::import_body(md).map_err(|e| ParseError::BodyImport(e.to_string()))
 }
-use super::prescan::{prescan_fence_content, CommentPathSegment, NestedComment, PreItem};
+use super::prescan::{prescan_fence_content, CommentPathSegment, NestedComment, PreItem, PreScan};
 use super::{Card, Document};
 
 /// A `MissingQuill` message naming the specific malformation. LLM authors hit
@@ -86,6 +86,46 @@ pub(super) struct MetadataBlock {
     pub(super) pre_warnings: Vec<Diagnostic>,
 }
 
+/// The document-absolute, 1-indexed position of a YAML parse failure.
+///
+/// `parser` is the position the engine reports inside the string it parsed:
+/// the fence content less the comment lines prescan drops
+/// ([`PreScan::source_lines`] maps what survives back) and less the leading
+/// whitespace `trim` removes. With no reported position the block's first
+/// content line is the anchor.
+fn document_position(
+    markdown: &str,
+    content_start: usize,
+    pre: &PreScan,
+    parser: Option<(usize, usize)>,
+) -> (usize, usize) {
+    let first_line = markdown[..content_start].lines().count() + 1;
+    let Some((rel_line, rel_column)) = parser else {
+        return (first_line, 1);
+    };
+
+    let cleaned = &pre.cleaned_yaml;
+    let trimmed_prefix = &cleaned[..cleaned.len() - cleaned.trim_start().len()];
+
+    let cleaned_index = trimmed_prefix.matches('\n').count() + rel_line.saturating_sub(1);
+    let source_index = pre
+        .source_lines
+        .get(cleaned_index)
+        .or_else(|| pre.source_lines.last())
+        .copied()
+        .unwrap_or(0);
+
+    // Only the first parsed line lost leading whitespace to `trim`.
+    let column = if rel_line <= 1 {
+        let head = trimmed_prefix.rsplit('\n').next().unwrap_or("");
+        rel_column + head.chars().count()
+    } else {
+        rel_column
+    };
+
+    (first_line + source_index, column)
+}
+
 /// Process one recognised card-yaml block into a [`MetadataBlock`].
 ///
 /// `block_start` / `block_end` bound the whole block; `content_start` /
@@ -138,11 +178,18 @@ pub(super) fn build_block(
         ) {
             Ok(parsed) => parsed,
             Err(e) => {
-                let line = markdown[..block_start].lines().count() + 1;
                 let enriched = super::yaml_hints::enrich_yaml_error(&e.to_string(), &content);
+                let (line, column) = document_position(
+                    markdown,
+                    content_start,
+                    &pre,
+                    e.location()
+                        .map(|l| (l.line() as usize, l.column() as usize)),
+                );
                 return Err(ParseError::YamlErrorWithLocation {
                     message: enriched.message,
                     line,
+                    column,
                     block_index,
                     hint: enriched.hint,
                 });

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -47,6 +47,11 @@ pub struct NestedComment {
 pub(crate) struct PreScan {
     /// YAML with `!must_fill` tags stripped and comment lines removed; fed to serde_saphyr.
     pub cleaned_yaml: String,
+    /// The 0-indexed line of the fence content each line of
+    /// [`Self::cleaned_yaml`] came from. Own-line comments are dropped rather
+    /// than blanked, so the two numberings diverge and a parse failure needs
+    /// this to travel back to a document position.
+    pub source_lines: Vec<usize>,
     /// Top-level fields and comments in source order.
     pub items: Vec<PreItem>,
     pub nested_comments: Vec<NestedComment>,
@@ -57,6 +62,20 @@ pub(crate) struct PreScan {
     pub warnings: Vec<Diagnostic>,
     /// `!must_fill` on mappings: turned into `ParseError::InvalidStructure` by the parser.
     pub fill_target_errors: Vec<String>,
+}
+
+/// The emitted YAML lines paired with the source line each came from.
+#[derive(Debug)]
+struct Cleaned {
+    lines: Vec<String>,
+    source_lines: Vec<usize>,
+}
+
+impl Cleaned {
+    fn push(&mut self, source_line: usize, text: String) {
+        self.lines.push(text);
+        self.source_lines.push(source_line);
+    }
 }
 
 #[derive(Debug)]
@@ -77,7 +96,10 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
     let mut out = PreScan::default();
 
     let lines: Vec<&str> = content.split('\n').collect();
-    let mut cleaned_lines: Vec<String> = Vec::with_capacity(lines.len());
+    let mut cleaned = Cleaned {
+        lines: Vec::with_capacity(lines.len()),
+        source_lines: Vec::with_capacity(lines.len()),
+    };
 
     let mut stack: Vec<Frame> = vec![Frame {
         indent: 0,
@@ -89,13 +111,13 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
     // Indent of the `key:` line that opened the current block scalar, if any.
     let mut block_scalar_indent: Option<usize> = None;
 
-    for raw_line in &lines {
+    for (source_line, raw_line) in lines.iter().enumerate() {
         let line = *raw_line;
         let indent = leading_space_count(line);
         let trimmed = &line[indent..];
 
         if trimmed.is_empty() {
-            cleaned_lines.push(line.to_string());
+            cleaned.push(source_line, line.to_string());
             continue;
         }
 
@@ -104,7 +126,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
         // A line at or below the key's indent ends the scalar.
         if let Some(key_indent) = block_scalar_indent {
             if indent > key_indent {
-                cleaned_lines.push(line.to_string());
+                cleaned.push(source_line, line.to_string());
                 continue;
             }
             block_scalar_indent = None;
@@ -210,9 +232,9 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
                     None if after_dash.trim_end().is_empty() => "-".to_string(),
                     None => format!("- {}", after_dash.trim_end()),
                 };
-                cleaned_lines.push(format!("{}{}", head, body));
+                cleaned.push(source_line, format!("{}{}", head, body));
             } else {
-                cleaned_lines.push(line.to_string());
+                cleaned.push(source_line, line.to_string());
             }
 
             // For a `- |-` item the content is indented past the dash, so the
@@ -254,8 +276,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
                     });
                 }
 
-                let cleaned = format!("{}:{}", key, value_without_tag);
-                cleaned_lines.push(cleaned);
+                cleaned.push(source_line, format!("{}:{}", key, value_without_tag));
 
                 if let Some(c) = trailing_comment {
                     out.items.push(PreItem::Comment {
@@ -305,9 +326,12 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
                     });
                 }
                 let head = format!("{:width$}", "", width = indent);
-                cleaned_lines.push(format!("{}{}:{}", head, source_key, value_without_tag));
+                cleaned.push(
+                    source_line,
+                    format!("{}{}:{}", head, source_key, value_without_tag),
+                );
             } else {
-                cleaned_lines.push(line.to_string());
+                cleaned.push(source_line, line.to_string());
             }
 
             if has_empty_inline_value(&value_without_tag) {
@@ -325,16 +349,13 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
             continue;
         }
 
-        cleaned_lines.push(line.to_string());
+        cleaned.push(source_line, line.to_string());
     }
 
     // A tag surviving here sits in a position prescan cannot lift (inside a flow
     // collection, or on a bare sequence element) where serde_saphyr would drop it
     // silently.
-    if cleaned_lines
-        .iter()
-        .any(|l| line_has_unsupported_fill_tag(l))
-    {
+    if cleaned.lines.iter().any(|l| line_has_unsupported_fill_tag(l)) {
         out.warnings.push(
             Diagnostic::new(
                 Severity::Warning,
@@ -347,7 +368,8 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
         );
     }
 
-    out.cleaned_yaml = cleaned_lines.join("\n");
+    out.cleaned_yaml = cleaned.lines.join("\n");
+    out.source_lines = cleaned.source_lines;
     out
 }
 
@@ -1004,6 +1026,26 @@ mod tests {
             let out = prescan_fence_content(input);
             assert_eq!(out.cleaned_yaml.lines().count(), input.lines().count());
         }
+    }
+
+    #[test]
+    fn source_lines_map_cleaned_lines_back_over_dropped_comments() {
+        let input = "# lead\ntitle: Doc\n\n# note\nrole: !must_fill\nbio: |\n  # not a comment\nend: x\n";
+        let out = prescan_fence_content(input);
+
+        assert_eq!(out.cleaned_yaml.split('\n').count(), out.source_lines.len());
+        let source = |needle: &str| {
+            let i = out
+                .cleaned_yaml
+                .split('\n')
+                .position(|l| l.contains(needle))
+                .expect("cleaned line present");
+            out.source_lines[i]
+        };
+        assert_eq!(source("title:"), 1);
+        assert_eq!(source("role:"), 4);
+        assert_eq!(source("# not a comment"), 6);
+        assert_eq!(source("end:"), 7);
     }
 
     #[test]

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -1630,3 +1630,75 @@ fn a_user_field_named_id_is_untouched() {
         Some(serde_json::json!("a"))
     );
 }
+
+/// The 1-indexed document line carrying `needle`.
+fn line_of(markdown: &str, needle: &str) -> u32 {
+    markdown
+        .lines()
+        .position(|l| l.contains(needle))
+        .map(|i| i as u32 + 1)
+        .unwrap_or_else(|| panic!("`{needle}` is not in the fixture"))
+}
+
+#[test]
+fn test_yaml_error_location_is_document_absolute() {
+    let markdown = "# Heading\n\nIntro prose.\n\n~~~\n$quill: usaf_memo\n$kind: main\ntitle: Briefing\n\n\nunit: 88th Communications Squadron: Wright-Patterson AFB\n~~~\n\nBody\n";
+    let diag = decompose(markdown).unwrap_err().to_diagnostic();
+
+    assert_eq!(
+        diag.code.as_deref(),
+        Some("parse::yaml_error_with_location")
+    );
+    let loc = diag.location.expect("the diagnostic carries a location");
+    assert_eq!(loc.file, "input.md");
+    assert_eq!(loc.line, line_of(markdown, "88th Communications"));
+    assert_eq!(loc.column, 35);
+}
+
+#[test]
+fn test_yaml_error_message_carries_one_line_number_system() {
+    let markdown = "~~~\n$quill: usaf_memo\n$kind: main\nunit: a: b\n~~~\n\nBody\n";
+    let diag = decompose(markdown).unwrap_err().to_diagnostic();
+
+    assert!(
+        diag.message.starts_with("YAML error in the root card-yaml block: "),
+        "the message names the block rather than a second line number: {}",
+        diag.message
+    );
+    assert!(
+        !diag.message.contains("(block 0)"),
+        "stale block suffix: {}",
+        diag.message
+    );
+    assert_eq!(
+        diag.args.keys().collect::<Vec<_>>(),
+        vec!["blockIndex"],
+        "the coordinates ride on `location`, not `args`"
+    );
+}
+
+#[test]
+fn test_yaml_error_location_survives_trimmed_leading_blanks() {
+    let markdown = "~~~\n\n# leading comment\n\n$quill: usaf_memo\n$kind: main\ntitle: Briefing\n\nunit: 88th Communications Squadron: Wright-Patterson AFB\n~~~\n\nBody\n";
+    let diag = decompose(markdown).unwrap_err().to_diagnostic();
+
+    let loc = diag.location.expect("the diagnostic carries a location");
+    assert_eq!(loc.line, line_of(markdown, "88th Communications"));
+    assert_eq!(loc.column, 35);
+}
+
+#[test]
+fn test_yaml_error_in_composable_card_names_the_block() {
+    let markdown = "~~~\n$quill: usaf_memo\n$kind: main\n~~~\n\nBody\n\n~~~\n$kind: note\n# a comment\nunit: a: b\n~~~\n";
+    let diag = decompose(markdown).unwrap_err().to_diagnostic();
+
+    assert!(
+        diag.message
+            .starts_with("YAML error in card-yaml block 1: "),
+        "got: {}",
+        diag.message
+    );
+    assert_eq!(diag.args["blockIndex"], serde_json::json!(1));
+    let loc = diag.location.expect("the diagnostic carries a location");
+    assert_eq!(loc.line, line_of(markdown, "unit: a: b"));
+}

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -335,16 +335,32 @@ pub enum ParseError {
     #[error("{0}")]
     BodyImport(String),
 
-    #[error("YAML error at line {line}: {message}")]
+    #[error("YAML error in {}: {message}", block_label(*block_index))]
     YamlErrorWithLocation {
         message: String,
-        /// 1-indexed line in the source document.
+        /// 1-indexed line of the failure in the source document, not in the
+        /// block's YAML payload: the two numberings meet here.
         line: usize,
+        /// 1-indexed column, paired with `line`.
+        column: usize,
         /// 0-indexed metadata block.
         block_index: usize,
         hint: Option<String>,
     },
 }
+
+/// Name of the card-yaml block at `block_index`, by position: the parse failed
+/// before `$kind` was readable.
+fn block_label(block_index: usize) -> String {
+    match block_index {
+        0 => "the root card-yaml block".to_string(),
+        n => format!("card-yaml block {}", n),
+    }
+}
+
+/// The document a [`ParseError`] points at. Markdown reaches the engine as a
+/// string, so the anchor names the input rather than a path on disk.
+pub const DOCUMENT_FILE: &str = "input.md";
 
 impl ParseError {
     /// The facts this error's message interpolates. See [`Diagnostic::args`].
@@ -365,16 +381,15 @@ impl ParseError {
             ParseError::InvalidQuillReference { value, reason: _ } => diag_args! {
                 "value" => value,
             },
-            // This diagnostic sets no `location`, so `args` is the only
-            // structured route to the coordinates. `message` is the YAML
-            // engine's own prose and keeps no key.
+            // The coordinates ride on the diagnostic's `location`; `message` is
+            // the YAML engine's own prose and keeps no key.
             ParseError::YamlErrorWithLocation {
                 message: _,
-                line,
+                line: _,
+                column: _,
                 block_index,
                 hint: _,
             } => diag_args! {
-                "line" => line,
                 "blockIndex" => block_index,
             },
         }
@@ -404,17 +419,20 @@ impl ParseError {
             ParseError::YamlErrorWithLocation {
                 message,
                 line,
+                column,
                 block_index,
                 hint,
             } => {
                 let mut d = Diagnostic::new(
                     Severity::Error,
-                    format!(
-                        "YAML error at line {} (block {}): {}",
-                        line, block_index, message
-                    ),
+                    format!("YAML error in {}: {}", block_label(*block_index), message),
                 )
-                .with_code("parse::yaml_error_with_location".to_string());
+                .with_code("parse::yaml_error_with_location".to_string())
+                .with_location(Location::new(
+                    DOCUMENT_FILE.to_string(),
+                    *line as u32,
+                    *column as u32,
+                ));
                 if let Some(h) = hint {
                     d = d.with_hint(h.clone());
                 }
@@ -695,6 +713,7 @@ mod args_canon {
             ParseError::YamlErrorWithLocation {
                 message: "x".into(),
                 line: 3,
+                column: 1,
                 block_index: 1,
                 hint: None,
             },

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -30,6 +30,8 @@ It exists so no public signature names `serde-saphyr`. A third-party error type 
 
 Two surfaces return one directly (`QuillValue::from_yaml_str`, `QuillConfig::schema_yaml`); `QuillConfig::from_yaml_with_warnings` converts through it to `quill::yaml_parse_error`. The card-yaml path does not travel this way: it becomes `ParseError::YamlErrorWithLocation`, which additionally knows the enclosing block.
 
+Its `line`/`column` are document coordinates, not block-relative ones. The assembler translates: the engine reports a position inside the string it parsed, which is the fence content minus the comment lines prescan drops (`PreScan::source_lines` maps what survives back) and minus the whitespace `trim` takes off the front. `to_diagnostic()` renders that as a `Location` against `DOCUMENT_FILE` (`input.md`) — markdown reaches the engine as a string, so the anchor names the input rather than a path on disk. The message names the block instead of repeating a number (`YAML error in the root card-yaml block: …`, `… in card-yaml block 2: …`); the engine's own snippet inside it stays block-relative, as the engine rendered it.
+
 **`RenderError`**: the main rendering error, a struct carrying a non-empty
 `Vec<Diagnostic>` (`RenderError::new` / `from_diag` / `coded(code, message)`
 for the one-error-diagnostic case every engine-side refusal takes;
@@ -339,7 +341,7 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `conform::field_decode` | `field`, `codec` | structured, coarser |
 | `parse::input_too_large` | `size`, `max` | structured |
 | `parse::invalid_quill_reference` | `value` | structured, coarser |
-| `parse::yaml_error_with_location` | `line`, `blockIndex` | structured, coarser |
+| `parse::yaml_error_with_location` | `blockIndex` | structured, coarser |
 | `parse::empty_input` | — | code-determined |
 | `parse::invalid_structure` | — | fallback |
 | `parse::missing_quill` | — | fallback |


### PR DESCRIPTION
## The problem

Every `parse::yaml_error_with_location` mixed two numbering systems and left the field a consumer would actually read empty:

```
YAML error at line 1 (block 0): error: line 9 column 1: simple key expected ':'
  --> :9:1
```

`line 1` was the block opener's document line; `line 9` and the snippet were relative to the block's YAML payload; `Diagnostic.location` was `null`. Anyone pointing at a line — an editor, or an LLM counting lines in the document it just wrote — had two systems to reconcile and no structured coordinate to read.

## The change

- `build_block` keeps the parser error's own position instead of discarding it with `e.to_string()`, mirroring `YamlError::from_de`, and translates it into document coordinates. Two rewrites sit between the two numberings: prescan drops comment lines from the YAML it hands the engine, so `PreScan::source_lines` now records the fence-content line each surviving line came from, and `trim` takes the leading whitespace off the front before the parse. `document_position` walks both back.
- `ParseError::YamlErrorWithLocation` gains `column`, and its `line` now means the failure's document line rather than the opener's.
- `to_diagnostic()` sets `Location::new(DOCUMENT_FILE, line, column)`. `DOCUMENT_FILE` is `"input.md"`: markdown reaches the engine as a string, so the anchor names the input rather than a path on disk, the same way the quill path passes `"Quill.yaml"` to `YamlError::to_diagnostic`.
- The message names the block instead of restating a number: `YAML error in the root card-yaml block: …`, `YAML error in card-yaml block 2: …`. `$kind` is not recoverable — the parse failed before it was readable — so the block is named by position. The engine's own snippet inside the message stays block-relative, as the engine rendered it.

## Deliberate shape changes

- **`args`**: `line` is gone; `blockIndex` stays. `args` is documented as "the facts `message` interpolates", the message no longer interpolates a line, and the coordinate is now on `location`, which is strictly better than the opener line the key used to carry. `prose/canon/ERROR.md` § "Diagnostic args" is updated in the same commit — the table is a tested contract. No binding or test read `args["line"]`.
- **`message`**: the `"YAML error at line N (block M): "` prefix is replaced as described. No test or binding asserted the old text.

## Tests

New in `assemble_tests.rs`: the issue's scenario (prose above the block, blank lines before the failure) asserting `location` is the document line and not the opener's; the same with leading blank and comment lines that `trim` and prescan remove, pinning the offset arithmetic; the message/args shape; and a failure in a composable card naming block 1. New in `prescan.rs`: `source_lines` maps cleaned lines back over dropped comments and block-scalar content.

Every workspace package's tests pass locally (run package-by-package — this container's disk could not hold the whole workspace's test binaries at once).

Closes #1460

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Z4QwKJsurUYYwPXKjue8K

---
_Generated by [Claude Code](https://claude.ai/code/session_019Z4QwKJsurUYYwPXKjue8K)_