### PR TITLE
fix(core): read a CRLF fence body as its LF twin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **a card fence with CRLF line endings parses as its LF twin
+  does.** The prescan splits the fence body on `\n`, so every CRLF line
+  reached the matchers with a trailing `\r`: a bare `x: !must_fill` matched
+  neither spelling the fill-tag stripper accepts, so the marker was read as an
+  unknown tag — dropped with a `parse::unsupported_yaml_tag` warning, a second
+  `parse::fill_marker_unsupported_position` warning, a `null` value and an
+  `x: null` emit — and a lone `-` opening a sequence item was not one. The
+  scan strips one trailing `\r` per line up front, so the cleaned YAML and
+  every captured comment are `\n`-only.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -89,8 +89,10 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
     // Indent of the `key:` line that opened the current block scalar, if any.
     let mut block_scalar_indent: Option<usize> = None;
 
-    for raw_line in &lines {
-        let line = *raw_line;
+    for &raw_line in &lines {
+        // The split is on `\n`, so a CRLF line ends in `\r`. Dropped once here:
+        // every matcher below, and the cleaned YAML, see `\n`-only lines.
+        let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
         let indent = leading_space_count(line);
         let trimmed = &line[indent..];
 
@@ -410,11 +412,7 @@ fn ensure_frame_at_indent(stack: &mut Vec<Frame>, indent: usize, kind: FrameKind
     stack.len() - 1
 }
 
-/// The slice runs to the `\n` this scan split on, so CRLF input carries a
-/// trailing `\r`. Dropped here: comment text reaches emit verbatim, and emit is
-/// `\n` only.
 fn strip_comment_marker(raw: &str) -> &str {
-    let raw = raw.strip_suffix('\r').unwrap_or(raw);
     let after = raw.trim_start_matches('#');
     after.strip_prefix(' ').unwrap_or(after)
 }
@@ -827,6 +825,35 @@ mod tests {
             }]
         );
         assert!(!out.cleaned_yaml.contains("!must_fill"));
+    }
+
+    #[test]
+    fn crlf_lines_carry_no_carriage_return_into_the_scan() {
+        let input = "dept: !must_fill\r\n# note\r\ntitle: x # trailing\r\n";
+        let out = prescan_fence_content(input);
+        assert_eq!(
+            out.items,
+            vec![
+                PreItem::Field {
+                    key: "dept".to_string(),
+                    fill: true,
+                },
+                PreItem::Comment {
+                    text: "note".to_string(),
+                    inline: false,
+                },
+                PreItem::Field {
+                    key: "title".to_string(),
+                    fill: false,
+                },
+                PreItem::Comment {
+                    text: "trailing".to_string(),
+                    inline: true,
+                },
+            ]
+        );
+        assert!(out.warnings.is_empty(), "got: {:?}", out.warnings);
+        assert!(!out.cleaned_yaml.contains('\r'));
     }
 
     #[test]

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -120,6 +120,32 @@ fn unsupported_fill_position_warns_not_silently_dropped() {
     );
 }
 
+/// The prescan splits on `\n`, so CRLF input reaches it with a trailing `\r` on
+/// every line. Line endings carry no meaning of their own: the parse must land
+/// where the LF twin lands.
+#[test]
+fn crlf_input_parses_as_its_lf_twin() {
+    let lf = "~~~card-yaml\n$quill: q\n$kind: main\n# note\nx: !must_fill\ny: keep\n~~~\n\nBody.\n";
+    let crlf = lf.replace('\n', "\r\n");
+
+    let lf_out = Document::parse(lf).unwrap();
+    let crlf_out = Document::parse(&crlf).unwrap();
+
+    assert!(
+        crlf_out.warnings.is_empty(),
+        "CRLF input must parse without warnings; got: {:?}",
+        crlf_out.warnings
+    );
+    assert!(
+        crlf_out.document.main().payload().is_fill("x"),
+        "a bare `!must_fill` must be recognised under CRLF"
+    );
+    assert_eq!(
+        crlf_out.document, lf_out.document,
+        "CRLF and LF input must parse to the same document"
+    );
+}
+
 #[test]
 fn nested_must_fill_round_trips() {
     let src = "~~~card-yaml\n$quill: q\n$kind: main\naddr:\n  street: !must_fill\n  city: Springfield\n~~~\n";


### PR DESCRIPTION
Under CRLF the prescan handed every line to its matchers with a trailing `\r`, so a bare `key: !must_fill` matched neither spelling `strip_fill_tag` accepts and was read as an unknown tag: dropped with two spurious warnings, a `null` value and a `key: null` emit, where the LF twin recorded the fill marker cleanly.

Line endings carry no meaning here, so the scan now strips one trailing `\r` per line at the top of its loop, and the `\r` case in `strip_comment_marker` (which covered comment text alone, from #1413) goes with it. A lone `-` opening a sequence item was missing its match for the same reason and is fixed by the same strip. Parsed values are unaffected: the cleaned lines are re-joined with `\n` regardless and saphyr already folded CRLF, which the unchanged workspace suite confirms. Tests cover the prescan directly and assert a CRLF document parses to a `Document` equal to its LF twin's with zero warnings.

Closes #1477

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_