### PR TITLE
fix(core): hint a nested richtext example in the blueprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,13 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **a nested richtext `example:` reaches the blueprint as its
+  `# e.g.` hint.** A richtext cell never inlines its example, and the
+  per-property builder for typed-dict properties and typed-table rows gated the
+  hint on `default:` alone, so a defaultless richtext property's `example:`
+  appeared in neither the cell nor a hint. Both gates are one helper now, and a
+  property's `example:` behaves as a card-level field's does at every depth, as
+  BLUEPRINT.md § Typed dictionaries states.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -210,12 +210,19 @@ fn typed_table_props(field: &FieldSchema) -> Option<&IndexMap<String, Box<FieldS
     }
 }
 
+/// Whether a leaf's `example:` surfaces as a `# e.g.` hint rather than as the
+/// cell's own value: a `default:` already occupies the cell, or the leaf is
+/// richtext, whose cell an example never inlines (see `scalar_value`). The gate
+/// is a value-axis question and stays keyed on `default`: `must_fill` never
+/// moves an example between the cell and the hint.
+fn eg_hinted(field: &FieldSchema) -> bool {
+    field.default.is_some() || matches!(field.r#type, FieldType::RichText { .. })
+}
+
 /// Push the leading prose comments for a *top-level* field: the description,
-/// then the `# e.g.` hint. `eg_when` gates the hint: a scalar surfaces it only
-/// when a `default:` already occupies the cell (otherwise the example *is* the
-/// cell's value), while typed containers always surface it (their example never
-/// inlines). The gate is a value-axis question and stays keyed on `default`:
-/// `must_fill` never moves an example between the cell and the hint.
+/// then the `# e.g.` hint. `eg_when` gates the hint: a leaf surfaces it under
+/// `eg_hinted`, while typed containers always surface it (their example never
+/// inlines).
 fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool) {
     if let Some(desc) = collapse_opt(&field.description) {
         items.push(PayloadItem::comment(desc));
@@ -253,11 +260,7 @@ fn scalar_value(field: &FieldSchema) -> JsonValue {
 /// Append a scalar / scalar-array / richtext field as a single payload field
 /// plus its trailing inline type annotation.
 fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
-    // A richtext field never inlines its `example:` as the marker value, so
-    // (unlike other defaultless scalars) the example would vanish entirely.
-    // Surface it as a `# e.g.` hint instead (no-ops when no `example:` is set).
-    let eg_when = field.default.is_some() || matches!(field.r#type, FieldType::RichText { .. });
-    push_leading(items, field, eg_when);
+    push_leading(items, field, eg_hinted(field));
     let (json, fill) = scalar_cell(field);
     items.push(PayloadItem::Field {
         key: field.name.clone(),
@@ -295,8 +298,7 @@ fn build_property_mapping(
                 inline: false,
             });
         }
-        // `# e.g.` only when a `default:` holds the cell (see `push_leading`).
-        if prop.default.is_some() {
+        if eg_hinted(prop) {
             if let Some(eg) = prop.example.as_ref() {
                 nested.push(NestedComment {
                     container_path: prefix.to_vec(),
@@ -1061,6 +1063,56 @@ main:
         assert!(t.contains("# e.g. Cupertino\n"), "{t}");
         assert!(t.contains("  street: !must_fill # string\n"));
         assert!(t.contains("  city: \"\" # string\n"));
+    }
+
+    /// A richtext cell never inlines its example, so the `# e.g.` hint is the
+    /// only place the example can land — at every depth a property is declared.
+    #[test]
+    fn a_richtext_example_surfaces_as_an_eg_hint_at_every_depth() {
+        let t = cfg(r#"
+quill: { name: x, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    bio: { type: richtext, example: Top hello }
+    contact:
+      type: object
+      properties:
+        bio: { type: richtext, example: Nested hello }
+    rows:
+      type: array
+      items:
+        type: object
+        properties:
+          bio: { type: richtext, example: Row hello }
+"#)
+        .blueprint();
+
+        assert!(
+            t.contains("# e.g. Top hello\nbio: !must_fill # richtext<markdown>\n"),
+            "{t}"
+        );
+        assert!(
+            t.contains(concat!(
+                "contact: # object\n",
+                "  # e.g. Nested hello\n",
+                "  bio: !must_fill # richtext<markdown>\n",
+            )),
+            "{t}"
+        );
+        assert!(
+            t.contains(concat!(
+                "rows: # array<object>\n",
+                "  # e.g. Row hello\n",
+                "  - bio: !must_fill # richtext<markdown>\n",
+            )),
+            "{t}"
+        );
+
+        let doc1 = Document::parse(&t).expect("blueprint must parse").document;
+        let doc2 = Document::parse(&doc1.to_markdown())
+            .expect("re-emit must parse")
+            .document;
+        assert_eq!(doc1, doc2, "the hinted blueprint must round-trip");
     }
 
     /// A typed dictionary is a namespace, not a cell: a literal on the


### PR DESCRIPTION
`build_property_mapping` re-implemented `append_scalar`'s `# e.g.` gate without its richtext clause, so a defaultless richtext property inside a typed dict, a typed-table row, or a variant cell dropped its `example:` altogether: not into the cell (a richtext cell never inlines one) and not into a hint. Both sites now call one `eg_hinted` helper, which is the whole behavior change; the deleted comments' content moved onto that helper.

Canon needed no edit: BLUEPRINT.md already says a property's `example:` behaves as a card-level field's does, so this makes the code match the doc. The new test asserts the hint at all three depths and that the blueprint still round-trips; it fails on the unfixed code. The diff stays clear of `build_card`, which open PR #1469 edits.

Merge-order note: #1557 (issue #1484) changes how a typed-table row whose first property carries a leading comment emits (bare-dash form). Whichever of the two lands second needs this test's `rows:` expectation updated to `rows: # array<object>\n  -\n    # e.g. Row hello\n    bio: !must_fill # richtext<markdown>\n`.

Closes #1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_