### PR TITLE
fix(core): read a fill marker's position, not any line that spells it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **`key: !must_fill` written inside a block scalar or a quoted
+  scalar is that scalar's text, and warns about nothing.** The
+  `parse::fill_marker_unsupported_position` check re-read every cleaned line
+  after the prescan, block-scalar bodies among them, and accepted any `:` plus
+  whitespace as the tag's left boundary, so `note: |` over
+  `see key: !must_fill here` kept the literal and still reported a marker
+  lost. The prescan now decides the warning per line as it reads one, where a
+  block-scalar body and a quoted value are known for what they are; the four
+  positions the marker genuinely cannot survive — a flow map, a flow
+  sequence, a bare sequence element, a flow value at depth — warn as before.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -89,6 +89,8 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
     // Indent of the `key:` line that opened the current block scalar, if any.
     let mut block_scalar_indent: Option<usize> = None;
 
+    let mut unsupported_fill_tag = false;
+
     for raw_line in &lines {
         let line = *raw_line;
         let indent = leading_space_count(line);
@@ -179,6 +181,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
             {
                 let (fill, value_without_tag, had_non_fill_tag) =
                     record_fill_and_tags(&mut out, &after_colon, &key);
+                unsupported_fill_tag |= value_has_unsupported_fill_tag(&value_without_tag);
                 if fill {
                     let mut key_path = item_path.clone();
                     key_path.push(CommentPathSegment::Key(key.clone()));
@@ -193,6 +196,8 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
                     kind: Some(FrameKind::Mapping),
                     child_count: 1,
                 });
+            } else {
+                unsupported_fill_tag |= value_has_unsupported_fill_tag(after_dash_trimmed);
             }
 
             if let Some(c) = &trailing_comment {
@@ -231,6 +236,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
 
                 let (fill, value_without_tag, _) =
                     record_fill_and_tags(&mut out, &value_part, &key);
+                unsupported_fill_tag |= value_has_unsupported_fill_tag(&value_without_tag);
 
                 out.items.push(PreItem::Field {
                     key: key.clone(),
@@ -291,6 +297,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
             let (value_part, trailing_comment) = split_trailing_comment(&after_colon);
 
             let (fill, value_without_tag, _) = record_fill_and_tags(&mut out, &value_part, &key);
+            unsupported_fill_tag |= value_has_unsupported_fill_tag(&value_without_tag);
             if fill {
                 out.nested_fills.push(key_path.clone());
             }
@@ -325,16 +332,11 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
             continue;
         }
 
+        unsupported_fill_tag |= line_has_unsupported_fill_tag(line);
         cleaned_lines.push(line.to_string());
     }
 
-    // A tag surviving here sits in a position prescan cannot lift (inside a flow
-    // collection, or on a bare sequence element) where serde_saphyr would drop it
-    // silently.
-    if cleaned_lines
-        .iter()
-        .any(|l| line_has_unsupported_fill_tag(l))
-    {
+    if unsupported_fill_tag {
         out.warnings.push(
             Diagnostic::new(
                 Severity::Warning,
@@ -351,31 +353,46 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
     out
 }
 
-/// True when `line` still carries a `!must_fill` / `!fill` tag in a value or
-/// element position that prescan could not lift. Block-style markers are
-/// stripped before this runs, so a survivor means an unsupported position.
-/// The boundary checks keep a quoted scalar that merely contains the literal
-/// text (e.g. `note: "see !must_fill"`) from matching.
+/// True when `value` — the text after a `key:` or a `- `, with a block-style
+/// marker already stripped — carries a `!must_fill` tag prescan cannot lift:
+/// the whole element, or a member of a flow collection. A quoted scalar is
+/// text, so a tag spelled inside one (`note: "see key: !must_fill here"`) does
+/// not match.
+fn value_has_unsupported_fill_tag(value: &str) -> bool {
+    let value = value.trim_start();
+    !value.starts_with(['"', '\'']) && fill_tag_in_node_position(value, true)
+}
+
+/// True when `line`, which prescan resolved into neither a key nor an element
+/// (a flow collection continued across lines), carries a `!must_fill` tag
+/// after flow punctuation. What opens the line is unknown, so a tag at its
+/// head is not read as a node.
 fn line_has_unsupported_fill_tag(line: &str) -> bool {
+    fill_tag_in_node_position(line, false)
+}
+
+/// True when a fill tag in `text` stands where YAML reads a node: after flow
+/// punctuation, or — when `head_is_node` — at the head of `text` itself.
+fn fill_tag_in_node_position(text: &str, head_is_node: bool) -> bool {
     for tag in FILL_TAGS {
         let mut from = 0;
-        while let Some(rel) = line[from..].find(tag) {
+        while let Some(rel) = text[from..].find(tag) {
             let at = from + rel;
             let after = at + tag.len();
             // Trailing boundary: a real tag ends at whitespace, flow
-            // punctuation, or end of line, not mid-word (`!fillet`).
-            let trailing_ok = line[after..]
+            // punctuation, or end of text, not mid-word (`!fillet`).
+            let trailing_ok = text[after..]
                 .chars()
                 .next()
                 .is_none_or(|c| c.is_whitespace() || matches!(c, ',' | '}' | ']'));
-            // Leading boundary: the tag sits in value/element position,
-            // directly after `{` / `[` / `,`, or after whitespace following
-            // `:` / `-` / `,` / `{` / `[`.
-            let before = line[..at].trim_end_matches([' ', '\t']);
+            // Leading boundary: the tag sits directly after `{` / `[` / `,`,
+            // or after whitespace following `:` / `-` / `,` / `{` / `[`.
+            let before = text[..at].trim_end_matches([' ', '\t']);
             let had_ws = before.len() != at;
             let leading_ok = match before.chars().last() {
                 Some('{') | Some('[') | Some(',') => true,
                 Some(':') | Some('-') => had_ws,
+                None => head_is_node,
                 _ => false,
             };
             if trailing_ok && leading_ok {

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -102,11 +102,23 @@ fn unsupported_fill_position_warns_not_silently_dropped() {
 
     assert!(
         warns("~~~card-yaml\n$quill: q\n$kind: main\naddr: {street: !must_fill, city: x}\n~~~\n"),
-        "flow-collection marker must warn"
+        "flow-map marker must warn"
+    );
+    assert!(
+        warns("~~~card-yaml\n$quill: q\n$kind: main\ntags: [!must_fill, a]\n~~~\n"),
+        "flow-sequence marker must warn"
     );
     assert!(
         warns("~~~card-yaml\n$quill: q\n$kind: main\ntags:\n  - !must_fill\n  - a\n~~~\n"),
         "bare sequence-element marker must warn"
+    );
+    assert!(
+        warns("~~~card-yaml\n$quill: q\n$kind: main\naddr:\n  street: {n: !must_fill}\n~~~\n"),
+        "marker in a nested flow value must warn"
+    );
+    assert!(
+        warns("~~~card-yaml\n$quill: q\n$kind: main\nto:\n  - name: [!must_fill]\n~~~\n"),
+        "marker in a flow value on a sequence-item line must warn"
     );
     assert!(
         !warns(
@@ -118,6 +130,47 @@ fn unsupported_fill_position_warns_not_silently_dropped() {
         !warns("~~~card-yaml\n$quill: q\n$kind: main\nnote: \"see !must_fill docs\"\n~~~\n"),
         "quoted literal must not warn"
     );
+}
+
+/// `key: !must_fill` spelled inside a block scalar or a quoted scalar is that
+/// scalar's text: the value keeps it verbatim and no marker is reported lost.
+#[test]
+fn fill_marker_text_inside_a_scalar_does_not_warn() {
+    let cases = [
+        (
+            "~~~card-yaml\n$quill: q\n$kind: main\nnote: |\n  see key: !must_fill here\n~~~\n",
+            "see key: !must_fill here\n",
+        ),
+        (
+            "~~~card-yaml\n$quill: q\n$kind: main\nnote: \"see key: !must_fill here\"\n~~~\n",
+            "see key: !must_fill here",
+        ),
+    ];
+
+    for (src, value) in cases {
+        let out = Document::parse(src).unwrap();
+        assert!(
+            out.warnings.is_empty(),
+            "marker text inside a scalar must not warn\nSource:\n{}\nGot: {:?}",
+            src,
+            out.warnings
+        );
+        assert_eq!(
+            out.document
+                .main()
+                .payload()
+                .get("note")
+                .and_then(|v| v.as_str()),
+            Some(value),
+            "scalar must keep the marker text verbatim\nSource:\n{}",
+            src
+        );
+        assert!(
+            !out.document.main().payload().is_fill("note"),
+            "marker text is not a marker\nSource:\n{}",
+            src
+        );
+    }
 }
 
 #[test]


### PR DESCRIPTION
The `parse::fill_marker_unsupported_position` warning fired on any line spelling `key: !must_fill`, including block-scalar bodies (passed through verbatim into the lines the post-scan re-read) and quoted scalars. The value was stored correctly and the document was still told a marker had been dropped.

The prescan now decides the warning per line inside its main loop, where block-scalar and quoted context is known, and the `cleaned_lines` post-scan is gone. The scan itself is unchanged apart from one added rule: the head of a value or element counts as a node position (the bare `- !must_fill` case), while the head of a line prescan could not resolve does not, so a multi-line scalar whose next line opens with the tag is not a false positive either. Tests cover the four genuinely unsupported shapes plus the two false positives, the latter asserting zero warnings and the exact literal value; the new test fails on the unfixed code.

Heads-up for merging: #1466 rewrites the same post-scan `if` and the `cleaned_lines` push sites, so these conflict textually. The resolution is to keep the `unsupported_fill_tag` flag and drop the `cleaned.lines.iter().any(…)` scan.

Closes #1482

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_