### PR TITLE
fix(core)!: give the §8 count caps their own codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core)!: **the §8 count caps report a count, not a byte size.** The
+  card-count and per-block field-count caps raised `parse::input_too_large`,
+  whose one message shape is `Input too large: {size} bytes (max: {max}
+  bytes)`, so 1001 fields read as 1001 bytes and the `size` arg rode out under
+  a code whose canon row says bytes. Each cap has its own variant and code:
+  `ParseError::TooManyFields` / `parse::too_many_fields` and
+  `ParseError::TooManyCards` / `parse::too_many_cards`, both carrying `count`
+  and `max`. `parse::input_too_large` keeps the two byte caps, document size
+  and YAML payload size. A consumer routing count overflow on
+  `parse::input_too_large` reads the two new codes instead.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -156,8 +156,8 @@ pub(super) fn build_block(
     // user-data fields.
     if let Some(serde_json::Value::Object(ref map)) = yaml_value {
         if map.len() > crate::error::MAX_FIELD_COUNT {
-            return Err(ParseError::InputTooLarge {
-                size: map.len(),
+            return Err(ParseError::TooManyFields {
+                count: map.len(),
                 max: crate::error::MAX_FIELD_COUNT,
             });
         }

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -324,8 +324,8 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
     // Composable cards are every block after the root (spec §8).
     let card_count = blocks.len().saturating_sub(1);
     if card_count > crate::error::MAX_CARD_COUNT {
-        return Err(ParseError::InputTooLarge {
-            size: card_count,
+        return Err(ParseError::TooManyCards {
+            count: card_count,
             max: crate::error::MAX_CARD_COUNT,
         });
     }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -306,6 +306,17 @@ pub enum ParseError {
     #[error("Input too large: {size} bytes (max: {max} bytes)")]
     InputTooLarge { size: usize, max: usize },
 
+    /// A card-yaml block carries more user fields than [`MAX_FIELD_COUNT`]
+    /// (spec §8), counted after `$`-key extraction. Code
+    /// `parse::too_many_fields`.
+    #[error("Too many fields in one card-yaml block: {count} (max: {max})")]
+    TooManyFields { count: usize, max: usize },
+
+    /// A document carries more composable cards than [`MAX_CARD_COUNT`]
+    /// (spec §8). Code `parse::too_many_cards`.
+    #[error("Too many cards: {count} (max: {max})")]
+    TooManyCards { count: usize, max: usize },
+
     #[error("Invalid YAML structure: {0}")]
     InvalidStructure(String),
 
@@ -357,6 +368,14 @@ impl ParseError {
                 "size" => size,
                 "max" => max,
             },
+            ParseError::TooManyFields { count, max } => diag_args! {
+                "count" => count,
+                "max" => max,
+            },
+            ParseError::TooManyCards { count, max } => diag_args! {
+                "count" => count,
+                "max" => max,
+            },
             ParseError::InvalidStructure(_) => diag_args! {},
             ParseError::EmptyInput(_) => diag_args! {},
             ParseError::MissingQuill(_) => diag_args! {},
@@ -387,6 +406,19 @@ impl ParseError {
                 format!("Input too large: {} bytes (max: {} bytes)", size, max),
             )
             .with_code("parse::input_too_large".to_string()),
+            ParseError::TooManyFields { count, max } => Diagnostic::new(
+                Severity::Error,
+                format!(
+                    "Too many fields in one card-yaml block: {} (max: {})",
+                    count, max
+                ),
+            )
+            .with_code("parse::too_many_fields".to_string()),
+            ParseError::TooManyCards { count, max } => Diagnostic::new(
+                Severity::Error,
+                format!("Too many cards: {} (max: {})", count, max),
+            )
+            .with_code("parse::too_many_cards".to_string()),
             ParseError::InvalidStructure(msg) => Diagnostic::new(Severity::Error, msg.clone())
                 .with_code("parse::invalid_structure".to_string()),
             ParseError::EmptyInput(msg) => Diagnostic::new(Severity::Error, msg.clone())
@@ -684,6 +716,8 @@ mod args_canon {
 
         for e in [
             ParseError::InputTooLarge { size: 2, max: 1 },
+            ParseError::TooManyFields { count: 2, max: 1 },
+            ParseError::TooManyCards { count: 2, max: 1 },
             ParseError::InvalidStructure("x".into()),
             ParseError::EmptyInput("x".into()),
             ParseError::MissingQuill("x".into()),

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -47,8 +47,14 @@ fn per_block_field_count_cap() {
         s.push_str(&format!("f{}: v\n", i));
     }
     s.push_str("~~~\n\nBody.");
-    let err = Document::parse(&s).unwrap_err().to_string();
-    assert!(err.contains("Input too large"), "got: {}", err);
+    let diag = Document::parse(&s).unwrap_err().to_diagnostic();
+    assert_eq!(diag.code.as_deref(), Some("parse::too_many_fields"));
+    assert!(
+        diag.message.contains("Too many fields") && !diag.message.contains("bytes"),
+        "a field count is not a byte count, got: {}",
+        diag.message
+    );
+    assert_eq!(diag.args.get("count"), Some(&serde_json::json!(1001)));
 }
 
 #[test]
@@ -57,8 +63,14 @@ fn card_count_cap_is_per_card() {
     for _ in 0..1001 {
         s.push_str("\n~~~card-yaml\n$kind: x\n~~~\n\nB.\n");
     }
-    let err = Document::parse(&s).unwrap_err().to_string();
-    assert!(err.contains("Input too large"), "got: {}", err);
+    let diag = Document::parse(&s).unwrap_err().to_diagnostic();
+    assert_eq!(diag.code.as_deref(), Some("parse::too_many_cards"));
+    assert!(
+        diag.message.contains("Too many cards") && !diag.message.contains("bytes"),
+        "a card count is not a byte count, got: {}",
+        diag.message
+    );
+    assert_eq!(diag.args.get("count"), Some(&serde_json::json!(1001)));
 }
 
 /// `docs/integration/operations.md` tells an integrator to read the caps rather

--- a/docs/integration/error-handling.md
+++ b/docs/integration/error-handling.md
@@ -53,7 +53,7 @@ The `code` namespaces are the routing surface:
 
 `parse::*` · `validation::*` · `quill::*` · `edit::*` (mutators) · `typst::*` · `pdfform::*` · `backend::*` · `engine::*`.
 
-Notable codes: `quill::name_mismatch` / `quill::version_mismatch` (a well-formed document paired with the wrong quill; see [Versioning](../quills/versioning.md)); `engine::backend_not_found` (the quill's declared backend is not registered); `parse::input_too_large`, which carries four of the five [§8 caps](../reference/markdown-spec.md#8-limits) — document size, YAML payload size, card count, field count — distinguished only by its `max` arg, the fifth (nesting depth) arriving as `parse::yaml_error_with_location`.
+Notable codes: `quill::name_mismatch` / `quill::version_mismatch` (a well-formed document paired with the wrong quill; see [Versioning](../quills/versioning.md)); `engine::backend_not_found` (the quill's declared backend is not registered); `parse::input_too_large`, which carries the two byte-sized [§8 caps](../reference/markdown-spec.md#8-limits) — document size and YAML payload size — distinguished only by its `max` arg, while the count caps arrive as `parse::too_many_cards` and `parse::too_many_fields` (args `count`, `max`) and the nesting cap as `parse::yaml_error_with_location`.
 
 ## Warnings vs errors
 

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -22,7 +22,7 @@ severity.
 
 **`Diagnostic`**: severity, optional error `code`, `message`, optional `location` (text anchor: file/line/column), optional `path` (document-model anchor, dotted/bracketed path into the typed `Document`, set by schema validation/coercion), optional `hint`, `source_chain` (omitted from serialization when empty). `location` and `path` are independent and may co-exist.
 
-**`ParseError`**: parsing-stage error enum, `InputTooLarge`, `InvalidStructure`, `EmptyInput`, `MissingQuill`, `InvalidQuillReference`, `YamlErrorWithLocation`; converts to `Diagnostic` via `to_diagnostic()`. The `InvalidQuillReference` case (`parse::invalid_quill_reference`) attaches the canonical `$quill` grammar (`quill_ref_hint()`) as the diagnostic hint. That hint is the single source of truth for the reference grammar: bindings surface it verbatim (e.g. WASM `Document.quillRefHint`) rather than re-stating the rule.
+**`ParseError`**: parsing-stage error enum, `InputTooLarge`, `TooManyFields`, `TooManyCards`, `InvalidStructure`, `EmptyInput`, `MissingQuill`, `InvalidQuillReference`, `YamlErrorWithLocation`; converts to `Diagnostic` via `to_diagnostic()`. The `InvalidQuillReference` case (`parse::invalid_quill_reference`) attaches the canonical `$quill` grammar (`quill_ref_hint()`) as the diagnostic hint. That hint is the single source of truth for the reference grammar: bindings surface it verbatim (e.g. WASM `Document.quillRefHint`) rather than re-stating the rule.
 
 **`YamlError`**: the one adapter every `serde-saphyr` error passes through. Sanitizes the message (the engine appends its own Rust API names (`from_multiple`, `DuplicateKeyPolicy`) which `yaml_hints::enrich_yaml_error` strips), derives the hint, and carries the 1-indexed line/column the engine located; `to_diagnostic(code, file)` renders all three. The emit side has no input to point at, so it carries neither position nor hint.
 
@@ -338,6 +338,8 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `conform::field_coercion_failed` | `field`, `target` | structured, coarser |
 | `conform::field_decode` | `field`, `codec` | structured, coarser |
 | `parse::input_too_large` | `size`, `max` | structured |
+| `parse::too_many_fields` | `count`, `max` | structured |
+| `parse::too_many_cards` | `count`, `max` | structured |
 | `parse::invalid_quill_reference` | `value` | structured, coarser |
 | `parse::yaml_error_with_location` | `line`, `blockIndex` | structured, coarser |
 | `parse::empty_input` | — | code-determined |


### PR DESCRIPTION
The §8 card-count and field-count caps both raised `ParseError::InputTooLarge`, which has a single message shape naming bytes, so a block with 1001 fields reported "Input too large: 1001 bytes (max: 1000 bytes)" and shipped the count as a `size` arg under a code documented as a byte count.

Each count cap now has its own variant and code: `parse::too_many_fields` and `parse::too_many_cards`, both carrying `count` and `max`; `parse::input_too_large` keeps document size and YAML payload size. This changes an emitted diagnostic code, so a consumer routing count overflow on `parse::input_too_large` reads the two new codes instead; the CHANGELOG entry is tagged `fix(core)!:` and names both. `ParseError` is `#[non_exhaustive]`, so the variants are additive for out-of-crate matchers.

The two cap tests were tightened from the old prefix check to assert the code, the count wording, and the `count` arg (both fail on the unfixed code), and the `args_canon` test pins the new key sets against the two new ERROR.md rows. No binding matches on `ParseError` variants; the one doc line that enumerated the code for the count case (`docs/integration/error-handling.md`) is updated. The ERROR.md edit is two table rows plus the variant list, clear of the rows PR #1467 touches.

Closes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_