### PR TITLE
fix(pdf): refuse a /Rotate that is not a direct integer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(pdf): **a `/Rotate` the reader cannot read as an integer refuses the
+  stamp.** `assert_unrotated_pages` parsed the raw value and treated a failure
+  as an absence, so `/Rotate 7 0 R` — legal for any dict value — climbed past
+  the page and fell to the default zero, stamping every widget in unrotated
+  user space onto a page the viewer turns. The first *present* value along the
+  ancestor chain now binds: a direct integer is checked as before
+  (`pdf::rotated_page` when it is not a multiple of 360), anything else is
+  `pdf::parse`, matching how `/MediaBox` treats an unresolvable value.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -722,17 +722,33 @@ fn root_pages_id(idx: &ObjectIndex, catalog_id: u32) -> Result<u32, PdfError> {
 /// Reject a page with a non-zero `/Rotate`, its own value or the one inherited
 /// from its nearest ancestor `/Pages` node. The stamp and flatten paths write
 /// geometry in unrotated user space and do not compensate, so a rotated base
-/// page would display every widget away from its intended box.
+/// page would display every widget away from its intended box. The first
+/// *present* value binds, and one that is not a direct integer — an indirect
+/// reference, say — is an error rather than an absence falling to the default
+/// zero.
 pub(crate) fn assert_unrotated_pages<'p>(
     idx: &ObjectIndex,
     pages: impl IntoIterator<Item = &'p Page>,
 ) -> Result<(), PdfError> {
-    let parse_rotate =
-        |raw: &[u8]| -> Option<i64> { std::str::from_utf8(raw.trim_ascii()).ok()?.parse().ok() };
     for page in pages {
-        let rotate = page
-            .inherited_attribute(idx, "Rotate", parse_rotate)
-            .unwrap_or(0);
+        let Some(raw) =
+            page.inherited_attribute(idx, "Rotate", |raw| Some(raw.trim_ascii().to_vec()))
+        else {
+            continue;
+        };
+        let rotate: i64 = std::str::from_utf8(&raw)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| {
+                err(
+                    CODE_PARSE,
+                    format!(
+                        "page object {} has /Rotate {}, which is not an integer",
+                        page.id,
+                        String::from_utf8_lossy(&raw)
+                    ),
+                )
+            })?;
         if rotate.rem_euclid(360) != 0 {
             return Err(err(
                 "pdf::rotated_page",

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -276,6 +276,63 @@ fn rotated_page_rejected_cleanly() {
     assert_eq!(err.code, "pdf::rotated_page");
 }
 
+/// A one-page base whose page carries `/Rotate` as the indirect reference
+/// `5 0 R`, resolving to `90`, or no `/Rotate` at all.
+fn build_base_with_indirect_rotate(rotate: bool) -> Vec<u8> {
+    let mut pdf = Pdf::new();
+    let catalog_id = Ref::new(1);
+    let page_tree_id = Ref::new(2);
+    let page_id = Ref::new(3);
+    let content_id = Ref::new(4);
+    let rotate_id = Ref::new(5);
+    let rect = Rect::new(0.0, 0.0, 612.0, 792.0);
+    pdf.catalog(catalog_id).pages(page_tree_id);
+    {
+        let mut pages = pdf.pages(page_tree_id);
+        pages.kids([page_id]).count(1).media_box(rect);
+    }
+    {
+        let mut page = pdf.page(page_id);
+        page.parent(page_tree_id).media_box(rect).contents(content_id);
+        if rotate {
+            page.pair(Name(b"Rotate"), rotate_id);
+        }
+    }
+    let mut content = Content::new();
+    content.set_line_width(1.0);
+    content.rect(72.0, 700.0, 200.0, 20.0);
+    content.stroke();
+    pdf.stream(content_id, &content.finish());
+    pdf.indirect(rotate_id).primitive(90);
+    pdf.finish()
+}
+
+#[test]
+fn indirect_rotate_rejected_cleanly() {
+    let fields = vec![text_field(
+        "FullName",
+        "full_name",
+        0,
+        [180.0, 700.0, 520.0, 720.0],
+        "Ada",
+    )];
+    let err = stamp(
+        build_base_with_indirect_rotate(true),
+        &fields,
+        &StampOptions::default(),
+    )
+    .expect_err("an indirect /Rotate is not a resolvable rotation");
+    assert_eq!(err.code, "pdf::parse");
+    assert!(err.message.contains("/Rotate"), "{}", err.message);
+
+    stamp(
+        build_base_with_indirect_rotate(false),
+        &fields,
+        &StampOptions::default(),
+    )
+    .expect("the same base without the /Rotate stamps");
+}
+
 #[test]
 fn implausible_size_errors_cleanly_without_panic() {
     let base = build_base_pdf(1);

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -74,7 +74,8 @@ incremental-update appender that splices a fresh `/AcroForm` (and `/Info`
 `/Producer` stamp) onto a base PDF. Deliberately small: it hard-errors on
 out-of-contract input (xref streams, encryption, indirect `/Annots`,
 non-zero-generation base objects, a base that already carries an `/AcroForm`,
-a non-finite widget `/Rect`) rather than parsing the full format.
+a non-finite widget `/Rect`, a page `/Rotate` it cannot resolve to zero) rather
+than parsing the full format.
 
 ### `bindings/*`
 


### PR DESCRIPTION
An indirect `/Rotate` slipped through the rotated-page refusal. `assert_unrotated_pages` parsed the raw value inside the `inherited_attribute` closure, and that helper reads `None` as "keep climbing", so `/Rotate 5 0 R` (legal for any dict value) was indistinguishable from no `/Rotate` at all and the page defaulted to unrotated, placing every stamped widget a quarter turn off.

The fix takes the first *present* value along the ancestor chain and parses it at the call site, raising `pdf::parse` when it is not a direct integer, which is how `/MediaBox` already handles the same shape. Direct values are unaffected: `0` passes, non-zero still refuses with `pdf::rotated_page`. Note this adds a refusal path: a base with an indirect `/Rotate 0` now fails where it previously stamped. ARCHITECTURE.md's out-of-contract list gains the rotation clause. The new test was seen failing (base accepted) before the fix.

Closes #1504

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_