### PR TITLE
fix(core): reject a field name that only normalises to ASCII

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,13 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **a field name is ASCII as written, not as it normalises.**
+  `is_valid_field_name` ran NFC before matching `[A-Za-z_][A-Za-z0-9_]*`,
+  which no non-ASCII name can pass except a canonical singleton that composes
+  to ASCII: `store_field("\u{212A}elvin", …)` was accepted, emitted verbatim,
+  and re-read as a nested key, so the document did not survive
+  `parse(to_markdown())`. The check reads the name's own characters, matching
+  the raw bytes the parser's key grammar accepts.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -9,8 +9,6 @@
 
 use std::collections::BTreeMap;
 
-use unicode_normalization::UnicodeNormalization;
-
 use quillmark_content::delta::diff_import;
 use quillmark_content::import::ImportError;
 use quillmark_content::{ApplyError, ChangeBundle, Delta, Normalized};
@@ -34,12 +32,14 @@ fn render_at(field: &str, at: &[PathSegment]) -> String {
         .to_string()
 }
 
-/// `true` if `name` matches `[A-Za-z_][A-Za-z0-9_]*` after NFC normalisation.
+/// `true` if `name` matches `[A-Za-z_][A-Za-z0-9_]*`, tested on `name`'s own
+/// characters: the parser reads a key's raw bytes, so a name that merely
+/// normalises to ASCII (`U+212A KELVIN SIGN`) is not a top-level key.
 ///
 /// Case is preserved verbatim; only `$`-prefixed keys are reserved, so a user
 /// field can never shadow system metadata.
 pub fn is_valid_field_name(name: &str) -> bool {
-    let mut chars = name.nfc();
+    let mut chars = name.chars();
     let Some(first) = chars.next() else {
         return false;
     };

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -79,6 +79,21 @@ fn test_document_store_field_rejects_dollar_prefixed_names() {
 }
 
 #[test]
+fn test_document_store_field_rejects_non_ascii_names() {
+    for name in ["\u{212A}elvin", "e\u{0301}tat"] {
+        let mut doc = make_doc();
+        assert_eq!(
+            doc.main_mut().store_field(name, qv("value")),
+            Err(EditError::InvalidFieldName(name.to_string())),
+            "expected InvalidFieldName for {:?}",
+            name
+        );
+        doc.main_mut().store_field("after", qv("w")).unwrap();
+        assert_eq!(Document::parse(&doc.to_markdown()).unwrap().document, doc);
+    }
+}
+
+#[test]
 fn test_document_store_field_updates_existing() {
     let mut doc = make_doc();
     doc.main_mut().store_field("title", qv("New Title")).unwrap();


### PR DESCRIPTION
`is_valid_field_name` NFC-normalised a name before matching `[A-Za-z_][A-Za-z0-9_]*`. NFC can only widen that match, so the single effect was to accept a canonical singleton whose composed form is ASCII, `U+212A KELVIN SIGN`. Such a name was stored and emitted with its raw bytes, which the parser's `key_end` then refuses, so the key came back through the leftover-mapping drain and the document did not survive `parse(to_markdown())`.

The check now tests the name's own characters, so the mutators admit exactly the names the parser accepts as top-level keys. The `unicode_normalization` import in `edit.rs` goes with it; the dependency stays for `normalize.rs`. No prose changes: the spec and authoring docs already state the bare regex. The new test pins both refusals (U+212A and a combining acute) and the round trip after a refused store; it fails on the unfixed code.

Closes #1481

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_