### PR TITLE
fix(content): rebase every non-formatting mark on diff_import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,13 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(content): **`diff_import` carries unknown marks forward beside anchors.**
+  The rebase loop matched `MarkKind::Anchor` alone, so a full-document rewrite
+  through the stale-text writer lane dropped every open-set mark, even one over
+  text the rewrite left untouched. It now rebases every non-formatting mark —
+  formatting is what the fresh import re-derives, and the rest lives in the
+  content but not in markdown — so an unknown tag and its attrs survive a
+  revise the way an anchor does.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/content/src/delta.rs
+++ b/crates/content/src/delta.rs
@@ -1,8 +1,8 @@
 //! The per-field edit surface: a [`Delta`] of text splices over the USV content,
 //! plus the **stale-text writer** path, cold-parse a full new markdown document,
-//! char-diff it against the base, and rebase the base's identity marks
-//! (anchors/comments) through the diff so annotations survive an LLM
-//! full-document rewrite with no preservation contract on the LLM.
+//! char-diff it against the base, and rebase the base's non-formatting marks
+//! (anchors/comments, unknown tags) through the diff so annotations survive an
+//! LLM full-document rewrite with no preservation contract on the LLM.
 //!
 //! ## Text splices, not attributed ops
 //!
@@ -29,7 +29,7 @@
 //! (the match is lost) drops the anchor: the accepted residual, stated not
 //! hidden.
 
-use crate::model::{Mark, MarkKind, Content, Normalized};
+use crate::model::{Mark, Content, Normalized};
 use serde::{Deserialize, Serialize};
 use similar::{ChangeTag, TextDiff};
 
@@ -336,9 +336,10 @@ fn push_insert(ops: &mut Vec<Op>, s: &str) {
 }
 
 /// The stale-text writer path: cold-parse `new_markdown`, char-diff it against
-/// `base`, and carry `base`'s identity marks (anchors) forward, rebased through
-/// the diff (re-homing verbatim block moves). The returned content is `new_rt`
-/// (structure/marks/islands from the fresh import) plus the surviving anchors.
+/// `base`, and carry `base`'s non-formatting marks (anchors and unknown tags)
+/// forward, rebased through the diff (re-homing verbatim block moves). The
+/// returned content is `new_rt` (structure/marks/islands from the fresh import)
+/// plus the surviving handles.
 ///
 /// Returns the new content and the [`Delta`] used: the text change an editor
 /// bridge can map its own positions through.
@@ -353,12 +354,12 @@ pub fn diff_import(
     let new_chars: Vec<char> = new_rt.text.chars().collect();
     let inserted = delta.inserted_spans();
     for m in &base.marks {
-        // Only identity marks live in the content but not in markdown;
-        // formatting marks are re-derived by the fresh import.
-        let MarkKind::Anchor { .. } = &m.kind else {
+        // Formatting marks are re-derived by the fresh import; every other
+        // kind lives in the content but not in markdown.
+        if m.kind.is_formatting() {
             continue;
-        };
-        if let Some((ns, ne)) = rebase_anchor(&delta, &base_chars, &new_chars, &inserted, m) {
+        }
+        if let Some((ns, ne)) = rebase_mark(&delta, &base_chars, &new_chars, &inserted, m) {
             new_rt.marks.push(Mark {
                 start: ns,
                 end: ne,
@@ -370,9 +371,10 @@ pub fn diff_import(
     Ok((new_rt.into_normalized(), delta))
 }
 
-/// Rebase one anchor through the delta. Returns its new range, or `None` if it
-/// detaches (its text was deleted and no verbatim move re-homes it).
-fn rebase_anchor(
+/// Rebase one non-formatting mark through the delta. Returns its new range, or
+/// `None` if it detaches (its text was deleted and no verbatim move re-homes
+/// it).
+fn rebase_mark(
     delta: &Delta,
     base_chars: &[char],
     new_chars: &[char],
@@ -380,7 +382,7 @@ fn rebase_anchor(
     m: &Mark,
 ) -> Option<(usize, usize)> {
     if m.start == m.end {
-        // Zero-width point anchor.
+        // Zero-width point mark.
         if !delta.is_deleted(m.start) {
             let p = delta.map_pos(m.start, Assoc::Before);
             return Some((p, p));

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -1,7 +1,7 @@
 //! The content property suite: round-trip modulo loss class
 //! (`import(export(rt)) == rt`, exact here since the generator emits only
-//! lossless islands), canonical serialization, and diff-import preserving
-//! identity marks.
+//! lossless islands), canonical serialization, and diff-import preserving the
+//! marks markdown cannot carry.
 
 use proptest::prelude::*;
 use quillmark_content::delta::diff_import;
@@ -381,6 +381,33 @@ proptest! {
         prop_assert!(anchor.is_some(), "anchor lost across surviving edit");
         let anchor = anchor.unwrap();
         prop_assert_eq!(&new_rt.text[anchor.start..anchor.end], a.as_str());
+    }
+
+    /// Property 3': an unknown mark has no markdown projection either, so the
+    /// fresh import cannot re-derive it and diff-import carries it forward
+    /// whole, tag and attrs intact.
+    #[test]
+    fn diff_import_preserves_surviving_unknown_mark(a in "[a-z]{3,8}", b in "[a-z]{3,8}") {
+        let base_md = format!("keep {a} here");
+        let mut base = from_markdown(&base_md).unwrap().into_content();
+        let start = 5;
+        let end = 5 + a.chars().count();
+        prop_assert_eq!(&base.text[start..end], a.as_str());
+        let kind = MarkKind::Unknown {
+            tag: "highlight".into(),
+            attrs: json!({ "color": "yellow" }),
+        };
+        base.marks.push(Mark::new(start, end, kind.clone()));
+        let base = base.into_normalized();
+
+        let new_md = format!("{b} keep {a} here");
+        let (new_rt, _delta) = diff_import(&base, &new_md).unwrap();
+        let mark = new_rt.marks.iter()
+            .find(|m| matches!(&m.kind, MarkKind::Unknown { tag, .. } if tag == "highlight"));
+        prop_assert!(mark.is_some(), "unknown mark lost across surviving edit");
+        let mark = mark.unwrap();
+        prop_assert_eq!(&new_rt.text[mark.start..mark.end], a.as_str());
+        prop_assert_eq!(&mark.kind, &kind);
     }
 
 }


### PR DESCRIPTION
`diff_import` rebased only `MarkKind::Anchor`, so a full-document rewrite through the stale-text writer lane (the LLM lane) silently dropped every `MarkKind::Unknown` mark, even over untouched text. Unknown marks are equally absent from markdown and the model promises they round-trip opaque, so the fresh import cannot re-derive them.

The loop now skips `is_formatting()` marks and rebases everything else, which keeps the rule open-set; `rebase_anchor` is renamed `rebase_mark` and the docs that said "identity marks (anchors)" now say "non-formatting marks". No wire or API change, and anchor behavior is byte-identical. A new property beside `diff_import_preserves_surviving_anchor` asserts an unknown mark survives a surrounding edit with its tag and attrs intact; it fails on the unfixed code.

Closes #1499

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_