### PR TITLE
fix(pdf): refuse a /Size past i32::MAX instead of panicking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(pdf): **a base PDF whose trailer `/Size` sits above `i32::MAX` is refused
+  rather than panicking mid-stamp.** `alloc_id` bounded only `u32` overflow, so
+  a `/Size` in `2^31 ..= 2^32-2` handed out ids that cast to a negative `i32`
+  and pdf-writer's `Ref::new` panicked ("indirect reference out of valid
+  range") — a crafted `form.pdf` opened cleanly and then took down the process,
+  and with it a WASM module. `alloc_id` stops at `i32::MAX`, and every id that
+  becomes a reference goes through a checked `to_ref`, which also covers the
+  base page ids that never pass through `alloc_id`. The refusal carries the
+  existing `pdf::write` id-space error.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -23,7 +23,7 @@ use quillmark_core::RenderedRegion;
 use crate::error::PdfError;
 use crate::reader::{err, find_dict_value, parse_indirect_ref, ObjectIndex, UpdatedObject};
 use crate::update::PdfUpdate;
-use crate::writer::{alloc_id, append_refs_to_array_key, dict_object, OnNonArray};
+use crate::writer::{alloc_id, append_refs_to_array_key, dict_object, to_ref, OnNonArray};
 use crate::{FieldSpec, FieldType, FormFont, TextAlign};
 
 const CODE_PARSE: &str = "pdf::stamp_parse";
