### PR TITLE
fix(core): warn when a cell still holds its schema's example (validation::example_unchanged)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- feat(core): **`validation::example_unchanged`: a cell still holding the value
+  its schema showed.** `Quill::validate` warns (non-fatal, beside
+  `validation::must_fill`) where an authored value is the field's `example:`,
+  or a body is its `body.example` or the `Write <kind> body here.` placeholder
+  the blueprint generates for a kind declaring none. The blueprint seats a
+  defaultless field's example in its value cell under the `!must_fill` marker
+  and a seed commits one on every field that declares it, so dropping the
+  marker leaves a value that is present, type-valid, in-domain and nobody's
+  answer — a signed memo reading `Duty Title` under the commander's name, with
+  a clean validate. Arrays are compared element-wise against the same index of
+  the shown literal, so a half-edited list names the element left behind; a
+  typed dictionary and a variant container are walked per cell. A field
+  declaring no `example:` never fires: absence is `must_fill`'s question. The
+  `trigger` arg says which cell spoke (`field` or `body`) and `example` carries
+  the shown value.
+
 - feat(core): **the values form: `reader.values()` reads a document as plain
   values and `writer.set_values(values)` writes them back.** A document has
   three forms: *stored* (verbatim, quill-free), *values* (stored with every

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -727,6 +727,21 @@ mod args_canon {
             "both `validation::must_fill` triggers must carry one key set"
         );
         add("validation::must_fill", marker.args);
+        // Two constructors again, one per cell a blueprint writes a value into.
+        let field_example = crate::quill::compose::example_unchanged_warning(
+            &path,
+            &serde_json::json!("Duty Title"),
+        );
+        let body_example = crate::quill::compose::body_example_unchanged_warning(
+            &crate::path::DocPath::main().body(),
+            "Write main body here.",
+        );
+        assert_eq!(
+            field_example.args.keys().collect::<Vec<_>>(),
+            body_example.args.keys().collect::<Vec<_>>(),
+            "both `validation::example_unchanged` triggers must carry one key set"
+        );
+        add("validation::example_unchanged", field_example.args);
         // Built at the variant walk rather than from an error type: a stranded
         // value is well-formed, so there is nothing to fail.
         add(

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -70,9 +70,16 @@ fn body_text(card: &CardSchema, fallback_kind: &str) -> String {
         return String::new();
     }
     let example = card.body.as_ref().and_then(|b| b.example.as_deref());
-    let fallback = format!("Write {} body here.", fallback_kind);
+    let fallback = body_placeholder(fallback_kind);
     let text = example.unwrap_or(fallback.as_str());
     format!("\n{}\n", text)
+}
+
+/// The body text a kind declaring no `body.example` shows. Shared with the
+/// `validation::example_unchanged` walk, which recognizes it in a document: the
+/// two are one string or the placeholder ships unnoticed.
+pub(super) fn body_placeholder(kind: &str) -> String {
+    format!("Write {kind} body here.")
 }
 
 /// Build the root card: `$quill` (with the `# keep verbatim` inline reminder),

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -216,8 +216,8 @@ impl Quill {
     /// `validation::*` diagnostics verbatim (same code, `path`, `hint`) so
     /// consumers route on the code without parsing message text: type
     /// mismatches, unknown card kinds, body-on-disabled-body, and the non-fatal
-    /// `validation::must_fill` warning, the only non-fatal one; the rest are
-    /// blockers.
+    /// warnings (`validation::must_fill`, `validation::out_of_variant`,
+    /// `validation::example_unchanged`); the rest are blockers.
     ///
     /// **A blocker here means the document does not render.** Values are judged
     /// in the form the render floor builds from them (`conform_value` at
@@ -234,6 +234,12 @@ impl Quill {
     /// content — so both run, and the `trigger` arg tells a consumer which
     /// fired. Where both would fire on one path (a bare marker on an unauthored
     /// cell) the marker wins: its hint is the actionable one.
+    ///
+    /// `validation::example_unchanged` answers what `must_fill` cannot: *which*
+    /// value a cell holds. The blueprint seats a defaultless field's `example:`
+    /// in its value cell, so dropping the marker leaves a schema-valid,
+    /// in-domain value nobody chose — `Duty Title` under a commander's name —
+    /// and every other check reads it as authored content.
     ///
     /// Field values, defaults, and presentation order are not part of this
     /// surface: read them from the [`Document`] payload and the quill schema
@@ -252,6 +258,7 @@ impl Quill {
                 .filter(|d| !claimed.contains(&d.path)),
         );
         diags.extend(validate_variants(self.config(), doc));
+        diags.extend(validate_examples(self.config(), doc));
         diags.extend(self.validate_seed(doc));
         diags
     }
@@ -1011,8 +1018,208 @@ pub(crate) fn unauthored_warning(path: &DocPath) -> Diagnostic {
     )
 }
 
+/// Surface every cell and body the document leaves at the value its schema
+/// *shows*, across the main card and every composable card.
+///
+/// The blueprint seats a defaultless field's `example:` in the value cell under
+/// the `!must_fill` marker (`prose/canon/BLUEPRINT.md` § "Placeholder value
+/// precedence"), and the marker is the only thing distinguishing it from an
+/// answer: an example is present, type-valid and in-domain, so coercion,
+/// validation and the unauthored predicate all read it as content. Drop the
+/// marker and a memo ships `Duty Title` under a signature block with a clean
+/// validate. This walk reads the same declarations the blueprint stamps from,
+/// and says the cell still holds what the schema showed.
+///
+/// It is about *which* value, never *whether* one was authored, so it declines
+/// the cells [`validate_unauthored`] owns: a field declaring no `example:` has
+/// nothing to compare against and is silent here whatever it holds.
+fn validate_examples(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    for (schema, card, path) in schema_cards(config, doc) {
+        let Some(schema) = schema else { continue };
+        let payload = card.payload();
+        for (name, field) in &schema.fields {
+            collect_example_field(field, payload.get(name), &path.field(name), &mut diags);
+        }
+        collect_body_example(schema, card, &path, &mut diags);
+    }
+    diags
+}
+
+/// Warn at each cell whose value is the one its own declaration shows.
+///
+/// The recursion is [`collect_unauthored_field`]'s, for the same reason: the
+/// cells it reaches are where the blueprint stamps its values. A **typed
+/// dictionary** and a **variant container** are namespaces, so each member is
+/// judged against its own `example:`; an **array** is judged element-wise
+/// against the same index of the array literal its field shows, so an author who
+/// edited the first line and left the second still hears about the second.
+/// Absence is not this walk's business: an absent cell holds no value to
+/// recognize.
+fn collect_example_field(
+    field: &FieldSchema,
+    value: Option<&QuillValue>,
+    path: &DocPath,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(present) = value.filter(|v| !v.as_json().is_null()) else {
+        return;
+    };
+    let json = present.as_json();
+
+    if field.is_variant_bearing() {
+        let authored = FieldSchema::authored_member(Some(json));
+        let shown = field
+            .example
+            .as_ref()
+            .and_then(|e| FieldSchema::authored_member(Some(e.as_json())));
+        if let Some(shown) = shown.filter(|s| Some(*s) == authored) {
+            out.push(example_unchanged_warning(
+                &path.field(VARIANT_DISCRIMINANT_KEY),
+                shown,
+            ));
+        }
+        if let Some(fields) = field.variant_fields(&field.selected_member(Some(json))) {
+            for (name, schema) in fields {
+                let cell = json
+                    .as_object()
+                    .and_then(|o| o.get(name))
+                    .map(|j| QuillValue::from_json(j.clone()));
+                collect_example_field(schema, cell.as_ref(), &path.field(name), out);
+            }
+        }
+        return;
+    }
+
+    if let (FieldType::Object, Some(props)) = (&field.r#type, &field.properties) {
+        for (name, prop) in props {
+            let pv = json
+                .as_object()
+                .and_then(|o| o.get(name))
+                .map(|j| QuillValue::from_json(j.clone()));
+            collect_example_field(prop, pv.as_ref(), &path.field(name), out);
+        }
+        return;
+    }
+
+    if let (FieldType::Array, Some(items)) = (&field.r#type, &field.items) {
+        // The array's own `example:` is the whole literal, so the element's
+        // counterpart is the one at its index; an element that is not the shown
+        // one still descends, since a typed table's cells carry examples of
+        // their own.
+        let shown = field.example.as_ref().and_then(|e| e.as_json().as_array());
+        for (index, element) in json.as_array().into_iter().flatten().enumerate() {
+            let at = path.index(index);
+            match shown.and_then(|eg| eg.get(index)).filter(|eg| *eg == element) {
+                Some(eg) => out.push(example_unchanged_warning(&at, eg)),
+                None => collect_example_field(
+                    items,
+                    Some(&QuillValue::from_json(element.clone())),
+                    &at,
+                    out,
+                ),
+            }
+        }
+        return;
+    }
+
+    if let Some(shown) = shown_example(field, json) {
+        out.push(example_unchanged_warning(path, shown.as_json()));
+    }
+}
+
+/// The `example:` `value` is still sitting at, `None` where the field declares
+/// none or the document wrote something else. A prose field shows its example
+/// twice — the markdown literal a blueprint inlines and the imported content a
+/// seed commits ([`FieldSchema::example_content`]) — and they are one
+/// declaration, so either match reports the declaration.
+fn shown_example<'a>(field: &'a FieldSchema, value: &serde_json::Value) -> Option<&'a QuillValue> {
+    let example = field.example.as_ref()?;
+    let matched = example.as_json() == value
+        || field
+            .example_content
+            .as_ref()
+            .is_some_and(|content| content.as_json() == value);
+    matched.then_some(example)
+}
+
+/// Warn when a card's body is the text the blueprint writes into it: the
+/// configured `body.example`, or the placeholder generated for a kind that
+/// declares none ([`super::blueprint::body_placeholder`]).
+///
+/// The comparison is against the markdown projection, the form the blueprint
+/// emitted and an author edits, re-imported so a body that only round-tripped
+/// through the content model (`__b__` → `**b**`) still counts as untouched.
+fn collect_body_example(
+    schema: &CardSchema,
+    card: &Card,
+    base: &DocPath,
+    out: &mut Vec<Diagnostic>,
+) {
+    if !schema.body_enabled() {
+        return;
+    }
+    let authored = card.body_markdown();
+    let authored = authored.trim();
+    if authored.is_empty() {
+        return;
+    }
+    let shown = match schema.body.as_ref().and_then(|b| b.example.as_deref()) {
+        Some(example) => example.to_string(),
+        None => super::blueprint::body_placeholder(&schema.name),
+    };
+    if authored == shown.trim() || canonical_markdown(&shown).as_deref() == Some(authored) {
+        out.push(body_example_unchanged_warning(&base.body(), shown.trim()));
+    }
+}
+
+/// `shown` through the content model and back, the round trip a body takes on
+/// its way into a document. `None` where the text does not import, which a
+/// generated placeholder and a load-validated example never do.
+fn canonical_markdown(shown: &str) -> Option<String> {
+    let content = crate::document::import_body(shown).ok()?;
+    Some(quillmark_content::export::to_markdown(&content).trim().to_string())
+}
+
+pub(crate) fn example_unchanged_warning(path: &DocPath, example: &serde_json::Value) -> Diagnostic {
+    let path = path.to_string();
+    let literal = serde_json::to_string(example).unwrap_or_else(|_| "null".to_string());
+    Diagnostic::new(
+        Severity::Warning,
+        format!("Field `{path}` still holds the schema's example value `{literal}`."),
+    )
+    .with_code("validation::example_unchanged".to_string())
+    .with_path(path)
+    .with_arg("example", example.clone())
+    .with_arg("trigger", "field".into())
+    .with_hint(
+        "Author the value this document means. An `example:` shows a cell's shape, never its \
+         content."
+            .to_string(),
+    )
+}
+
+pub(crate) fn body_example_unchanged_warning(path: &DocPath, example: &str) -> Diagnostic {
+    let path = path.to_string();
+    Diagnostic::new(
+        Severity::Warning,
+        format!("Body `{path}` still holds the text the blueprint wrote there."),
+    )
+    .with_code("validation::example_unchanged".to_string())
+    .with_path(path)
+    .with_arg("example", example.into())
+    .with_arg("trigger", "body".into())
+    .with_hint(
+        "Write the body this document means, in place of the example or placeholder text."
+            .to_string(),
+    )
+}
+
 #[cfg(test)]
 mod must_fill_tests;
