### PR TITLE
fix(core): run the fill-target check in store_fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **`Card::store_fields` refuses a `!must_fill` marker targeting a
+  mapping, as `Card::store_field` does.** The batch checked the field-name
+  grammar and value depth only, so a `QuillValue` carrying a marker on a
+  nested object node was stored, emitted with the marker dropped, and refused
+  by the `@0.92.0` storage DTO on reload. `edit::validate_fill_targets` runs
+  per field in the same all-or-nothing pass, so the offending name rides the
+  batch's error vector as `edit::fill_on_mapping` beside every other
+  violation. The WASM `storeFields` inherits it.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -706,6 +706,10 @@ impl Card {
             .iter()
             .filter_map(|(name, value)| {
                 check_field(name, value.as_json())
+                    .and_then(|()| {
+                        validate_fill_targets(value, false)
+                            .map_err(|v| edit_error_from_violation(name, v))
+                    })
                     .err()
                     .map(|e| (name.clone(), e))
             })

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -285,6 +285,30 @@ fn test_store_fill_refuses_a_mapping() {
     let _ = crate::document::Document::parse(&md).expect("the emitted document re-parses");
 }
 
+/// The batch carries the same fill-target rule as the single write: a marker on
+/// a nested mapping emits as an unmarked key and reloads as a DTO violation.
+#[test]
+fn test_card_store_fields_refuses_a_nested_fill_on_a_mapping() {
+    let marked = || {
+        let mut value = QuillValue::from_json(serde_json::json!({"a": {"b": 1}}));
+        assert!(value.set_fill_at(&[crate::value::PathSegment::Key("a".to_string())]));
+        value
+    };
+    let mut card = Card::new("note").unwrap();
+    card.store_field("keep", qv("old")).unwrap();
+
+    let single = card
+        .store_field("x", marked())
+        .expect_err("a marker on a nested mapping is refused");
+    let batch = card
+        .store_fields([("keep".to_string(), qv("new")), ("x".to_string(), marked())])
+        .expect_err("and the batch refuses it identically");
+
+    assert_eq!(batch, vec![("x".to_string(), single)]);
+    assert!(card.payload().get("x").is_none());
+    assert_eq!(card.payload().get("keep").unwrap().as_str(), Some("old"));
+}
+
 #[test]
 fn test_card_store_fields_clears_fill_and_repeated_name_last_wins() {
     let mut card = Card::new("note").unwrap();


### PR DESCRIPTION
`Card::store_fields` validated its batch with `check_field` only, while the single-field `store_field` runs `validate_field` **and** `validate_fill_targets` through `Payload::insert`. Because `QuillValue::set_fill_at` is public, a value carrying a `!must_fill` marker on a nested object node was refused by `store_field` and accepted by `store_fields`; markdown emit then dropped the marker, and the storage DTO refused the row on reload.

The batch's dry run now chains `validate_fill_targets(value, false)` after `check_field` per field, keeping the all-or-nothing contract and the `Vec<(String, EditError)>` shape, so the batch refuses what the single write refuses with the same `edit::fill_on_mapping` error; the WASM `storeFields` inherits it with no binding change. The other `insert_unchecked` callers (`writer.rs` `CardPlan::apply` and `set_all_impl`) are fed only by `resolve_field_write`, whose `Leniency::Write` conform cannot return a caller value holding a nested marker, so they are unchanged. The new test fails on the unfixed code.

Closes #1479

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_