### PR TITLE
fix(content): pad code spans whose content touches the fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,13 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(content): **a code span whose content touches its fence exports with the
+  CommonMark space pad.** Export emitted `fence + content + fence`, so an edge
+  backtick joined the fence run (text `` `a `` came back as ` ```a`` `) and a
+  span that begins and ends with a space lost one off each side on re-import
+  (`" a "` came back as `"a"`). A pad space now flanks the content in exactly
+  those two cases, which import strips back off; a span of nothing but spaces
+  is exempt from the strip and so stays unpadded.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -729,8 +729,22 @@ fn render_marked_core(
                 let content: String = chars[cs..ce].iter().collect();
                 let ticks = longest_backtick_run(&content) + 1;
                 let fence = "`".repeat(ticks.max(1));
+                // CommonMark folds an edge backtick into the fence and strips
+                // one space off each side of a span that begins and ends with
+                // one, unless it is all spaces; the pad defeats both.
+                let pad = content.starts_with('`')
+                    || content.ends_with('`')
+                    || (content.starts_with(' ')
+                        && content.ends_with(' ')
+                        && content.chars().any(|c| c != ' '));
                 out.push_str(&fence);
+                if pad {
+                    out.push(' ');
+                }
                 out.push_str(&content);
+                if pad {
+                    out.push(' ');
+                }
                 out.push_str(&fence);
                 pos = ce;
                 continue;
@@ -1745,6 +1759,28 @@ mod tests {
         assert_eq!(md, "**ab**`cdef`");
         let rt2 = from_markdown(&md).unwrap();
         assert_eq!(rt2.text, "abcdef");
+    }
+
+    /// CommonMark reads a code span's edge backtick as part of the fence run and
+    /// strips one space off each side of a span that begins *and* ends with one,
+    /// so both shapes need the pad the parser then removes. A span of nothing but
+    /// spaces is exempt from the strip, so a pad there would grow it.
+    #[test]
+    fn code_span_edges_keep_their_pad() {
+        for (md, text, want) in [
+            ("`` `a ``", "`a", "`` `a ``"),
+            ("`` a` ``", "a`", "`` a` ``"),
+            ("`` `a` ``", "`a`", "`` `a` ``"),
+            ("`` ` ``", "`", "`` ` ``"),
+            ("`  a  `", " a ", "`  a  `"),
+            ("`a`", "a", "`a`"),
+            ("`  `", "  ", "`  `"),
+        ] {
+            let rt = from_markdown(md).unwrap();
+            assert_eq!(rt.text, text, "import of {md:?}");
+            assert_eq!(to_markdown(&rt), want);
+            round_trips(md);
+        }
     }
 
     /// Entity-shaped text must not re-import as the decoded entity: exporting

--- a/crates/content/tests/properties.rs
+++ b/crates/content/tests/properties.rs
@@ -41,13 +41,26 @@ fn special_url() -> impl Strategy<Value = String> {
     (clean_word(), r"[a-z0-9 ()&]{1,5}").prop_map(|(a, b)| format!("ex.com/{a}{b}"))
 }
 
+// A code span whose content touches its fence: an edge backtick would join the
+// fence run and edge spaces would be stripped, so export owes each a space pad.
+fn code_span() -> impl Strategy<Value = String> {
+    prop_oneof![
+        clean_word().prop_map(|w| format!("`{w}`")),
+        clean_word().prop_map(|w| format!("`` `{w} ``")),
+        clean_word().prop_map(|w| format!("`` {w}` ``")),
+        clean_word().prop_map(|w| format!("`` `{w}` ``")),
+        clean_word().prop_map(|w| format!("`  {w}  `")),
+        Just("`` ` ``".to_string()),
+    ]
+}
+
 fn inline_token() -> impl Strategy<Value = String> {
     prop_oneof![
         plain_word(),
         clean_word().prop_map(|w| format!("**{w}**")),
         clean_word().prop_map(|w| format!("_{w}_")),
         clean_word().prop_map(|w| format!("~~{w}~~")),
-        clean_word().prop_map(|w| format!("`{w}`")),
+        code_span(),
         clean_word().prop_map(|w| format!("<u>{w}</u>")),
         (clean_word(), clean_word()).prop_map(|(t, u)| format!("[{t}](https://ex.com/{u})")),
         (clean_word(), special_url()).prop_map(|(t, u)| format!("[{t}](<{u}>)")),


### PR DESCRIPTION
Code-span export skipped CommonMark's space pad, so an edge backtick merged into the fence run and an edge space was stripped on re-import: the text `` `a `` exported as ` ```a`` ` (re-imported as that literal string, mark and all gone), and `" a "` came back as `"a"`. `MarkKind::Code` sits outside the verify-and-drop net's flanking set, so nothing noticed.

The code arm of `render_marked_core` now pads with one space each side when the content starts or ends with a backtick, or starts and ends with a space and is not all spaces (CommonMark exempts an all-spaces span from the strip, so padding `"  "` would grow it). `code_span_edges_keep_their_pad` pins the issue's rows plus the two that must stay unpadded, and `inline_token`'s code arm in `properties.rs` widens to generate the edge forms so the round-trip property guards them. Both were seen failing before the fix.

Closes #1492

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_