### PR TITLE
fix(core): validate $seed overlay cells as document values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **a `$seed` overlay cell is validated as the document value it
+  is.** `validate` judged each cell as a Quill.yaml schema literal, a context
+  that refuses the container spelling of a variant-bearing enum and reads a
+  present-null as a typed value, so `classification: { value: CUI, note:
+  hello }` and `author: null` each drew a `validation::type_mismatch` warning
+  while `seed_card` committed both. An overlay cell is what `seed_card` writes
+  into the new card, so it takes the same pass a card's own fields take: the
+  container is a spelling it accepts, null reads as absent, and a mistyped
+  cell still warns. Overlays stay advisory and never gate render.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -262,9 +262,10 @@ impl Quill {
     /// (`compile_data` / `dry_run` ignore `$seed`), so every diagnostic here is
     /// a **warning** rooted at `$seed.<kind>[.<field>]`. An overlay keyed by a
     /// name that is not a declared `card_kind` is flagged; otherwise each
-    /// overlaid field is checked against that kind's schema with the same
-    /// conformance core the schema's own `example:` / `default:` literals use
-    /// (partial values allowed, no null/absence gating).
+    /// overlaid field is checked against that kind's schema as the **document**
+    /// value it is — an overlay cell is what `seed_card` commits into a new
+    /// card — so the variant container is a spelling it accepts, a present-null
+    /// cell reads as absent, and an omitted field raises nothing.
     /// The reserved `$body` key is the body override, not a field, and is
     /// skipped.
     fn validate_seed(&self, doc: &Document) -> Vec<Diagnostic> {
@@ -316,9 +317,7 @@ impl Quill {
                     continue;
                 };
                 let qv = QuillValue::from_json(value.clone());
-                for violation in
-                    super::validation::validate_schema_literal(field_schema, &qv, &field_path)
-                {
+                for violation in super::validation::validate_field(field_schema, &qv, &field_path) {
                     diags.push(seed_violation_diagnostic(&violation));
                 }
             }

--- a/crates/core/src/quill/seed/tests.rs
+++ b/crates/core/src/quill/seed/tests.rs
@@ -261,13 +261,18 @@ fn doc_with_seed(seed_block: &str) -> Document {
 #[test]
 fn seed_overlay_type_mismatch_is_advisory_and_does_not_gate_render() {
     let quill = quill_from_yaml(QUILL);
-    let doc = doc_with_seed("$seed:\n  note:\n    author: 123\n");
+    let doc = doc_with_seed("$seed:\n  note:\n    author: { given: A }\n");
 
     let diags = quill.validate(&doc);
     let seed_diag = diags
         .iter()
         .find(|d| d.path.as_deref() == Some("$seed.note.author"))
         .expect("a diagnostic rooted at the seed field");
+    assert_eq!(
+        seed_diag.code.as_deref(),
+        Some("validation::type_mismatch"),
+        "a shape no card could carry is still flagged: {seed_diag:?}",
+    );
     assert_eq!(
         seed_diag.severity,
         Severity::Warning,
@@ -305,6 +310,72 @@ fn well_formed_seed_overlay_yields_no_seed_diagnostics() {
             .iter()
             .any(|d| d.path.as_deref().is_some_and(|p| p.starts_with("$seed"))),
         "a well-formed overlay should produce no seed diagnostics: {diags:?}",
+    );
+}
+
+/// The container is the spelling `seed_variant` reads its discriminant off, so
+/// the overlay the seeder accepts is the overlay the validator passes.
+#[test]
+fn a_variant_container_overlay_validates_clean_and_seeds() {
+    const VARIANT_QUILL: &str = r#"
+quill:
+  name: seed_test
+  version: "1.0"
+  backend: typst
+  description: Seed variant test
+main:
+  fields:
+    title:
+      type: string
+card_kinds:
+  entry:
+    fields:
+      classification:
+        type: enum
+        values: [UNCLASSIFIED, CUI]
+        default: ""
+        variants:
+          CUI:
+            note: { type: richtext }
+"#;
+    let quill = quill_from_yaml(VARIANT_QUILL);
+    let doc = doc_with_seed(
+        "$seed:\n  entry:\n    classification:\n      value: CUI\n      note: hello\n",
+    );
+
+    let diags = quill.validate(&doc);
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.path.as_deref().is_some_and(|p| p.starts_with("$seed"))),
+        "a container overlay is a document value, not a schema literal: {diags:?}",
+    );
+
+    let overlay = overlay(json!({ "classification": { "value": "CUI", "note": "hello" } }));
+    let card = quill
+        .seed_card("entry", Some(&overlay))
+        .expect("kind exists");
+    assert_eq!(
+        card.payload()
+            .get("classification")
+            .expect("seeded classification")
+            .as_json()["value"],
+        json!("CUI"),
+    );
+}
+
+/// Null ≡ absent in an overlay cell as in any authored one: the field is simply
+/// unanswered, and the seeded card blank-fills it at render.
+#[test]
+fn a_null_overlay_cell_draws_no_diagnostic() {
+    let quill = quill_from_yaml(QUILL);
+    let doc = doc_with_seed("$seed:\n  note:\n    author: null\n");
+    let diags = quill.validate(&doc);
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.path.as_deref().is_some_and(|p| p.starts_with("$seed"))),
+        "a present-null overlay cell is an absent one: {diags:?}",
     );
 }
 

--- a/prose/canon/CARDS.md
+++ b/prose/canon/CARDS.md
@@ -170,6 +170,9 @@ The main card **carries** `$seed` but is never a *subject* of it: its keys range
 over `card_kinds`, and `main ∉ card_kinds` (a `$seed.main` entry is an advisory
 unknown-kind). Overlays are validated only on the editor surface
 (`Quill::validate`, warning-severity, rooted at `$seed.<kind>[.<field>]`) and
-**never gate render**: `compile_data` / `dry_run` ignore `$seed` entirely. A
-malformed overlay surfaces enforcement only when a card is actually spawned from
-it, as an ordinary card diagnostic on that card.
+**never gate render**: `compile_data` / `dry_run` ignore `$seed` entirely. Each
+cell is judged as the **document** value it is — an overlay cell is what
+`seed_card` commits into the new card — so the container spelling of a
+variant-bearing enum and a present-null cell read here exactly as they read in a
+card. A malformed overlay surfaces enforcement only when a card is actually
+spawned from it, as an ordinary card diagnostic on that card.


### PR DESCRIPTION
`validate` judged each `$seed` overlay cell in the schema-literal context (`validate_schema_literal`), which exists for Quill.yaml's own `example:` / `default:` literals: it refuses the container spelling of a variant-bearing enum and does not treat a present-null as absent. An overlay cell is the value `seed_card` writes into a new card, so those two rules were wrong for it. `classification: { value: CUI, note: hello }` and `author: null` each drew a warning the seeder disagreed with.

The cells now take `validate_field` (`ValueContext::Document`), the one-line repair (a) from triage; repair (b) (routing through `resolve_field_write`) is left alone because it would change the diagnostic codes `$seed` emits. A cell the render floor cannot adopt still warns, and overlays remain advisory and never gate render. CARDS.md states the context. The diff stays inside `validate_seed`'s body, so PR #1467's `validate_examples` insertion above it is at most a trivial textual conflict. Two new tests fail on the unfixed code.

Closes #1486

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_