### PR TITLE
fix(core): break a field_at tie toward the later region

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(core): **the default `field_at` hands a tie to the later-painted
+  placement.** It ranked `regions()` with `min_by`, which keeps the first of
+  equal distances, so two placements on one rect resolved to the one
+  underneath — against the documented contract and against the Typst backend,
+  which overrides `field_at` with later-wins. The default now walks `regions()`
+  in reverse, so a pdfform quill whose widgets overlap answers with the
+  last-stamped one. A backend that mixes widget and content regions through the
+  default overrides `field_at` to hand a widget the tie, as Typst does.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/backends/pdfform/tests/sample_form.rs
+++ b/crates/backends/pdfform/tests/sample_form.rs
@@ -3,7 +3,7 @@
 //! values land in `/V`; appearance synthesis is the viewer's job.
 
 use lopdf::Document as PdfDoc;
-use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
+use quillmark::{Document, FileTreeNode, OutputFormat, Quill, Quillmark, RenderOptions};
 
 const FILLED: &str = "~~~\n\
 $quill: sample_form\n\
@@ -239,5 +239,57 @@ fn apply_rebinds_values_and_reports_dirty_pages() {
     assert_eq!(
         decode_pdf_text(name.get(b"V").unwrap().as_str().unwrap()),
         "Grace Hopper"
+    );
+}
+
+/// The fixture's schema with two bound widgets stacked on one rect, so every
+/// point inside it sits the same distance from both.
+const STACKED_FORM_JSON: &str = r#"{
+  "schema": "quillmark/form@0.2.0",
+  "fields": [
+    {
+      "name": "Under",
+      "schema_field": "full_name",
+      "page": 0,
+      "rect": { "x": 180, "y": 100, "w": 340, "h": 20 }
+    },
+    {
+      "name": "Over",
+      "schema_field": "comments",
+      "page": 0,
+      "rect": { "x": 180, "y": 100, "w": 340, "h": 20 }
+    }
+  ]
+}"#;
+
+#[test]
+fn field_at_tie_takes_the_later_stamped_widget() {
+    let mut tree = quillmark::tree_from_path(quillmark_fixtures::quills_path("sample_form"))
+        .expect("load sample_form tree");
+    tree.insert(
+        "form.json",
+        FileTreeNode::File {
+            contents: STACKED_FORM_JSON.as_bytes().to_vec(),
+        },
+    )
+    .expect("replace form.json");
+    let quill = Quill::from_tree(tree).expect("load patched quill");
+    let doc = Document::parse(FILLED).expect("parse markdown").document;
+    let session = Quillmark::new().open(&quill, &doc).expect("open ok");
+
+    let regions = session.regions();
+    assert_eq!(
+        regions.iter().map(|r| r.field.as_str()).collect::<Vec<_>>(),
+        ["full_name", "comments"],
+        "regions follow `form.json` order, which is stamping order"
+    );
+    assert_eq!(regions[0].rect, regions[1].rect);
+
+    let [x0, y0, x1, y1] = regions[0].rect;
+    assert_eq!(
+        session
+            .field_at(regions[0].page, (x0 + x1) / 2.0, (y0 + y1) / 2.0, 0.0)
+            .as_deref(),
+        Some("comments")
     );
 }

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -105,9 +105,15 @@ pub trait SessionHandle: Send + Sync + 'static {
     /// for a backend whose regions enumerate every placement. A backend that
     /// emits first-placement-only content must override this with a real
     /// document hit-test, or clicks on unenumerated placements dead-end.
+    ///
+    /// A tie goes to the last of [`regions`](Self::regions), the later-painted
+    /// placement. That order lists widgets before content, so a backend placing
+    /// both lanes overrides this to hand a widget the tie, as the Typst backend
+    /// does.
     fn field_at(&self, page: usize, x: f32, y: f32, tol: f32) -> Option<String> {
         self.regions()
             .into_iter()
+            .rev()
             .filter_map(|r| Some((r.distance(page, x, y)?, r)))
             .filter(|(d, _)| *d <= tol)
             .min_by(|(a, _), (b, _)| a.total_cmp(b))
@@ -459,6 +465,31 @@ main:
                 span: Some([pos, pos]),
             })
         }
+    }
+
+    /// Two regions on one rect, so every hit inside it is a tie.
+    struct TiedRegionHandle;
+    impl SessionHandle for TiedRegionHandle {
+        fn render(&self, _: &RenderOptions) -> Result<RenderResult, RenderError> {
+            unimplemented!("render is not exercised by geometry tests")
+        }
+        fn page_count(&self) -> usize {
+            1
+        }
+        fn regions(&self) -> Vec<RenderedRegion> {
+            ["under", "over"]
+                .into_iter()
+                .map(|field| RenderedRegion::new(field.to_string(), 0, [0.0, 0.0, 10.0, 10.0]))
+                .collect()
+        }
+    }
+
+    #[test]
+    fn field_at_tie_takes_the_later_region() {
+        let session = LiveSession::new(Box::new(TiedRegionHandle), config());
+        assert_eq!(session.field_at(0, 5.0, 5.0, 0.0).as_deref(), Some("over"));
+        // Outside both rects by the same gap: the tolerant path ties too.
+        assert_eq!(session.field_at(0, 14.0, 5.0, 8.0).as_deref(), Some("over"));
     }
 
     #[test]


### PR DESCRIPTION
The core default `SessionHandle::field_at` used `min_by` over `regions()`, which keeps the first of equal distances, so two placements on one rect resolved to the one painted underneath, against PREVIEW.md's "On a tie the later-painted wins" and against the Typst backend, which overrides `field_at` with later-wins. pdfform overrides only `regions` and so inherited the wrong answer: two overlapping widgets resolved to the first one in `form.json`.

The default now iterates `regions()` in reverse before `min_by`. Because that order lists widget regions before content, the rustdoc requires a backend placing both lanes to override `field_at` and hand a widget the tie, as Typst does; `regions()` ordering is unchanged, and PREVIEW.md already says what the code now does. A core unit test and a pdfform acceptance test pin the tie direction; both were seen failing before the change.

Closes #1475

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_