### PR TITLE
fix(core): clear a root must_fill bit on the value a field write stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **a field write clears a root `!must_fill` bit riding on the
+  value it is handed.** The payload item's own `fill` flag is the one carrier
+  of a root marker — emit, the wire and the storage DTO all read it there —
+  while `QuillValue::set_fill_at(&[])` marks the value tree's root, and a
+  value stored after that call kept both bits, disagreeing. `Payload` clears
+  the tree's root bit on insert, so `is_fill` and `QuillValue::fill` answer
+  alike and a document compares equal to itself across the markdown and the
+  storage round-trip, where the split state emitted one document and compared
+  as another. Parse skips a nested-fill path naming only its own key, the
+  route reaching the same split from source.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -458,7 +458,9 @@ fn build_payload(
 
 /// Apply the nested `!must_fill` markers rooted at `key` onto `value`'s tree.
 /// Paths are rooted at the owning top-level key, so the first segment is
-/// stripped. A marker on a mapping node is rejected, as at the top level.
+/// stripped. A path that is nothing but that key names the root, whose marker
+/// the item's own `fill` flag carries. A marker on a mapping node is rejected,
+/// as at the top level.
 fn apply_nested_fills(
     key: &str,
     value: &mut QuillValue,
@@ -468,7 +470,7 @@ fn apply_nested_fills(
         let Some((CommentPathSegment::Key(first), rest)) = path.split_first() else {
             continue;
         };
-        if first != key {
+        if first != key || rest.is_empty() {
             continue;
         }
         if value.is_object_at(rest) {

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -502,8 +502,16 @@ impl Payload {
     }
 
     /// Insert or replace field `key` with `value`, setting its fill marker.
-    /// Position-preserving for an existing key, append otherwise.
-    fn insert_item(&mut self, key: String, value: QuillValue, fill: bool) -> Option<QuillValue> {
+    /// Position-preserving for an existing key, append otherwise. The item's
+    /// `fill` flag is the one carrier of a root marker, so a root fill bit on
+    /// the incoming tree is cleared rather than stored beside it.
+    fn insert_item(
+        &mut self,
+        key: String,
+        mut value: QuillValue,
+        fill: bool,
+    ) -> Option<QuillValue> {
+        value.clear_root_fill();
         for item in self.items.iter_mut() {
             if let PayloadItem::Field {
                 key: k,

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -299,6 +299,28 @@ fn test_card_store_fields_clears_fill_and_repeated_name_last_wins() {
     assert_eq!(value.as_str(), Some("final"));
 }
 
+/// The payload item's flag is the sole carrier of a root `!must_fill`, so a
+/// value arriving with its own root bit set is stored under the marker the
+/// mutator names: `Payload::is_fill` and [`QuillValue::fill`] agree afterwards.
+#[test]
+fn test_store_clears_a_root_fill_bit_on_the_incoming_value() {
+    let mut marked = qv("draft");
+    assert!(marked.set_fill_at(&[]));
+
+    let mut card = Card::new("note").unwrap();
+    card.store_fields([("x".to_string(), marked.clone())])
+        .unwrap();
+    card.store_field("y", marked.clone()).unwrap();
+    card.store_fill("z", marked).unwrap();
+
+    for key in ["x", "y"] {
+        assert!(!card.payload().is_fill(key), "{key} carries no marker");
+        assert!(!card.payload().get(key).unwrap().fill(), "{key} value");
+    }
+    assert!(card.payload().is_fill("z"));
+    assert!(!card.payload().get("z").unwrap().fill());
+}
+
 #[test]
 fn test_store_field_scalar_conversions() {
     let mut card = Card::new("note").unwrap();

--- a/crates/core/src/document/tests/emit_idempotence_tests.rs
+++ b/crates/core/src/document/tests/emit_idempotence_tests.rs
@@ -66,3 +66,42 @@ fn markdown_and_json_converge_on_canonical_form() {
         passed, skipped
     );
 }
+
+/// Emit, the wire and the storage DTO all read a root `!must_fill` off the
+/// payload item's flag, so a value tree whose own root bit disagrees with that
+/// flag compares as a different `Document` than it emits. A caller's root bit
+/// is normalized on the way in, and both round-trips return an equal document
+/// whether the field is marked or not.
+#[test]
+fn a_root_fill_bit_on_a_stored_value_round_trips() {
+    use crate::document::Document;
+    use crate::value::QuillValue;
+
+    let mut marked = QuillValue::from_json(serde_json::json!("draft"));
+    assert!(marked.set_fill_at(&[]));
+
+    let mut doc = Document::new("q@1.0.0".parse().expect("reference"));
+    doc.main_mut()
+        .store_fields([("x".to_string(), marked.clone())])
+        .expect("store_fields accepts the value");
+    doc.main_mut()
+        .store_field("y", marked.clone())
+        .expect("store_field accepts the value");
+    doc.main_mut()
+        .store_fill("z", marked)
+        .expect("store_fill accepts the value");
+
+    let md = doc.to_markdown();
+    assert!(md.contains("\nx: draft\n"), "{md}");
+    assert!(md.contains("\ny: draft\n"), "{md}");
+    assert!(md.contains("\nz: !must_fill draft\n"), "{md}");
+
+    let reparsed = Document::parse(&md)
+        .expect("the emitted document re-parses")
+        .document;
+    assert_eq!(reparsed, doc, "markdown round-trip:\n{md}");
+
+    let json = serde_json::to_string(&doc).expect("to_json");
+    let restored: Document = serde_json::from_str(&json).expect("from_json");
+    assert_eq!(restored, doc, "storage DTO round-trip");
+}

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -240,6 +240,13 @@ impl QuillValue {
         }
     }
 
+    /// Clear `fill` on the root node. A stored field's root marker rides the
+    /// owning [`PayloadItem`](crate::PayloadItem)'s flag, so the tree beneath
+    /// it carries the nested markers alone.
+    pub(crate) fn clear_root_fill(&mut self) {
+        self.node.fill = false;
+    }
+
     /// Whether the node at `path` (relative to the root) is a mapping.
     /// Used to reject `!must_fill` on object-valued nodes.
     pub fn is_object_at(&self, path: &[PathSegment]) -> bool {


### PR DESCRIPTION
A root `!must_fill` lived in two unreconciled places: `PayloadItem::Field.fill` and the value tree's own root bit. `Payload::insert_item` set only the flag and `QuillValue::set_fill_at(&[])` only the bit, so a caller-marked value kept both in disagreement. Since `QuillValue::PartialEq` compares the tree while emit, `is_fill`, the wire and the DTO all read the flag, such a document emitted one thing and compared as another, failing both `parse(to_markdown()) == doc` and the storage round-trip while every projection looked clean.

`insert_item` now clears the incoming root bit, making the item flag the whole state, and `apply_nested_fills` skips a path that names only its owning key (the parse-side route into the same state, and the guard `quill::seed` already uses).

One deviation from the issue's proposed fix as worded: mirroring the flag onto the node bit would leave every `store_fill` with a root bit that neither emit, the DTO (`nonroot_fill_paths` drops the root path) nor a reparse restores, breaking the same two round-trips. Clearing is the invariant already stated at `value.rs`, `dto.rs`, `emit.rs` and `conform.rs`. The wire and DTO are untouched; a hand-crafted DTO carrying an explicit empty `nested_fills` path can still reach the split state, left as a follow-up. Two new tests fail on the unfixed code.

Closes #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_