### PR TITLE
fix(pdf): skip hex strings when scanning for a dict's end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(pdf): **a dict ending in a hex string parses to its real `>>`.** The
+  scanner stepped over literal strings and `%`-comments but read a hex string
+  as ordinary bytes, so the string's own `>` abutting the dict's `>>` closed
+  the dict one byte early: `<< /T <41>>>` read as ` /T <41`, every
+  `find_dict_value` on that inner swallowed the rest as one hex string, and a
+  `/Producer` stamp rewrote the `/Info` with an unterminated `<…` — a title
+  lost to any reader. `skip_string_or_comment` steps a `<` that no `<` follows
+  to just past its `>`, which the dict, array and `endobj` scans all inherit.
+  The trigger is real: pdf-writer's compact mode, which krilla and typst-pdf
+  use, writes a non-ASCII `/Title` or `/Author` exactly this way.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -174,9 +174,9 @@ pub(crate) fn append_incremental_update(
 /// A header is `<id> <generation> obj` at a token boundary, so `19 0 obj` is not
 /// found inside `519 0 obj`, at any generation (re-saved PDFs carry non-zero
 /// ones). A later occurrence overwrites an earlier one, so a lookup answers with
-/// the live copy. Literal strings, `%`-comments and stream bodies are skipped, so
-/// header bytes inside a string value or inside stream data cannot shadow the
-/// real object.
+/// the live copy. Strings, `%`-comments and stream bodies are skipped, so header
+/// bytes inside a string value or inside stream data cannot shadow the real
+/// object.
 pub struct ObjectIndex<'a> {
     pdf: &'a [u8],
     starts: HashMap<u32, usize>,
@@ -275,10 +275,9 @@ fn obj_header_id(rest: &[u8]) -> Option<u32> {
     std::str::from_utf8(&rest[..digits]).ok()?.parse().ok()
 }
 
-/// The index just past the `endobj` closing the body at `from`. Literal
-/// `( … )` strings, `%`-comments and stream bodies are skipped so those bytes
-/// inside a string value, a comment or stream data cannot truncate the object
-/// early.
+/// The index just past the `endobj` closing the body at `from`. Strings,
+/// `%`-comments and stream bodies are skipped so those bytes inside a string
+/// value, a comment or stream data cannot truncate the object early.
 fn find_endobj_end(pdf: &[u8], from: usize) -> Option<usize> {
     let needle = b"endobj";
     let mut i = from;
@@ -384,13 +383,16 @@ fn skip_ws_and_comments(b: &[u8], start: usize) -> usize {
     }
 }
 
-/// If `b[i]` opens a literal string or a `%`-comment, the index just past it, so
-/// a scanner steps over raw `<<`/`>>`/`[`/`]`/`endobj` bytes without reading them
-/// as structure. Hex strings need no handling: a well-formed one holds only hex
-/// digits. `None` when `b[i]` is neither, and the caller advances one byte.
+/// If `b[i]` opens a string — literal or hex — or a `%`-comment, the index just
+/// past it, so a scanner steps over raw `<<`/`>>`/`[`/`]`/`endobj` bytes without
+/// reading them as structure. A hex string's closing `>` is one of those:
+/// against the enclosing dict's `>>` it forms a `>>` that is not the dict's. A
+/// `<` followed by `<` opens a dict, not a hex string. `None` when `b[i]` opens
+/// none of them, and the caller advances one byte.
 fn skip_string_or_comment(b: &[u8], i: usize) -> Option<usize> {
     match b.get(i)? {
         b'(' => Some(skip_pdf_string(b, i)),
+        b'<' if b.get(i + 1) != Some(&b'<') => Some(skip_pdf_hex_string(b, i)),
         b'%' => {
             let mut j = i + 1;
             while j < b.len() && b[j] != b'\n' && b[j] != b'\r' {
@@ -576,10 +578,10 @@ pub fn extract_outer_dict(obj_bytes: &[u8]) -> Option<&[u8]> {
     Some(&obj_bytes[open + 2..close])
 }
 
-/// The index of the `>>` matching the `<<` at `open`. Literal strings and
-/// `%`-comments are skipped: either can carry `<<` / `>>` as raw bytes that
-/// would otherwise skew the nesting depth. `Err` carries the index the scan ran
-/// out at, for a caller that reads an unbalanced dict leniently.
+/// The index of the `>>` matching the `<<` at `open`. Strings and `%`-comments
+/// are skipped: any of them can carry `<<` / `>>` as raw bytes that would
+/// otherwise skew the nesting depth. `Err` carries the index the scan ran out
+/// at, for a caller that reads an unbalanced dict leniently.
 fn dict_end(b: &[u8], open: usize) -> Result<usize, usize> {
     let mut depth = 0i32;
     let mut i = open;
@@ -878,6 +880,18 @@ mod tests {
         let dict = extract_outer_dict(obj).expect("dict parses");
         let mb = find_dict_value(dict, "MediaBox").expect("/MediaBox survives the comment");
         assert_eq!(parse_rect_array(mb), Some([0.0, 0.0, 1.0, 2.0]));
+    }
+
+    #[test]
+    fn outer_dict_ends_after_a_trailing_hex_string() {
+        for (obj, inner) in [
+            (&b"<< /T <41>>>"[..], &b" /T <41>"[..]),
+            (b"<< /T <>>>", b" /T <>"),
+            (b"<< /T (a)>>", b" /T (a)"),
+            (b"<< /D << /T <41>>>>>", b" /D << /T <41>>>"),
+        ] {
+            assert_eq!(extract_outer_dict(obj), Some(inner));
+        }
     }
 
     #[test]

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -3,7 +3,7 @@
 //! values land in `/V` and the viewer synthesizes appearances.
 
 use pdf_writer::writers::Form;
-use pdf_writer::{Content, Finish, Name, Pdf, Rect, Ref};
+use pdf_writer::{Content, Finish, Name, Pdf, Rect, Ref, Settings, TextStr};
 use quillmark_pdf::{regions_of, stamp, FieldSpec, FieldType, StampOptions};
 
 /// An `n`-page US-Letter base satisfying the spine's input contract.
@@ -233,6 +233,69 @@ fn producer_only_no_fields_stamps_info_producer() {
     assert_eq!(
         info.get(b"Producer").unwrap().as_str().unwrap(),
         b"Quillmark test"
+    );
+}
+
+/// A one-page base whose compact `/Info` ends in a hex-encoded `/Title` —
+/// what pdf-writer's compact mode emits for a non-ASCII title written last.
+fn build_base_with_hex_title_info(title: &str) -> Vec<u8> {
+    let mut pdf = Pdf::with_settings(Settings { pretty: false });
+    let catalog_id = Ref::new(1);
+    let page_tree_id = Ref::new(2);
+    let page_id = Ref::new(3);
+    let content_id = Ref::new(4);
+    let info_id = Ref::new(5);
+    let rect = Rect::new(0.0, 0.0, 612.0, 792.0);
+    pdf.catalog(catalog_id).pages(page_tree_id);
+    {
+        let mut pages = pdf.pages(page_tree_id);
+        pages.kids([page_id]).count(1).media_box(rect);
+    }
+    pdf.page(page_id)
+        .parent(page_tree_id)
+        .media_box(rect)
+        .contents(content_id);
+    let mut content = Content::new();
+    content.set_line_width(1.0);
+    content.rect(72.0, 700.0, 200.0, 20.0);
+    content.stroke();
+    pdf.stream(content_id, &content.finish());
+    pdf.document_info(info_id)
+        .producer(TextStr("Base"))
+        .title(TextStr(title));
+    pdf.finish()
+}
+
+#[test]
+fn producer_stamp_preserves_a_trailing_hex_title() {
+    let title = "Résumé";
+    let result = stamp(
+        build_base_with_hex_title_info(title),
+        &[],
+        &StampOptions::default().with_producer("Quillmark test".into()),
+    )
+    .expect("stamp ok");
+
+    let doc = lopdf::Document::load_mem(&result).expect("lopdf reparse");
+    let info_ref = doc
+        .trailer
+        .get(b"Info")
+        .expect("trailer /Info")
+        .as_reference()
+        .expect("/Info indirect");
+    let info = doc.get_object(info_ref).unwrap().as_dict().unwrap();
+    assert_eq!(
+        info.get(b"Producer").unwrap().as_str().unwrap(),
+        b"Quillmark test"
+    );
+    let mut utf16be = vec![0xFE, 0xFF];
+    for unit in title.encode_utf16() {
+        utf16be.extend_from_slice(&unit.to_be_bytes());
+    }
+    assert_eq!(
+        info.get(b"Title").unwrap().as_str().unwrap(),
+        utf16be.as_slice(),
+        "the hex /Title survives the /Producer rewrite"
     );
 }
 


### PR DESCRIPTION
A hex string closing a dict abuts the dict's own `>>`, and the reader's scan took the `>>` starting at the string's `>`, ending the dict one byte early. Everything downstream inherited the truncation: `find_dict_value` read the rest of the dict as one unterminated hex string, and stamping a `/Producer` emitted an `/Info` that lopdf cannot load at all, a `/Title` silently lost.

The fix folds the case into `skip_string_or_comment`, so a `<` that no `<` follows is skipped to past its `>`; `<<` still opens a dict, which is exact because `<` is not a hex digit. The array and `endobj` scans inherit the same step. The trigger is ordinary rather than crafted: pdf-writer's compact mode, which krilla and typst-pdf use, writes a non-ASCII `/Title` or `/Author` exactly this way. A reader unit test and a stamp integration test were both seen failing before the fix.

Closes #1501

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_