### PR TITLE
fix(content): refuse a continues line after a single-line block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(content): **a heading, an island and a rule take no continuation lines.**
+  `segment` grouped a `continues` line into the block above, but export renders
+  only the first line of those three kinds, so `SetContinues` on the line after
+  a heading validated clean and exported `"# a"` with the continuation dropped,
+  while the Typst emitter still rendered it. `LineKind::takes_continuations`
+  names the kinds a continuation is legal after (`Para`, `Code`, `Unknown`);
+  `SetContinues` refuses the write (`ApplyError::ContinuesSingleLineBlock`),
+  `normalize` clears a flag `SetKind` or a stored document left there, and
+  `validate` rejects a hand-built one (`Invariant::ContinuesSingleLineBlock`),
+  the repair-or-refuse split `ContinuesAcrossContainers` already carries.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -374,7 +374,9 @@ export type MarkOp =
  * A line/block edit. `split`/`join` splice `\n` in post-`delta`,
  * post-`islandOps` coordinates; `setKind`/`setContainers`/`setContinues` touch
  * metadata. `setContinues` sets or clears a line's within-block hard-break flag
- * (`ContentLine.continues`); `continues: true` on line 0 is rejected.
+ * (`ContentLine.continues`); `continues: true` is rejected on line 0, on a line
+ * whose containers differ from the line above, and after a heading, island or
+ * rule, each of which is a block of one line.
  */
 export type LineOp =
     | { op: "split"; at: number }

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -58,7 +58,9 @@ pub struct Line {
     /// line break rather than starting a new block. `false` = a new block
     /// (paragraph spacing on either side); `true` = a within-block line break (a
     /// markdown hard break; consecutive lines of one code fence). The first line
-    /// is always `false`.
+    /// is always `false`, as is one whose container path differs from the line
+    /// above or whose block above renders a single line
+    /// ([`LineKind::takes_continuations`]).
     pub continues: bool,
 }
 
