### PR TITLE
fix(content): keep the marks flanking an unknown island's placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(content): **a mark flanking an unknown island's placeholder survives
+  export.** The verify-and-drop net re-imports the rendered line and expects
+  the line's own text back, island slot included, but a type this build has no
+  projection for renders as a comment placeholder that re-imports as nothing.
+  The probe could never match, so every `**` / `*` / `~~` on such a line was
+  dropped as unrepresentable. The expected text omits the slots of islands with
+  no markdown projection and keeps every other one, so the probe measures
+  delimiter leakage alone and still reads an image's slot back.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -534,9 +534,12 @@ fn render_inline(ctx: &Ctx, i: usize, escape_leading_block: bool) -> String {
                     .filter(|&&c| c == ISLAND_SLOT)
                     .count();
             ctx.rt.islands.get(before).map(|isl| {
-                let mut tmp = String::new();
-                emit_island(isl, &mut tmp);
-                tmp
+                let mut markup = String::new();
+                emit_island(isl, &mut markup);
+                SlotMarkup {
+                    markup,
+                    projects: KnownIslandType::parse(&isl.island_type).is_some(),
+                }
             })
         },
     )
@@ -579,6 +582,14 @@ fn bucket_marks(
     (code_ranges, fmt, links)
 }
 
+/// One island slot's markdown, and whether re-importing that markdown yields a
+/// slot back. A type with no markdown projection renders as a placeholder
+/// comment, which re-imports as no content text.
+struct SlotMarkup {
+    markup: String,
+    projects: bool,
+}
+
 /// Render marks over a standalone char slice to markdown: the projection's mark
 /// boundary sweep, shared by prose lines and table cells. `code_ranges`/`fmt`/
 /// `links` are the marks clipped to `chars` (local offsets); `escape_pipe` adds
@@ -607,7 +618,7 @@ fn render_marked_core(
     escape_punct_at: Option<usize>,
     escape_leading_block: bool,
     escape_pipe: bool,
-    island_markup_at: impl Fn(usize) -> Option<String>,
+    island_markup_at: impl Fn(usize) -> Option<SlotMarkup>,
 ) -> String {
     let n = chars.len();
 
@@ -708,8 +719,8 @@ fn render_marked_core(
                 out.push('[');
                 for (i, &c) in chars[ls..le].iter().enumerate() {
                     if c == ISLAND_SLOT {
-                        if let Some(markup) = island_markup_at(ls + i) {
-                            out.push_str(&markup);
+                        if let Some(slot) = island_markup_at(ls + i) {
+                            out.push_str(&slot.markup);
                         }
                     } else {
                         escape_char_into(c, i == 0, escape_pipe, &mut out);
@@ -738,8 +749,8 @@ fn render_marked_core(
             if pos < n {
                 let c = chars[pos];
                 if c == ISLAND_SLOT {
-                    if let Some(markup) = island_markup_at(pos) {
-                        out.push_str(&markup);
+                    if let Some(slot) = island_markup_at(pos) {
+                        out.push_str(&slot.markup);
                     }
                 } else if Some(pos) == escape_punct_at {
                     out.push('\\');
@@ -779,7 +790,16 @@ fn render_marked_core(
     // A punctuation sentinel blocks every leading-block construct, preserves edge
     // whitespace, and is flanking-equivalent to the line start/end it replaces,
     // so it never masks or invents a leak.
-    let expected: String = chars.iter().collect();
+    //
+    // A slot whose island has no markdown projection re-imports as nothing, so
+    // the expected text drops it; every other slot stays, so the probe still
+    // catches a leak that eats an island's markup.
+    let expected: String = chars
+        .iter()
+        .enumerate()
+        .filter(|&(i, &c)| c != ISLAND_SLOT || island_markup_at(i).is_some_and(|s| s.projects))
+        .map(|(_, c)| c)
+        .collect();
     let want = format!(",{expected},");
     let text_safe = |md: &str| {
         crate::import::from_markdown(&format!(",{md},"))
@@ -1602,6 +1622,61 @@ mod tests {
         let back = from_markdown(&to_markdown(&rt)).unwrap();
         assert_eq!(back.text, "ab");
         assert_eq!(back.lines.len(), 1);
+    }
+
+    /// The placeholder re-imports as no content text, so the net's expected text
+    /// carries no slot for it. Reading one back there would fail every probe and
+    /// cost the line every mark markdown can carry.
+    #[test]
+    fn a_mark_flanking_an_unknown_island_placeholder_survives() {
+        let rt = Content {
+            text: format!("x{ISLAND_SLOT} bold"),
+            lines: vec![Line::new(LineKind::Para)],
+            marks: vec![Mark::new(3, 7, MarkKind::Strong)],
+            islands: vec![Island::new("isl-0".into(), "widget".into())],
+        }
+        .into_normalized();
+        assert_eq!(rt.validate(), Ok(()), "hand-built content invalid");
+        let md = to_markdown(&rt);
+        assert_eq!(md, "x<!-- island:widget --> **bold**");
+        let back = from_markdown(&md).unwrap();
+        assert_eq!(back.text, "x bold");
+        assert_eq!(back.marks, vec![Mark::new(2, 6, MarkKind::Strong)]);
+    }
+
+    /// An image's markup does re-import as a slot, so the net still expects one
+    /// back and a mark that would eat it is dropped. Here both `**` sit against
+    /// the image's punctuation, where CommonMark flanking refuses them.
+    #[test]
+    fn a_mark_leaking_around_an_image_slot_is_still_dropped() {
+        let image = || {
+            Island::new("isl-0".into(), "image".into())
+                .with_props(serde_json::json!({"alt": "a", "url": "u"}))
+        };
+        let over_slot = Content {
+            text: format!("a{ISLAND_SLOT}b"),
+            lines: vec![Line::new(LineKind::Para)],
+            marks: vec![Mark::new(1, 2, MarkKind::Strong)],
+            islands: vec![image()],
+        }
+        .into_normalized();
+        let md = to_markdown(&over_slot);
+        assert_eq!(md, "a![a](u)b");
+        let back = from_markdown(&md).unwrap();
+        assert_eq!(back.text, over_slot.text);
+        assert_eq!(back.islands.len(), 1);
+        assert!(back.marks.is_empty(), "leaking mark kept: {md:?}");
+        // A mark on the same line whose delimiters do flank rides through.
+        let before_slot = Content {
+            text: format!("a{ISLAND_SLOT}b"),
+            lines: vec![Line::new(LineKind::Para)],
+            marks: vec![Mark::new(0, 1, MarkKind::Strong)],
+            islands: vec![image()],
+        }
+        .into_normalized();
+        let md = to_markdown(&before_slot);
+        assert_eq!(md, "**a**![a](u)b");
+        assert_eq!(from_markdown(&md).unwrap(), before_slot);
     }
 
     /// An image `alt` is the one place the character reference cannot carry an


### PR DESCRIPTION
`render_marked_core`'s safety net expected an island slot back for every slot on the line, but an unknown island type renders as an HTML comment placeholder that re-imports as nothing. The probe never matched, so the net dropped every `**` / `*` / `~~` on that line, losing formatting on each markdown write of a document holding an open-set island.

The expected text now drops the slots of islands with no markdown projection and keeps the rest, so the probe measures delimiter leakage only and an image's slot is still read back. That needed the island type inside `render_marked_core`: the `island_markup_at` closure returns `SlotMarkup { markup, projects }` instead of a bare `String`, which keeps the check tight rather than stripping `ISLAND_SLOT` from both sides of the comparison. Two tests: the placeholder case (fails before this change) and the image-leak guard.

Closes #1495

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_