### PR TITLE
fix(core): report a present variant container as authored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **a variant container the document wrote reads `authored`
+  whichever rung filled its discriminant.** `resolve()` lifted a present
+  container off the blank rung only, so `classification: {}` reported
+  `default` where the schema declared one and `authored` where it did not —
+  the reported rung turning on the schema rather than the document. A present
+  container is `authored`, as any other present value is; a present-null still
+  reads as absent and keeps the discriminant's rung. The value the row carries
+  is unchanged.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -662,8 +662,10 @@ fn compose_members(
 /// that world is present, so no guarded access is needed; outside it, none is.
 ///
 /// The discriminant cuts the same ladder as any enum (authored › `default:` ›
-/// blank), and the container reports it joined with what its live world's cells
-/// contributed ([`compose_members`]) — the rule every namespace follows.
+/// blank), but the container's own rung is the *cell's*: one the document wrote
+/// reads authored whichever rung filled the tag, joined with what its live
+/// world's cells contributed ([`compose_members`]) — the rule every namespace
+/// follows (`prose/canon/SCHEMAS.md` § "The resolved-value view").
 fn resolve_variant_sourced(
     value: Option<&QuillValue>,
     field: &FieldSchema,
@@ -691,11 +693,10 @@ fn resolve_variant_sourced(
             None => (String::new(), FieldSource::Blank),
         },
     };
-    // A present container with no discriminant is still authored: the author
-    // wrote the cell, and the ladder filled the tag they left out.
-    let source = match (present.is_some(), source) {
-        (true, FieldSource::Blank) => FieldSource::Authored,
-        (_, s) => s,
+    let source = if present.is_some() {
+        FieldSource::Authored
+    } else {
+        source
     };
 
     let mut out = serde_json::Map::new();

--- a/crates/core/src/quill/tests/variant_tests.rs
+++ b/crates/core/src/quill/tests/variant_tests.rs
@@ -475,6 +475,53 @@ fn resolve_reports_the_container_as_one_cell_matching_the_plate() {
     assert_eq!(row.source, crate::quill::resolved::FieldSource::Default);
 }
 
+fn classification_row(quill: &Quill, document: &Document) -> crate::quill::resolved::ResolvedField {
+    quill
+        .resolve(document)
+        .main
+        .fields
+        .into_iter()
+        .find(|f| f.name == "classification")
+        .expect("classification row")
+}
+
+/// A container the document wrote reads `authored` whichever rung filled its
+/// discriminant (`prose/canon/SCHEMAS.md` § "The resolved-value view"), so the
+/// reported rung does not turn on whether the schema happens to carry a
+/// `default:`.
+#[test]
+fn a_present_container_reads_authored_whichever_rung_filled_the_tag() {
+    let quill = quill();
+    for fields in ["classification: {}\n", "classification:\n  value:\n"] {
+        let document = doc(fields);
+        let row = classification_row(&quill, &document);
+        assert_eq!(row.value.as_json(), &plate(&document));
+        assert_eq!(
+            row.source,
+            crate::quill::resolved::FieldSource::Authored,
+            "{fields}"
+        );
+    }
+
+    // The value the row carries is still the `default:` member's blank-filled
+    // world: only the rung the container reports changes.
+    let yaml = quill_yaml().replace(
+        "      default: \"\"\n      variants:",
+        "      default: CUI\n      variants:",
+    );
+    let defaulted = quill_from_yaml(&yaml);
+    let row = classification_row(&defaulted, &doc("classification: {}\n"));
+    assert_eq!(
+        row.value.as_json(),
+        &json!({ "value": "CUI", "controlled_by": "", "category": "" })
+    );
+    assert_eq!(row.source, crate::quill::resolved::FieldSource::Authored);
+
+    // A present-null container is absent, so it keeps the discriminant's rung.
+    let row = classification_row(&defaulted, &doc("classification:\n"));
+    assert_eq!(row.source, crate::quill::resolved::FieldSource::Default);
+}
+
 /// A value the container cannot be built from stays raw, as a mis-shaped
 /// `array` or typed dictionary does: `resolve()` labels the row Authored, and a
 /// blank world under that label would read as an answer the document gave.


### PR DESCRIPTION
`resolve()` reported a present-but-discriminantless variant container as `Default` whenever the schema declared a `default:`, so whether an authored container read `authored` depended on the schema rather than on the document. That contradicts `resolve_variant_sourced`'s own inline comment and SCHEMAS.md § "The resolved-value view" ("a container authored at all reads `authored`"); `usaf_memo`'s `classification` ships `default: ""`, so the wrong branch was the ordinary one.

A present container now reports `Authored` outright; `present` already filters nulls, so a present-null container stays on the `Default` rung as null≡absent requires. `FieldSource` is a wire surface and this changes a reported rung, in the direction canon already documents; the resolved *value* is untouched. The new test covers `classification: {}` and `classification: { value: }` against both a blank and a `CUI` default, asserting plate parity alongside the rung, and fails on the unfixed code.

Closes #1489

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_