@@ -164,17 +164,17 @@ pub fn stamp(
         let mut widgets_by_page: Vec<Vec<u32>> = vec![Vec::new(); page_count];
         for (spec, &wid) in fields.iter().zip(&widget_ids) {
             widgets_by_page[spec.page].push(wid);
-            let page_ref = Ref::new(pages[spec.page].id as i32);
+            let page_ref = to_ref(pages[spec.page].id)?;
             up.objects.push(UpdatedObject {
                 id: wid,
-                bytes: write_widget_object(spec, Ref::new(wid as i32), page_ref),
+                bytes: write_widget_object(spec, to_ref(wid)?, page_ref),
             });
         }
 
         for (font, &fid) in fonts.iter().zip(&font_ids) {
             let mut fchunk = Chunk::new();
             fchunk
-                .type1_font(Ref::new(fid as i32))
+                .type1_font(to_ref(fid)?)
                 .base_font(Name(font.base_font()));
             up.objects.push(UpdatedObject {
                 id: fid,
@@ -185,12 +185,14 @@ pub fn stamp(
         let has_signature = fields
             .iter()
             .any(|f| matches!(f.field_type, FieldType::Signature));
+        let field_refs: Vec<Ref> = widget_ids
+            .iter()
+            .map(|&id| to_ref(id))
+            .collect::<Result<_, _>>()?;
         let mut achunk = Chunk::new();
         {
-            let mut form: Form<'_> = achunk
-                .indirect(Ref::new(acroform_id as i32))
-                .start::<Form>();
-            form.fields(widget_ids.iter().map(|&id| Ref::new(id as i32)));
+            let mut form: Form<'_> = achunk.indirect(to_ref(acroform_id)?).start::<Form>();
+            form.fields(field_refs);
             if has_signature {
                 form.sig_flags(SigFlags::SIGNATURES_EXIST);
             }
@@ -201,7 +203,7 @@ pub fn stamp(
                 let mut dr = form.insert(Name(b"DR")).dict();
                 let mut font_dict = dr.insert(Name(b"Font")).dict();
                 for (font, &fid) in fonts.iter().zip(&font_ids) {
-                    font_dict.pair(Name(font.resource_name().as_bytes()), Ref::new(fid as i32));
+                    font_dict.pair(Name(font.resource_name().as_bytes()), to_ref(fid)?);
                 }
             }
             form.finish();

--- a/crates/quillmark-pdf/src/update.rs
+++ b/crates/quillmark-pdf/src/update.rs
@@ -52,8 +52,8 @@ impl PdfUpdate {
         let info_ref = find_dict_value(trailer, "Info").and_then(parse_indirect_ref);
 
         // One counter seeded at `/Size`, so created ids never collide with the
-        // base's. `alloc_id` checks it: a malformed near-`u32::MAX` `/Size` errors
-        // instead of wrapping into a colliding id.
+        // base's. `alloc_id` bounds it: a malformed large `/Size` errors instead
+        // of handing out an id that collides or that no reference admits.
         let mut next_id = size;
         let mut objects: Vec<UpdatedObject> = Vec::new();
         let mut extra_info_ref = None;

--- a/crates/quillmark-pdf/src/writer.rs
+++ b/crates/quillmark-pdf/src/writer.rs
@@ -2,10 +2,16 @@
 //! the two emit identical bytes for an object, a text string, and the `/Info`
 //! `/Producer` stamp.
 
+use pdf_writer::Ref;
+
 use crate::error::PdfError;
 use crate::reader::{err, find_dict_value, splice_dict_value, ObjectIndex, UpdatedObject};
 
 const CODE_PARSE: &str = "pdf::write";
+
+/// The largest object id a PDF reference carries here: `pdf_writer::Ref` holds
+/// an `i32` and panics outside `1 ..= i32::MAX`.
+const MAX_ID: u32 = i32::MAX as u32;
 
 /// Serialize one indirect object from its inner dict bytes:
 /// `<id> 0 obj\n<< <inner> >>\nendobj\n`.
@@ -16,17 +22,31 @@ pub fn dict_object(id: u32, inner: &[u8]) -> UpdatedObject {
     UpdatedObject { id, bytes }
 }
 
-/// Hand out the next object id from `next`, checked so a malformed
-/// near-`u32::MAX` `/Size` errors instead of wrapping into a colliding id.
+/// Hand out the next object id from `next`, bounded at `i32::MAX` so a
+/// malformed large `/Size` errors instead of wrapping into a colliding id or
+/// handing out one no reference admits.
 pub fn alloc_id(next: &mut u32) -> Result<u32, PdfError> {
     let id = *next;
-    *next = id.checked_add(1).ok_or_else(|| {
-        err(
+    if id > MAX_ID {
+        return Err(err(
             CODE_PARSE,
             "PDF object id space exhausted (/Size too large)",
-        )
-    })?;
+        ));
+    }
+    *next = id + 1;
     Ok(id)
+}
+
+/// `id` as a reference, refusing what [`Ref::new`] panics on. Base object ids
+/// reach this straight from the file, so the bound is the reader's to enforce.
+pub(crate) fn to_ref(id: u32) -> Result<Ref, PdfError> {
+    if id == 0 || id > MAX_ID {
+        return Err(err(
+            CODE_PARSE,
+            format!("PDF object id {id} is outside the writable id space 1..={MAX_ID}"),
+        ));
+    }
+    Ok(Ref::new(id as i32))
 }
 
 /// Escape bytes for a PDF literal string `( … )`: `(`, `)`, `\` → `\x`.
@@ -211,6 +231,25 @@ pub fn winansi_encode(s: &str) -> Vec<u8> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn alloc_id_stops_at_the_reference_id_space() {
+        let mut next = MAX_ID;
+        assert_eq!(alloc_id(&mut next).unwrap(), MAX_ID);
+        let err = alloc_id(&mut next).unwrap_err();
+        assert_eq!(err.code, CODE_PARSE);
+        assert!(err.message.contains("id space"), "{}", err.message);
+    }
+
+    #[test]
+    fn to_ref_rejects_ids_no_reference_admits() {
+        // Base object ids skip `alloc_id`, so these reach `to_ref` unbounded.
+        assert!(to_ref(0).is_err());
+        assert!(to_ref(MAX_ID + 1).is_err());
+        assert!(to_ref(u32::MAX).is_err());
+        assert_eq!(to_ref(1).unwrap(), Ref::new(1));
+        assert_eq!(to_ref(MAX_ID).unwrap(), Ref::new(i32::MAX));
+    }
 
     #[test]
     fn winansi_latin1_and_cp1252_punctuation() {

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -276,8 +276,9 @@ fn rotated_page_rejected_cleanly() {
     assert_eq!(err.code, "pdf::rotated_page");
 }
 
-#[test]
-fn implausible_size_errors_cleanly_without_panic() {
+/// A one-page base whose trailer `/Size` reads `size`. The xref table precedes
+/// the trailer, so the length change leaves every stored offset intact.
+fn base_with_spliced_size(size: &str) -> Vec<u8> {
     let base = build_base_pdf(1);
     // Byte-level splice: the PDF binary-marker comment is not valid UTF-8.
     let needle = b"/Size 5";
@@ -286,14 +287,39 @@ fn implausible_size_errors_cleanly_without_panic() {
         .position(|w| w == needle)
         .expect("trailer /Size");
     let mut tampered = base[..at].to_vec();
-    tampered.extend_from_slice(b"/Size 4294967295");
+    tampered.extend_from_slice(format!("/Size {size}").as_bytes());
     tampered.extend_from_slice(&base[at + needle.len()..]);
+    tampered
+}
+
+#[test]
+fn implausible_size_errors_cleanly_without_panic() {
     let err = stamp(
-        tampered,
+        base_with_spliced_size("4294967295"),
         &[],
         &StampOptions::default().with_producer("Quillmark test".into()),
     )
     .expect_err("near-u32::MAX /Size should error");
+    assert!(err.message.contains("id space"), "{}", err.message);
+}
+
+#[test]
+fn size_past_i32_max_errors_cleanly_without_panic() {
+    // Ids seeded from here fit a `u32` but not the `i32` a reference holds.
+    let fields = vec![text_field(
+        "FullName",
+        "full_name",
+        0,
+        [180.0, 700.0, 520.0, 720.0],
+        "Ada",
+    )];
+    let err = stamp(
+        base_with_spliced_size("2147483648"),
+        &fields,
+        &StampOptions::default(),
+    )
+    .expect_err("/Size past i32::MAX should error");
+    assert_eq!(err.code, "pdf::write");
     assert!(err.message.contains("id space"), "{}", err.message);
 }
 


### PR DESCRIPTION
A trailer `/Size` in `2^31 ..= 2^32-2` made `alloc_id` hand out object ids that `as i32` turns negative, and pdf-writer's `Ref::new` panics on those. A crafted `form.pdf` opened fine and then panicked inside `stamp`, taking the process (or a WASM module) with it.

`alloc_id` now stops at `i32::MAX`, and a checked `to_ref` helper in `writer.rs` carries every id that becomes a `Ref`, which covers the base page ids that never pass through `alloc_id`. Both refusals reuse the existing `pdf::write` id-space error, so no new diagnostic code appears. The pdfform flatten path hand-formats its ids and has no such cast, so it needed no change. The new integration test splices `/Size 2147483648` into a one-page base and was seen panicking on the unfixed code.

Closes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_