### PR TITLE
refactor(core)!: mark ParseOutputFormatError non_exhaustive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,10 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- refactor(core)!: **`ParseOutputFormatError` is `#[non_exhaustive]` and gains
+  `new`.** It was the one `pub`-field type in core's root modules without the
+  attribute COMPATIBILITY.md's struct rule asks for. Its field stays readable;
+  an out-of-crate struct literal becomes `ParseOutputFormatError::new(input)`.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -44,9 +44,17 @@ impl std::fmt::Display for OutputFormat {
     }
 }
 
-/// Error returned when a string does not name an [`OutputFormat`].
+/// Error returned when a string does not name an [`OutputFormat`]. The field
+/// is the input as parsed, lowercased.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub struct ParseOutputFormatError(pub String);
+
+impl ParseOutputFormatError {
+    pub fn new(input: impl Into<String>) -> Self {
+        Self(input.into())
+    }
+}
 
 impl std::fmt::Display for ParseOutputFormatError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -70,7 +78,7 @@ impl std::str::FromStr for OutputFormat {
             "pdf" => Ok(OutputFormat::Pdf),
             "svg" => Ok(OutputFormat::Svg),
             "png" => Ok(OutputFormat::Png),
-            other => Err(ParseOutputFormatError(other.to_string())),
+            other => Err(ParseOutputFormatError::new(other)),
         }
     }
 }
@@ -92,6 +100,14 @@ mod tests {
         }
     }
 
+    #[test]
+    fn unknown_output_format_names_the_input_lowercased() {
+        assert_eq!(
+            OutputFormat::from_str("Docx"),
+            Err(ParseOutputFormatError::new("docx"))
+        );
+        assert_eq!(ParseOutputFormatError::new("docx").0, "docx");
+    }
 }
 
 /// An artifact produced by rendering.


### PR DESCRIPTION
`ParseOutputFormatError(pub String)` was the one `pub`-field type in core's root modules without `#[non_exhaustive]`, which COMPATIBILITY.md's struct rule asks for on every such type so a field can land later without a semver-major. It is constructed once (in `OutputFormat::from_str`) and matched nowhere in the workspace.

The attribute goes on, with `new` beside it as the rule prescribes for a struct another crate may build. The field stays readable out of crate; only an out-of-crate struct literal stops compiling, which is why the CHANGELOG entry carries `!`. A small test pins that an unknown format is reported lowercased through `new`.

Closes #1523

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_