### PR TITLE
fix(content): saturate the delta base-length sum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(content): **a change bundle whose `retain`/`delete` counts sum past
+  `usize` is a base mismatch, not a panic.** `Delta::expected_base_len` summed
+  the counts unchecked, so a host-authored bundle carrying
+  `{"retain": 18446744073709551615}` aborted in debug and wrapped in release,
+  where the wrapped total let `apply` slice past the base. The sum saturates,
+  and the saturated length exceeds any real base, so `try_apply` and
+  `apply_field_change` return the `DeltaBaseMismatch` the contract already
+  names. No wire or API change.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/content/src/delta.rs
+++ b/crates/content/src/delta.rs
@@ -88,15 +88,14 @@ pub struct BaseLengthMismatch {
 
 impl Delta {
     /// Chars of base the `Retain`/`Delete` ops together consume: the base
-    /// length this delta was built against.
+    /// length this delta was built against. Saturating, so a wire delta whose
+    /// counts exceed `usize` reports a length no base has and
+    /// [`try_apply`](Self::try_apply) rejects it as a mismatch.
     pub fn expected_base_len(&self) -> usize {
-        self.ops
-            .iter()
-            .map(|op| match op {
-                Op::Retain(n) | Op::Delete(n) => *n,
-                Op::Insert(_) => 0,
-            })
-            .sum()
+        self.ops.iter().fold(0usize, |acc, op| match op {
+            Op::Retain(n) | Op::Delete(n) => acc.saturating_add(*n),
+            Op::Insert(_) => acc,
+        })
     }
 
     /// Apply to `base`, producing the new text. Base beyond what the ops
@@ -508,6 +507,22 @@ mod tests {
             ops: vec![Op::Delete(9)],
         };
         assert!(over_del.try_apply("hello").is_err());
+    }
+
+    #[test]
+    fn try_apply_rejects_delta_whose_counts_overflow() {
+        // Counts arrive off the wire, where any u64 deserializes.
+        let over = Delta {
+            ops: vec![Op::Retain(usize::MAX), Op::Retain(2)],
+        };
+        assert_eq!(over.expected_base_len(), usize::MAX);
+        assert_eq!(
+            over.try_apply("hello"),
+            Err(BaseLengthMismatch {
+                expected: usize::MAX,
+                actual: 5,
+            })
+        );
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -1398,6 +1398,22 @@ mod tests {
     }
 
     #[test]
+    fn apply_field_change_rejects_a_bundle_whose_retains_overflow() {
+        // The whole host lane: JSON bundle through the store, not a Delta
+        // built in Rust.
+        let bundle = change_bundle_from_value(&serde_json::json!({
+            "delta": { "ops": [{ "retain": usize::MAX }, { "retain": 2 }] }
+        }))
+        .unwrap();
+        let mut rt = from_markdown("hi").unwrap();
+        assert!(matches!(
+            rt.apply_field_change(&bundle),
+            Err(ApplyError::DeltaBaseMismatch { .. })
+        ));
+        assert_eq!(rt.text, "hi");
+    }
+
+    #[test]
     fn apply_mark_ops_remove_punches_hole() {
         let mut rt = from_markdown("abcdef").unwrap();
         rt.apply_mark_ops(&[MarkOp::Add {


### PR DESCRIPTION
A change bundle whose `retain` or `delete` counts sum past `usize` panicked in debug and, in release, wrapped to a small "expected" length that `try_apply` accepted, after which `apply` sliced past the base and panicked anyway. Since `Op::Retain` deserializes any `u64`, that was reachable from an untrusted host-authored bundle through `change_bundle_from_value`, the one wire number not already bounded by `usv_from`.

`expected_base_len` now folds with `saturating_add`, so the total saturates instead of wrapping and the delta is rejected as `DeltaBaseMismatch`, which is what the API contract already promises for a wrong-revision base. No wire or API change; `apply`'s panic on an over-long delta is untouched. Tests cover both the direct `try_apply` call and the full JSON-bundle lane.

Closes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_