@@ -129,6 +131,18 @@ impl LineKind {
     /// open arm, leaving the two emitters to drift on a construct neither knows.
     pub fn projects_as_para(&self) -> bool {
         matches!(self, LineKind::Para | LineKind::Unknown { .. })
+    }
+
+    /// Whether a block of this kind renders the lines that [`Line::continues`]
+    /// joins to its first. A paragraph spans its hard-break run and a code
+    /// block its fence's interior; a heading, an island and a rule are one
+    /// line, and both emitters render that line alone, so a continuation there
+    /// is text the projection never reaches.
+    pub fn takes_continuations(&self) -> bool {
+        matches!(
+            self,
+            LineKind::Para | LineKind::Code { .. } | LineKind::Unknown { .. }
+        )
     }
 
     /// The wire `kind` name.
@@ -803,6 +817,11 @@ pub enum Invariant {
     /// that skipped it, the same pairing as
     /// [`LineKindMismatch`](Invariant::LineKindMismatch).
     ContinuesAcrossContainers { line: usize },
+    /// A line has `continues: true` but the line before it opens a block whose
+    /// kind renders one line ([`LineKind::takes_continuations`]), so the
+    /// continuation's text reaches no projection. `normalize` clears the flag;
+    /// this catches a hand-built content that skipped it.
+    ContinuesSingleLineBlock { line: usize },
     /// An [`MarkKind::Unknown`] reused a reserved built-in `type` name.
     ReservedUnknownTag(String),
     /// A [`LineKind::Unknown`] reused a reserved built-in `kind` name: its
@@ -977,20 +996,6 @@ impl Content {
     /// serialization commits to.
     pub fn normalize(&mut self) {
         canonicalize_containers(&mut self.lines);
-        // A `continues` line whose container path differs from the line above
-        // claims to continue a block it is not in. `Join` mints these by
-        // merging two lines of differing paths, leaving the *next* line
-        // continuing across the seam. Both projections already read the flag as
-        // dead there — `export::emit_block` and `emit::segment_end` both
-        // require the depth to match before they absorb a continuation — so
-        // clearing it changes nothing observable and states what is already
-        // true. Same treatment, and the same reason, as the line-kind demotion
-        // below; a *deliberate* one is refused up front by the op channel.
-        for i in 1..self.lines.len() {
-            if self.lines[i].continues && self.lines[i].containers != self.lines[i - 1].containers {
-                self.lines[i].continues = false;
-            }
-        }
         // A splice writes text, never kinds: typing into a table line leaves it
         // `Island` over prose, joining a fence to an image line leaves it `Code`
         // over a slot, and export reads the kind and not the text, so the
@@ -1010,6 +1015,20 @@ impl Content {
                     canonicalize_keys(attrs);
                     collapse_empty_bag(attrs);
                 }
+            }
+        }
+        // Two accepted ops leave a `continues` line under a block it cannot
+        // continue: `Join` across differing paths, where both projections
+        // already read the flag as dead, and `SetKind` retagging the line
+        // above into a one-line block, where export would drop the text. Read
+        // after the demotion above, which settles what a spliced-over kind is;
+        // a deliberate one is refused up front by the op channel.
+        for i in 1..self.lines.len() {
+            if self.lines[i].continues
+                && (self.lines[i].containers != self.lines[i - 1].containers
+                    || !self.lines[i - 1].kind.takes_continuations())
+            {
+                self.lines[i].continues = false;
             }
         }
         // A table island's props are repaired (padded to one column count, cell
@@ -1121,14 +1140,21 @@ impl Content {
         if self.lines.first().is_some_and(|l| l.continues) {
             return Err(Invariant::FirstLineContinues);
         }
-        // The one relational line invariant `validate` carries. Every other
-        // container rule is a property of a line pair too, and `normalize`
-        // settles each: a non-canonical `ordinal` renumbers, a run opening
-        // under a fresh parent re-reads, this flag clears. What is left here is
-        // the assertion that it ran.
+        // The relational line invariants `validate` carries, both of them a
+        // `continues` line against the block above it. Every other container
+        // rule is a property of a line pair too, and `normalize` settles each:
+        // a non-canonical `ordinal` renumbers, a run opening under a fresh
+        // parent re-reads, this flag clears. What is left here is the
+        // assertion that it ran.
         for (i, pair) in self.lines.windows(2).enumerate() {
-            if pair[1].continues && pair[1].containers != pair[0].containers {
+            if !pair[1].continues {
+                continue;
+            }
+            if pair[1].containers != pair[0].containers {
                 return Err(Invariant::ContinuesAcrossContainers { line: i + 1 });
+            }
+            if !pair[0].kind.takes_continuations() {
+                return Err(Invariant::ContinuesSingleLineBlock { line: i + 1 });
             }
         }
         // Only the formatting-mark edge test below reads it.
@@ -1893,6 +1919,45 @@ mod tests {
         rt.normalize();
         assert!(rt.lines[1].continues, "a hard break inside one item survives");
         assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// A heading, an island and a rule render as their own line alone, so a
+    /// `continues` line after one is text no projection reaches. `SetKind`
+    /// mints the shape by retagging the line a continuation already follows;
+    /// `normalize` clears the flag, and `validate` asserts that it ran.
+    #[test]
+    fn continues_after_a_single_line_block_is_cleared() {
+        let cases = [
+            (LineKind::Heading { level: 1 }, "a\nb", "# a\n\nb"),
+            (LineKind::Island, "\u{FFFC}\nb", "<!-- island:widget -->\n\nb"),
+            (LineKind::Rule, "\nb", "***\n\nb"),
+        ];
+        for (kind, text, markdown) in cases {
+            let mut rt = Content::new(
+                text.to_string(),
+                vec![
+                    Line::new(kind.clone()),
+                    Line::new(LineKind::Para).with_continues(true),
+                ],
+            )
+            .with_islands(match kind {
+                LineKind::Island => vec![Island::new("isl-0".into(), "widget".into())],
+                _ => vec![],
+            });
+            assert_eq!(
+                rt.validate(),
+                Err(Invariant::ContinuesSingleLineBlock { line: 1 }),
+                "a hand-built content that skipped normalize is caught"
+            );
+            rt.normalize();
+            assert!(!rt.lines[1].continues, "normalize clears it");
+            assert_eq!(rt.validate(), Ok(()));
+            assert_eq!(
+                crate::export::to_markdown(&rt.into_normalized()),
+                markdown,
+                "the continuation projects as the paragraph it is"
+            );
+        }
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -58,7 +58,8 @@ pub enum LineOp {
     /// break, a code fence's interior line) rather than starting a new block.
     /// Split, join and text-delta `\n` insertion all mint `continues: false`
     /// lines, so this is the only op that reaches the flag. Setting it on line 0
-    /// is [`ApplyError::FirstLineContinues`].
+    /// is [`ApplyError::FirstLineContinues`]; setting it after a block that
+    /// renders one line is [`ApplyError::ContinuesSingleLineBlock`].
     SetContinues { line: usize, continues: bool },
 }
 
@@ -345,6 +346,11 @@ pub enum ApplyError {
     /// its container path differs from the previous line's, and a within-block
     /// break lives inside one container.
     ContinuesAcrossContainers { line: usize },
+    /// [`LineOp::SetContinues`] would make a line continue a block that renders
+    /// one line ([`LineKind::takes_continuations`]): a heading, an island or a
+    /// rule. Export reads the block's first line alone, so the write would
+    /// silently drop the continuation's text.
+    ContinuesSingleLineBlock { line: usize },
     /// The text delta's expected base length disagreed with the content:
     /// it was built against a different revision.
     DeltaBaseMismatch {
@@ -687,6 +693,18 @@ impl Content {
                             .is_some_and(|(l, prev)| l.containers != prev.containers)
                     {
                         return Err(ApplyError::ContinuesAcrossContainers { line: *line });
+                    }
+                    // The kind side of the same refusal: a heading, an island
+                    // and a rule are one line, so nothing after one is inside
+                    // the block it claims to continue.
+                    if *continues
+                        && self
+                            .lines
+                            .get(*line)
+                            .and(self.lines.get(line.wrapping_sub(1)))
+                            .is_some_and(|prev| !prev.kind.takes_continuations())
+                    {
+                        return Err(ApplyError::ContinuesSingleLineBlock { line: *line });
                     }
                     let l = self.line_mut(*line)?;
                     l.continues = *continues;
@@ -1583,6 +1601,44 @@ mod tests {
             Ok(())
         );
         assert!(rt.lines[1].continues);
+    }
+
+    /// A heading, an island and a rule are one line in both projections, so a
+    /// line continuing one is text neither emitter reaches. Refused on the
+    /// deliberate channel, exactly as the container crossing is.
+    #[test]
+    fn set_continues_after_a_single_line_block_is_refused() {
+        for markdown in ["# a\n\nb", "| h |\n| --- |\n| c |\n\nb", "***\n\nb"] {
+            let mut rt = from_markdown(markdown).unwrap();
+            let line = rt.lines.len() - 1;
+            assert_eq!(
+                rt.apply_line_ops(&[LineOp::SetContinues {
+                    line,
+                    continues: true
+                }]),
+                Err(ApplyError::ContinuesSingleLineBlock { line }),
+                "{markdown}"
+            );
+            assert!(!rt.lines[line].continues);
+            assert_eq!(crate::export::to_markdown(&rt), markdown, "{markdown}");
+        }
+
+        // `SetKind` reaches the shape from the other side, by retagging the
+        // block a continuation already follows. That retag is accepted and the
+        // terminal `normalize` clears the flag, so the continuation lands as
+        // the paragraph it is rather than vanishing.
+        let mut rt = from_markdown("a\\\nb").unwrap();
+        assert!(rt.lines[1].continues, "a hard break is a continuation");
+        assert_eq!(
+            rt.apply_line_ops(&[LineOp::SetKind {
+                line: 0,
+                kind: LineKind::Heading { level: 1 },
+            }]),
+            Ok(())
+        );
+        assert!(!rt.lines[1].continues);
+        assert_eq!(rt.validate(), Ok(()));
+        assert_eq!(crate::export::to_markdown(&rt), "# a\n\nb");
     }
 
     /// A `Join` merging two lines of differing paths leaves the line after the

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -32,6 +32,14 @@ A **segment** is a maximal run of lines joined by `Line::continues`: one
 paragraph, one heading, one whole code fence, one island line. It is what
 "paragraph-level" means against the content, and the unit a region keys on.
 
+Only a `para`, `code` or unknown block takes continuations
+(`LineKind::takes_continuations`), and a continuation stays inside one container
+path. A heading, an island and a rule are one line, and both emitters render
+that line alone, so a `continues` line after one would be text neither
+projection reaches: `Content::normalize` clears the flag there,
+`Content::validate` rejects it (`Invariant::ContinuesSingleLineBlock`,
+`ContinuesAcrossContainers`), and `LineOp::SetContinues` refuses to write it.
+
 ## Escape functions
 
 Two escapers guard the two Typst contexts; both live in `emit`:


### PR DESCRIPTION
A `continues` line after a heading, island or rule was accepted by the op channel and by `validate`, and then dropped on export: `segment()` groups the line into the block above, but the Heading/Island/Rule arms of `emit_leaf_block` render `range.start` alone. The Typst emitter renders the whole segment, so the same content projected two different ways.

The fix mirrors the existing `ContinuesAcrossContainers` triple (refuse in `SetContinues`, clear in `normalize`, reject in `validate`) over one named reading, `LineKind::takes_continuations`. Both error enums are `#[non_exhaustive]` and decode normalizes before validating, so the variants are additive and a stored document in this shape repairs instead of failing. The one ordering subtlety: the `normalize` repair moved after the line-kind demotion, which can turn an `Island`-tagged prose line into a `Para` that legitimately takes continuations. CONVERT.md and the WASM `LineOp` doc state the rule.

Closes #1493

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_