+
+#[cfg(test)]
+mod example_unchanged_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/quill/compose/example_unchanged_tests.rs
+++ b/crates/core/src/quill/compose/example_unchanged_tests.rs
@@ -1,0 +1,245 @@
+//! The value axis's other half: a cell holding the value its schema showed.
+
+use crate::quill::quill_from_yaml;
+use crate::{Document, Quill};
+
+fn unchanged(quill: &Quill, md: &str) -> Vec<(String, String)> {
+    let doc = Document::parse(md).expect("parse").document;
+    let mut out: Vec<(String, String)> = quill
+        .validate(&doc)
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("validation::example_unchanged"))
+        .map(|d| {
+            (
+                d.path.clone().expect("every example_unchanged anchors at a path"),
+                d.args["trigger"].as_str().expect("trigger arg").to_string(),
+            )
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn paths(quill: &Quill, md: &str) -> Vec<String> {
+    unchanged(quill, md).into_iter().map(|(p, _)| p).collect()
+}
+
+const MEMO: &str = r#"
+quill: { name: eg, version: 1.0.0, backend: typst, description: examples }
+main:
+  body:
+    example: The first paragraph. Top-level paragraphs are auto-numbered.
+  fields:
+    subject:  { type: string, example: Duty Title }
+    memo_for: { type: array, items: { type: string }, example: [ORG1/SYMBOL, ORG2/SYMBOL] }
+    freeform: { type: string }
+    status:   { type: string, default: draft, example: final }
+    signer:
+      type: object
+      properties:
+        name:  { type: string, example: FIRST M. LAST }
+        grade: { type: string, example: "Rank, USAF" }
+card_kinds:
+  indorsement:
+    fields:
+      from: { type: string, example: FIRST M. LAST }
+"#;
+
+fn md(fields: &str) -> String {
+    format!("~~~card-yaml\n$quill: eg@1.0.0\n$kind: main\n{fields}~~~\n")
+}
+
+fn with_body(fields: &str, body: &str) -> String {
+    format!("{}\n{body}\n", md(fields))
+}
+
+#[test]
+fn a_cell_left_at_its_example_warns_and_an_authored_one_does_not() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(
+        unchanged(&quill, &md("subject: Duty Title\n")),
+        [("main.subject".to_string(), "field".to_string())]
+    );
+    assert!(paths(&quill, &md("subject: Airfield closure\n")).is_empty());
+}
+
+#[test]
+fn a_field_declaring_no_example_never_warns() {
+    let quill = quill_from_yaml(MEMO);
+
+    for value in ["freeform: Duty Title\n", "freeform: \"\"\n", "freeform: x\n"] {
+        assert!(
+            paths(&quill, &md(value)).is_empty(),
+            "nothing to recognize: {value}"
+        );
+    }
+}
+
+/// The seed commits an example whether or not the field is obliged, so the
+/// warning is keyed on the value, not on the obligation axis.
+#[test]
+fn a_defaulted_fields_example_warns_too() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(paths(&quill, &md("status: final\n")), ["main.status"]);
+    assert!(paths(&quill, &md("status: signed\n")).is_empty());
+}
+
+#[test]
+fn an_array_warns_at_the_element_left_behind() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(
+        paths(&quill, &md("memo_for: [AF/A1, ORG2/SYMBOL]\n")),
+        ["main.memo_for[1]"],
+        "a partially edited array warns at the untouched element, not the container"
+    );
+    assert_eq!(
+        paths(&quill, &md("memo_for: [ORG1/SYMBOL, ORG2/SYMBOL]\n")),
+        ["main.memo_for[0]", "main.memo_for[1]"]
+    );
+    assert!(paths(&quill, &md("memo_for: [AF/A1, AF/A2]\n")).is_empty());
+}
+
+/// Position is part of the value: an example element the author moved is one
+/// they handled.
+#[test]
+fn an_array_compares_index_for_index() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert!(paths(&quill, &md("memo_for: [ORG2/SYMBOL, AF/A1]\n")).is_empty());
+}
+
+#[test]
+fn a_typed_dictionary_warns_at_the_property_that_holds_the_example() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(
+        paths(
+            &quill,
+            &md("signer:\n  name: FIRST M. LAST\n  grade: Col, USAF\n")
+        ),
+        ["main.signer.name"]
+    );
+}
+
+#[test]
+fn a_composable_card_is_judged_per_instance() {
+    let quill = quill_from_yaml(MEMO);
+    let root = md("subject: Airfield closure\n");
+    let card = "\n~~~card-yaml\n$kind: indorsement\nfrom: FIRST M. LAST\n~~~\nReviewed.\n";
+
+    assert_eq!(
+        paths(&quill, &format!("{root}{card}{card}")),
+        [
+            "cards.indorsement[0].from",
+            "cards.indorsement[1].from"
+        ]
+    );
+}
+
+#[test]
+fn a_body_left_at_the_schemas_example_warns() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(
+        unchanged(
+            &quill,
+            &with_body(
+                "subject: Airfield closure\n",
+                "The first paragraph. Top-level paragraphs are auto-numbered."
+            )
+        ),
+        [("main.body".to_string(), "body".to_string())]
+    );
+    assert!(paths(
+        &quill,
+        &with_body("subject: Airfield closure\n", "The runway closes Friday.")
+    )
+    .is_empty());
+}
+
+#[test]
+fn a_body_left_at_the_generated_placeholder_warns() {
+    let quill = quill_from_yaml(MEMO);
+    let root = md("subject: Airfield closure\n");
+
+    let placeholder =
+        "\n~~~card-yaml\n$kind: indorsement\nfrom: Ada\n~~~\nWrite indorsement body here.\n";
+    assert_eq!(
+        paths(&quill, &format!("{root}{placeholder}")),
+        ["cards.indorsement[0].body"],
+        "a kind declaring no `body.example` still shows text, and it is recognizable"
+    );
+
+    let written = "\n~~~card-yaml\n$kind: indorsement\nfrom: Ada\n~~~\nConcur.\n";
+    assert!(paths(&quill, &format!("{root}{written}")).is_empty());
+}
+
+#[test]
+fn an_empty_body_is_not_an_example() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert!(paths(&quill, &md("subject: Airfield closure\n")).is_empty());
+}
+
+/// The blueprint stamps a body it emitted through the content model, so the
+/// comparison meets it there rather than byte-for-byte.
+#[test]
+fn a_body_that_only_round_tripped_still_counts_as_untouched() {
+    let quill = quill_from_yaml(
+        r#"
+quill: { name: rt, version: 1.0.0, backend: typst, description: round trip }
+main:
+  body:
+    example: Write __this__ over.
+  fields:
+    subject: { type: string }
+"#,
+    );
+    let md = "~~~card-yaml\n$quill: rt@1.0.0\n$kind: main\nsubject: S\n~~~\n\nWrite **this** over.\n";
+
+    assert_eq!(paths(&quill, md), ["main.body"]);
+}
+
+const VARIANT: &str = r#"
+quill: { name: vr, version: 1.0.0, backend: typst, description: variants }
+main:
+  fields:
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI]
+      example: CUI
+      variants:
+        CUI:
+          controlled_by: { type: string, example: ORG1/SYMBOL }
+          category:      { type: string }
+"#;
+
+fn vr(fields: &str) -> String {
+    format!("~~~card-yaml\n$quill: vr@1.0.0\n$kind: main\n{fields}~~~\n")
+}
+
+#[test]
+fn the_walk_reaches_the_selected_worlds_cells() {
+    let quill = quill_from_yaml(VARIANT);
+
+    assert_eq!(
+        paths(
+            &quill,
+            &vr("classification:\n  value: CUI\n  controlled_by: ORG1/SYMBOL\n  category: PRVCY\n")
+        ),
+        ["main.classification.controlled_by", "main.classification.value"],
+        "the discriminant and its live world are both cells the blueprint stamped"
+    );
+
+    assert!(
+        paths(
+            &quill,
+            &vr("classification:\n  value: UNCLASSIFIED\n  controlled_by: ORG1/SYMBOL\n")
+        )
+        .is_empty(),
+        "a stranded value belongs to `out_of_variant`, not to this walk"
+    );
+}

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -86,8 +86,9 @@ families:
   *render floor* also refuses it (`validation::type_mismatch`); the floor is
   more lenient than the write, and what it adopts is valid.
 - **Validation warnings**: `Quill::validate(doc)` returns every
