### PR TITLE
refactor(core): mint the kindless slot refusal in build_card

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,12 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- refactor(core): **`set_values` refuses a kindless card slot through the card
+  constructor rather than a hand-built error.** `plan_slot` carried an early
+  return minting `edit::invalid_kind_name` for a position holding no card and
+  naming no kind; flattening the kind to `Option<&str>` sends that case to
+  `build_card`, where `Card::new("")` raises the same error at the same
+  `cards[<i>]` path.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -382,8 +382,7 @@ impl CardPlan {
 
 /// Resolve the values for card position `index`. The kind is the entry's, or
 /// the card's there when the entry carries none; a position holding no card
-/// and naming no kind is refused as building a kindless card is, at
-/// `cards[<index>]`.
+/// and naming no kind is a kindless build, refused at `cards[<index>]`.
 fn plan_slot(
     config: &QuillConfig,
     doc: &Document,
@@ -393,15 +392,8 @@ fn plan_slot(
 ) -> Option<Slot> {
     let current = doc.card(index);
     let kind = match &incoming.kind {
-        None => current.map(|c| c.kind()),
-        Some(kind) => Some(kind.as_deref()),
-    };
-    let Some(kind) = kind else {
-        errors.push((
-            DocPath::card(None, index),
-            EditError::InvalidKindName(String::new()),
-        ));
-        return None;
+        None => current.and_then(|c| c.kind()),
+        Some(kind) => kind.as_deref(),
     };
     let base = DocPath::card(kind, index);
     let schema = kind.and_then(|k| config.card_kind(k));

--- a/crates/core/src/writer/values_tests.rs
+++ b/crates/core/src/writer/values_tests.rs
@@ -206,6 +206,7 @@ fn a_card_entry_without_a_kind_keeps_the_cards_and_a_differing_kind_rebuilds() {
         ["cards[1]"],
         "a position with no card to inherit from is refused as a kindless build is"
     );
+    assert!(matches!(&errors[0].1, EditError::InvalidKindName(k) if k.is_empty()));
 }
 
 #[test]


### PR DESCRIPTION
`plan_slot`'s early return for a kindless card slot duplicated the error its own `build_card` path already produces. Flattening the kind to `Option<&str>` lets that case reach `Card::new("")`, which raises the same `edit::invalid_kind_name` at the same `cards[<i>]` path, so the refusal comes from the constructor that owns the kind rule rather than from a hand-built copy.

No API, wire or diagnostic change; the other kind inputs are untouched because the slot guard compares `Option<&str>` either way. The two existing values tests pin the behavior, and the one covering this case gains the error-variant assertion it was missing (it passes on both sides, as a refactor pin should).

Closes #1524

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_