### PR TITLE
refactor(content): fold push_code_line into Inline::push_text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,13 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- refactor(content): **code-block import filters its text through
+  `Inline::push_text`.** `push_code_line` differed from it only in dropping a
+  `\n` where `push_text` spaces one, and its segments come from a
+  `split('\n')`, so the two agree on every input it receives.
+  `change_bundle_from_value` reads `delta` with a single lookup and
+  deserializes it from the borrowed `Value` rather than a clone, and
+  `op_array`'s absent and null cases are one `Option::filter`.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -627,22 +627,7 @@ impl Builder {
                 continues,
             );
             self.code_opened = true;
-            // Code text is literal; still enforce content invariants.
-            self.push_code_line(seg);
-        }
-    }
-
-    fn push_code_line(&mut self, seg: &str) {
-        for c in seg.chars() {
-            match c {
-                '\n' => continue,
-                ISLAND_SLOT => continue,
-                other => {
-                    if let Some(c) = crate::normalize::admit_char(other) {
-                        self.inline.push_raw(c);
-                    }
-                }
-            }
+            self.inline.push_text(seg);
         }
     }
 
@@ -1082,6 +1067,17 @@ mod tests {
             == LineKind::Code {
                 lang: Some("rust".into())
             }));
+    }
+
+    #[test]
+    fn code_block_drops_a_stray_slot_and_breaks_on_a_bare_cr() {
+        let rt = imp("```\na\u{FFFC}b\nc\rd\n```");
+        assert_eq!(rt.text, "ab\nc\nd");
+        assert_eq!(rt.lines.len(), 3);
+        assert!(rt
+            .lines
+            .iter()
+            .all(|l| l.kind == LineKind::Code { lang: None }));
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -9,6 +9,7 @@ use crate::model::{
 };
 use crate::normalize::admit_char;
 use crate::usv::char_to_byte;
+use serde::Deserialize;
 use std::borrow::Cow;
 
 /// A mark edit in final-text coordinates (post-delta, post-line-op).
@@ -277,9 +278,9 @@ pub fn change_bundle_from_value(v: &Value) -> Result<ChangeBundle, String> {
         .as_object()
         .ok_or("bundle must be an object { delta?, islandOps?, lineOps?, markOps? }")?;
     let get = |snake: &str, camel: &str| obj.get(snake).or_else(|| obj.get(camel));
-    let delta = match get("delta", "delta") {
+    let delta = match obj.get("delta") {
         Some(Value::Null) | None => Delta { ops: Vec::new() },
-        Some(d) => serde_json::from_value(d.clone()).map_err(|e| format!("invalid delta: {e}"))?,
+        Some(d) => Delta::deserialize(d).map_err(|e| format!("invalid delta: {e}"))?,
     };
     Ok(ChangeBundle {
         delta,
@@ -298,12 +299,9 @@ fn op_array<T>(
     convert: impl Fn(&Value) -> Result<T, ParseError>,
     what: &str,
 ) -> Result<Vec<T>, String> {
-    let Some(value) = value else {
+    let Some(value) = value.filter(|v| !v.is_null()) else {
         return Ok(Vec::new());
     };
-    if value.is_null() {
-        return Ok(Vec::new());
-    }
     let arr = value
         .as_array()
         .ok_or_else(|| format!("{what} must be an array"))?;


### PR DESCRIPTION
Pure refactor, no behavior or wire change. `push_code_line` and `Inline::push_text` differ only in the `'\n'` arm, and the sole caller splits on `'\n'` first, so that arm is unreachable and the two are extensionally equal. The caller now uses `push_text` and the duplicate is deleted.

In the op-wire reader, `delta` is looked up once instead of twice, deserialized from the borrowed `&Value` rather than a deep clone, and `op_array`'s two early returns become one `Option::filter`. The new import test is a guard rather than a failing-before test: it was run against the unchanged code first and passes identically on both sides, pinning that a fence containing a stray `U+FFFC` and a bare `\r` imports to the same text and line kinds.

Closes #1530

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_