-  `validation::*` diagnostic, mixing severities; `validation::must_fill` and
-  the `$seed` checks are the non-fatal ones. This is the editor-facing
+  `validation::*` diagnostic, mixing severities; `validation::must_fill`,
+  `validation::out_of_variant`, `validation::example_unchanged` and the `$seed`
+  checks are the non-fatal ones. This is the editor-facing
   surface; the render pipeline blank-fills instead of warning on incomplete
   documents. A **fatal** row here means the document does not render: values
   are judged in the form the render floor builds from them
@@ -210,10 +211,25 @@ the schema obliges the cell (see [SCHEMAS.md](SCHEMAS.md) § "Native
 validation"). An incomplete document therefore produces no *fatal* field-level
 diagnostic, and warns exactly where a human has yet to make a call.
 
+`validation::example_unchanged` (non-fatal) asks the other question: not
+*whether* a cell was authored but *which* value it holds. The blueprint seats a
+defaultless field's `example:` in its value cell under the `!must_fill` marker,
+and a seed commits one on every field that declares it, so a dropped marker
+leaves a value that is present, type-valid, in-domain, and nobody's answer.
+It fires where the authored value is the shown one — element-wise inside an
+array, so a half-edited list still names the leftover element — and on a body
+left at its `body.example` or at the `Write <kind> body here.` placeholder
+generated for a kind declaring none. Its `trigger` arg says which cell spoke
+(`field` or `body`); `example` carries the shown value in its JSON shape. A
+field declaring no `example:` never fires: there is nothing to recognize, and
+absence is `must_fill`'s question.
+
 Implementation: `crates/core/src/quill/validation.rs` (the `ValidationError`
 `Display` impl, for `validation::type_mismatch`) and
 `crates/core/src/quill/compose.rs` (`validate_fills`/`fill_warning` and
-`validate_unauthored`/`unauthored_warning`, for `validation::must_fill`).
+`validate_unauthored`/`unauthored_warning`, for `validation::must_fill`;
+`validate_examples`/`example_unchanged_warning`, for
+`validation::example_unchanged`).
 
 ## Document-model paths
 
