### PR TITLE
fix(core): keep an inline trailer on its own `$` line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **a new `$` entry lands after the preceding `$` line's inline
+  comment, not between the line and its comment.** `Payload::upsert_meta`
+  inserted one past the last lower-ranked `$` item, which is the index the
+  trailing comment occupies, and emit reads a trailer as belonging to whatever
+  item precedes it: `$quill: q@1.0 # note` with no explicit `$kind` emitted
+  `$kind: main # note`. The insert now steps over that comment, so the four
+  callers — the `$kind` synthesis on parse, `store_ext`, `store_seed_overlay`,
+  `set_quill_ref` — leave the trailer on its own key and `parse(to_markdown())`
+  holds.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -400,12 +400,17 @@ impl Payload {
             .unwrap_or_else(|| {
                 // Insert after the last lower-ranked `$` item and before any
                 // non-`$` entry: keeps the `$` ordering without displacing
-                // user fields.
-                self.items
+                // user fields. That item's inline trailer sits at the same
+                // index and stays with it.
+                let after = self
+                    .items
                     .iter()
                     .rposition(|i| matches!(i.meta_rank(), Some(r) if r < new_rank))
-                    .map(|p| p + 1)
-                    .unwrap_or(0)
+                    .map_or(0, |p| p + 1);
+                match self.items.get(after) {
+                    Some(PayloadItem::Comment { inline: true, .. }) => after + 1,
+                    _ => after,
+                }
             });
         self.items.insert(insert_at, new);
     }

--- a/crates/core/src/document/tests/emit_idempotence_tests.rs
+++ b/crates/core/src/document/tests/emit_idempotence_tests.rs
@@ -1,4 +1,4 @@
-use crate::document::tests::collect_md_files;
+use crate::document::tests::{collect_md_files, parse};
 
 #[test]
 fn markdown_and_json_converge_on_canonical_form() {
@@ -64,5 +64,45 @@ fn markdown_and_json_converge_on_canonical_form() {
     eprintln!(
         "markdown_and_json_converge_on_canonical_form: {} passed, {} skipped",
         passed, skipped
+    );
+}
+
+#[test]
+fn synthesised_kind_leaves_the_quill_trailer_on_quill() {
+    let src = "~~~card-yaml\n$quill: q@1.0 # note on quill\ntitle: x\n~~~\n";
+    let doc = parse(src);
+
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("$quill: q@1.0 # note on quill\n$kind: main\n"),
+        "trailer belongs to $quill, not to the synthesised $kind\nGot:\n{}",
+        emitted
+    );
+    assert_eq!(
+        parse(&emitted),
+        doc,
+        "emit must re-parse to the same document"
+    );
+}
+
+#[test]
+fn store_ext_leaves_the_kind_trailer_on_kind() {
+    let src = "~~~card-yaml\n$quill: q@1.0\n$kind: main # note on kind\ntitle: x\n~~~\n";
+    let mut doc = parse(src);
+
+    let mut ext = serde_json::Map::new();
+    ext.insert("editor".into(), serde_json::json!({ "pinned": true }));
+    doc.main_mut().store_ext(ext).expect("shallow map stores");
+
+    let emitted = doc.to_markdown();
+    assert!(
+        emitted.contains("$kind: main # note on kind\n$ext:\n"),
+        "trailer belongs to $kind, not to the new $ext\nGot:\n{}",
+        emitted
+    );
+    assert_eq!(
+        parse(&emitted),
+        doc,
+        "emit must re-parse to the same document"
     );
 }


### PR DESCRIPTION
`Payload::upsert_meta` computes its fallback insert index as "one past the last lower-ranked `$` item", which is the index an inline trailing comment on that item occupies. The new entry landed between the `$` line and its comment, and since `emit_payload_items` attaches a trailer to whatever item precedes it, the comment came out on the wrong key: `$quill: q@1.0 # note on quill` with no explicit `$kind` emitted `$kind: main # note on quill`, breaking `parse(to_markdown()) == doc`.

The insert now steps over an immediately following `Comment { inline: true }`; the `position` arm is untouched because it already lands after such a trailer. All four callers (`$kind` synthesis on parse, `store_ext`, `store_seed_overlay`, `set_quill_ref`) share `upsert_meta`, so this covers them all. Two tests in `emit_idempotence_tests.rs` cover the parse-side synthesis and the `store_ext` path; both fail before the change.

Closes #1478

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_