### PR TITLE
fix(core): keep a sequence item's leading comment inside the item

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **a comment between a bare `-` and the item's first key stays
+  inside the item.** The prescan records such a comment against the item, but
+  emit wrote it above the `- ` line, where it re-parses as a comment on the
+  sequence — a parse-emit-parse inequality on input the parser accepts without
+  a warning, settling only on the second emit. A sequence item whose mapping
+  carries an own-line comment before its first key emits in the bare-dash form,
+  the comment and the mapping indented under it, so the first emit is the fixed
+  point. A blueprint's typed-table row takes that form too, its first
+  property's description sitting inside the row with the rest.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -343,6 +343,13 @@ fn emit_own_line_pending(out: &mut String, ctx: EmitCtx<'_>, position: usize, in
     }
 }
 
+/// Whether [`emit_own_line_pending`] has anything to write at `position`.
+fn has_own_line_pending(ctx: EmitCtx<'_>, position: usize) -> bool {
+    ctx.nested
+        .iter()
+        .any(|c| c.position == position && !c.inline && c.container_path.as_slice() == ctx.path)
+}
+
 /// Return the inline trailer for `position` in the context path. If multiple
 /// inline comments share the slot, returns the first and emits the rest as
 /// own-line.
@@ -516,7 +523,9 @@ fn emit_sequence_children(
 
 /// Emit a single `- <value>\n` sequence item. When the item is a mapping,
 /// if both the seq-item trailer and the first key's trailer are present,
-/// the inner one degrades to an own-line comment.
+/// the inner one degrades to an own-line comment. A mapping carrying an
+/// own-line comment before its first key takes the bare-dash form, the shape
+/// the parser reads that comment back from.
 fn emit_sequence_item(
     out: &mut String,
     value: &JsonValue,
@@ -532,7 +541,14 @@ fn emit_sequence_item(
             out.push('\n');
         }
         JsonValue::Object(map) => {
-            emit_own_line_pending(out, ctx, 0, base_indent);
+            if has_own_line_pending(ctx, 0) {
+                push_indent(out, base_indent);
+                out.push('-');
+                push_trailer(out, inline_trailer);
+                out.push('\n');
+                emit_mapping_children(out, map, base_indent + 2, ctx);
+                return;
+            }
 
             let mut first = true;
             for (i, (k, v)) in map.iter().enumerate() {

--- a/crates/core/src/document/tests/emit_idempotence_tests.rs
+++ b/crates/core/src/document/tests/emit_idempotence_tests.rs
@@ -66,3 +66,31 @@ fn markdown_and_json_converge_on_canonical_form() {
         passed, skipped
     );
 }
+
+/// A comment between a bare `-` and the item's first key belongs to the item, so
+/// it re-emits inside the item and the first emit is already the fixed point.
+#[test]
+fn a_comment_before_a_sequence_item_first_key_stays_inside_the_item() {
+    use crate::document::Document;
+
+    let src = "\
+~~~
+$quill: test@1.0
+$kind: main
+items:
+  -
+    # c
+    name: a
+~~~
+
+Body.
+";
+    let doc = Document::parse(src).expect("parses").document;
+    let md = doc.to_markdown();
+    assert_eq!(md, src, "the first emit is not the fixed point");
+
+    let reparsed = Document::parse(&md)
+        .expect("the emitted document re-parses")
+        .document;
+    assert_eq!(doc, reparsed, "emit is not a fixed point: {md}");
+}

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -906,7 +906,7 @@ main:
 "#)
         .blueprint();
         assert!(t.contains(
-            "# Cited works.\nreferences: # array<object>\n  # Citing organization.\n  - org: !must_fill # string\n"
+            "# Cited works.\nreferences: # array<object>\n  -\n    # Citing organization.\n    org: !must_fill # string\n"
         ));
         assert!(t.contains("    # Publication year.\n    year: 0 # integer\n"));
     }


### PR DESCRIPTION
A comment between a bare `-` and the item's first key is recorded by the prescan against the item, but emit wrote it above the `- ` line, where it re-parses as a comment on the enclosing sequence. So `parse(to_markdown()) == doc` was false on input accepted without a warning, and the document only settled on the second emit, against markdown-spec.md §9's first-emit promise.

`emit_sequence_item` now writes the bare-dash form when the item mapping carries an own-line comment at position 0, deferring to `emit_mapping_children` at `base_indent + 2`, so the authored position is reproduced and the first emit is the fixed point.

One visible consequence worth a look: `blueprint` addresses a typed-table row property's description to the row, so such a row now renders in the bare-dash form too, with every description directly above its property (the second property's already was). Its expected string in `typed_table_must_fill_emits_synthetic_row_with_leaf_markers` is updated; no fixture or canon doc pins the old shape, and the old shape did not survive its own parse-emit round trip. The new test in `emit_idempotence_tests.rs` was seen failing on unfixed HEAD with exactly the bytes the issue reports.

Closes #1484

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_