### PR TITLE
fix(core): name the field's own declared type in a type mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **a type mismatch names the field's own declared type, so `date`,
+  `datetime` and `enum` report themselves.** The validator collapsed the three
+  onto `string`, so `due: 20260101` against `type: date` read "schema declares
+  `string`. Either provide a value of type `string` or change the schema's
+  `type:` to `integer`" — a type the schema does not declare and an exit that
+  discards the field's format. The declared type now has one source,
+  `FieldType::as_str`, which the schema-literal path already re-derived for its
+  own messages. `validation::type_mismatch` carries the name in `args.expected`,
+  so a consumer reading that key sees `date`, `datetime` or `enum` where it saw
+  `string`.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1391,14 +1391,11 @@ impl QuillConfig {
             let diag = match &violation {
                 ValidationError::TypeMismatch {
                     path,
+                    expected: declared,
                     actual,
                     source_token,
                     ..
                 } => {
-                    // Use the field's declared `type:` verbatim (`datetime`,
-                    // `markdown`, …); the validator's `expected` collapses those
-                    // to `string`, which would misreport the author's intent.
-                    let declared = schema.r#type.as_str();
                     // validation.rs uses "number" for all non-integer JSON numbers;
                     // display as "float" so messages match the YAML author's mental model.
                     let display_actual = if actual == "number" {

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2249,6 +2249,24 @@ fn datetime_type_mismatch_reports_datetime_not_string() {
 }
 
 #[test]
+fn nested_example_type_mismatch_names_the_element_type() {
+    let yaml = example_default_yaml(
+        "    tags:\n      type: array\n      items:\n        type: string\n      example: [1]\n",
+    );
+    let errors = QuillConfig::from_yaml_with_warnings(&yaml).unwrap_err();
+    let diag = errors
+        .iter()
+        .find(|d| d.code.as_deref() == Some("quill::example_type_mismatch"))
+        .expect("expected example_type_mismatch error");
+    assert!(
+        diag.message.contains("declares type 'string'"),
+        "message should name the item type the element is judged against, got: {}",
+        diag.message
+    );
+    assert!(!diag.message.contains("type 'array'"));
+}
+
+#[test]
 fn type_date_accepts_bare_dates_and_rejects_time_components() {
     let yaml = r#"
 quill:

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -617,7 +617,7 @@ fn validate_value(
     if !type_valid && !format_error_already_reported {
         errors.push(ValidationError::TypeMismatch {
             path: path.to_string(),
-            expected: expected_type_name(&field.r#type).to_string(),
+            expected: field.r#type.as_str().to_string(),
             actual: yaml_scalar_type(value.as_json()).to_string(),
             source_token: verbatim_yaml_scalar(value.as_json()),
             // The `default:` token is a document-authoring aid ("omit the line
@@ -804,21 +804,6 @@ pub(crate) fn validate_schema_literal(
     validate_value(schema, value, path, ValueContext::SchemaLiteral)
 }
 
-fn expected_type_name(field_type: &FieldType) -> &'static str {
-    match field_type {
-        FieldType::String | FieldType::Date | FieldType::DateTime => "string",
-        // Enum is a closed string domain; a mistyped value reports the base type.
-        FieldType::Enum => "string",
-        FieldType::RichText { .. } => "richtext",
-        FieldType::PlainText { .. } => "plaintext",
-        FieldType::Integer => "integer",
-        FieldType::Number => "number",
-        FieldType::Boolean => "boolean",
-        FieldType::Array => "array",
-        FieldType::Object => "object",
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -910,6 +895,38 @@ main:
             ValidationError::TypeMismatch { path, expected, actual, source_token, .. }
             if path == "main.count" && expected == "integer" && actual == "number" && source_token == "9.5"
         )));
+    }
+
+    #[test]
+    fn date_type_mismatch_names_date_not_string() {
+        let config = config_with("    due:\n      type: date", "");
+        let doc = doc_from_fm(&[("due", json!(20260101))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        let err = errors
+            .iter()
+            .find(|e| matches!(e, ValidationError::TypeMismatch { path, .. } if path == "main.due"))
+            .expect("expected a type mismatch on main.due");
+        assert!(
+            err.to_string().contains("schema declares `date`"),
+            "message should name the date type, got: {err}"
+        );
+        assert_eq!(err.args().get("expected"), Some(&json!("date")));
+    }
+
+    #[test]
+    fn enum_type_mismatch_names_enum_not_string() {
+        let config = config_with("    lvl:\n      type: enum\n      values: [a, b]", "");
+        let doc = doc_from_fm(&[("lvl", json!(["a", "b"]))]);
+        let errors = validate_typed_document(&config, &doc).unwrap_err();
+        let err = errors
+            .iter()
+            .find(|e| matches!(e, ValidationError::TypeMismatch { path, .. } if path == "main.lvl"))
+            .expect("expected a type mismatch on main.lvl");
+        assert!(
+            err.to_string().contains("schema declares `enum`"),
+            "message should name the enum type, got: {err}"
+        );
+        assert_eq!(err.args().get("expected"), Some(&json!("enum")));
     }
 
     #[test]


### PR DESCRIPTION
`expected_type_name` mapped `Date`, `DateTime` and `Enum` to `"string"`, so a document diagnostic named a type the schema does not declare and offered an exit that discards the field's format: `due: 20260101` on `type: date` read "schema declares `string` … change the schema's `type:` to `integer`".

Since the fix makes every arm identical to `FieldType::as_str`, the wrapper is gone and the one call site reads the schema directly; `config.rs`'s parallel re-derivation is replaced by the violation's own `expected`, so "declared type" has a single source across the document and schema-literal paths. That also corrects a nested schema literal, which named the container's type against an element judged by the item schema.

`args.expected` is wire-visible: a consumer reading that key now sees `date`, `datetime` or `enum` where it saw `string`, which the CHANGELOG entry calls out. The plain-enum path now agrees with `validate_variant`, which already emitted `expected: "enum"`. ERROR.md is unchanged: its contract already promises "the field's declared type" and its arg table lists keys, not values. Three new tests, all seen failing before the fix.

Closes #1491

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_