@@ -315,6 +331,7 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `validation::body_disabled` | `card` | structured |
 | `validation::coercion_failed` | `value`, `target` | structured, coarser |
 | `validation::must_fill` | `trigger` | structured |
+| `validation::example_unchanged` | `example`, `trigger` | structured |
 | `validation::out_of_variant` | `variant`, `selected` | structured |
 | `validation::not_inline` | — | code-determined |
 | `validation::not_plain` | — | code-determined |


### PR DESCRIPTION
## What

A new non-fatal warning family, `validation::example_unchanged`, joining `validation::must_fill` in the `Quill::validate` flow.

`must_fill` asks *whether* a cell was authored. This asks *which* value it holds. The blueprint seats a defaultless field's `example:` in its value cell under the `!must_fill` marker, and a seed commits one on every field that declares it — so the marker is the only thing distinguishing the example from an answer. It is present, type-valid and in-domain, so coercion, validation and the unauthored predicate all read it as content. Drop the marker and a memo ships `Duty Title` under the commander's name with a clean validate (the ~220 leftovers #1461 counted).

## How

`validate_examples` in `crates/core/src/quill/compose.rs` walks `schema_cards` beside `validate_unauthored` / `validate_variants`, with the same recursion shape:

- **Scalar leaf**: warns when the authored value structurally equals the field's `example:` (or its `example_content` cache, the same declaration a seed commits for a prose field).
- **Array**: element-wise against the same index of the array literal the field shows, so a half-edited list names only the element left behind; an element that is not the shown one still descends, since a typed table's cells carry examples of their own.
- **Typed dictionary / variant container**: namespaces, so each member is judged against its own `example:`; a variant recurses into the world its discriminant selects, and the discriminant itself is a cell.
- **Body**: warns when a card's body is its `body.example` or the `Write <kind> body here.` placeholder the blueprint generates for a kind declaring none. That placeholder now has one definition (`blueprint::body_placeholder`), shared with the blueprint, so the string cannot drift out from under the check. Comparison is against the markdown projection, re-imported, so a body that only round-tripped through the content model (`__b__` → `**b**`) still counts as untouched.
- A field declaring **no** `example:` never fires: there is nothing to recognize, and absence is `must_fill`'s question.

Two constructors, one code: `example_unchanged_warning` (`trigger: field`) and `body_example_unchanged_warning` (`trigger: body`), both carrying the shown value under `example` in its JSON shape. `crates/core/src/error.rs` pins their key sets against each other, the way the two `must_fill` triggers are pinned, and `prose/canon/ERROR.md` carries the new row plus the narrative that `diagnostic_args_match_canon` reads.

The warning is keyed on the value, not on the obligation axis: a *defaulted* field's example fires too, because a seed commits it unmarked.

## Tests

`crates/core/src/quill/compose/example_unchanged_tests.rs` (12 tests, registered like `must_fill_tests`): untouched scalar vs. authored value, no-example field silent, defaulted field's example, array element left behind, whole array, index-for-index positioning, typed dictionary property, per-instance composable cards, body at `body.example`, body at the generated placeholder, body genuinely written, empty body, content round-trip, and the variant walk reaching the selected world's cells.

`cargo test --workspace`: 63 test binaries, all green, no pre-existing test changed.

Closes #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019Z4QwKJsurUYYwPXKjue8K


---
_Generated by [Claude Code](https://claude.ai/code/session_019Z4QwKJsurUYYwPXKjue8K)_