### PR TITLE
fix(typst): resolve quill assets from content images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(typst): **an image in a content field resolves a quill asset.**
+  `![logo](assets/logo.svg)` in a `richtext` field lowers to `#image(..)`
+  inside the helper package's `lib.typ`, and Typst resolves an image path
+  against the root of the file holding the call, never leaving it; assets sat
+  under the project root alone, so the one thing an image island lowers to
+  failed the render outright. `QuillWorld` registers each `assets/` file under
+  the helper package's file id as well, one `Bytes` behind both ids, and a
+  content image names an asset by its quill-root path, rooted or relative, the
+  path a plate names it by.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/backends/typst/src/world.rs
+++ b/crates/backends/typst/src/world.rs
@@ -143,18 +143,22 @@ impl QuillWorld {
         Ok((world, windows))
     }
 
-    /// A [`FileId`] for `rel` inside the virtual `@local/quillmark-helper`
-    /// package (e.g. `lib.typ`).
-    pub(crate) fn helper_fid(rel: &str) -> FileId {
-        let spec = PackageSpec {
+    /// The spec of the virtual `@local/quillmark-helper` package.
+    fn helper_spec() -> PackageSpec {
+        PackageSpec {
             namespace: helper::HELPER_NAMESPACE.into(),
             name: helper::HELPER_NAME.into(),
             version: helper::HELPER_VERSION
                 .parse()
                 .expect("Invalid helper version"),
-        };
+        }
+    }
+
+    /// A [`FileId`] for `rel` inside the virtual `@local/quillmark-helper`
+    /// package (e.g. `lib.typ`).
+    pub(crate) fn helper_fid(rel: &str) -> FileId {
         file_id(
-            Some(spec),
+            Some(Self::helper_spec()),
             VirtualPath::new(rel).expect("valid helper vpath"),
         )
     }
@@ -228,7 +232,11 @@ impl QuillWorld {
         Ok(font_data)
     }
 
-    /// Loads assets from quill's in-memory file system.
+    /// Loads assets from quill's in-memory file system. Each asset lands under
+    /// its project path *and* under the same path inside the helper package:
+    /// Typst resolves an `image` path against the root of the file holding the
+    /// call and never leaves it, and a content block's `#image(..)` is emitted
+    /// into the helper's `lib.typ`. One `Bytes` backs both ids.
     fn load_assets_from_quill(
         source: &Quill,
         binaries: &mut HashMap<FileId, Bytes>,
@@ -245,8 +253,12 @@ impl QuillWorld {
                         continue;
                     }
                 };
-                let id = file_id(None, virtual_path);
-                binaries.insert(id, Bytes::new(contents.to_vec()));
+                let bytes = Bytes::new(contents.to_vec());
+                binaries.insert(
+                    file_id(Some(Self::helper_spec()), virtual_path.clone()),
+                    bytes.clone(),
+                );
+                binaries.insert(file_id(None, virtual_path), bytes);
             }
         }
 

--- a/crates/backends/typst/tests/content_image_asset.rs
+++ b/crates/backends/typst/tests/content_image_asset.rs
@@ -1,0 +1,76 @@
+//! An image island lowers to `#image(..)` inside the helper package's
+//! `lib.typ`, and Typst resolves an image path against the root of the file
+//! holding the call. A quill asset is therefore reachable from a content field
+//! under the path it has in the quill, rooted or relative, the same path the
+//! plate reaches it by.
+
+use quillmark_core::{Backend, FileTreeNode, OutputFormat, Quill, RenderOptions};
+use quillmark_typst::TypstBackend;
+use std::collections::HashMap;
+
+mod common;
+use common::content;
+
+const YAML: &str = r#"
+quill:
+  name: content_image_asset
+  version: 0.1.0
+  backend: typst
+  description: content image resolving a quill asset
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    body:
+      type: richtext
+      description: a paragraph carrying an image island
+"#;
+
+const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 300pt, height: 300pt, margin: 20pt)
+
+#image("assets/logo.svg", width: 16pt)
+
+#data.body
+"#;
+
+const LOGO: &[u8] = br#"<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+viewBox="0 0 16 16"><rect width="16" height="16" fill="blue"/></svg>"#;
+
+fn quill_with_logo() -> Quill {
+    let mut root = FileTreeNode::Directory {
+        files: HashMap::new(),
+    };
+    for (path, contents) in [
+        ("Quill.yaml", YAML.as_bytes()),
+        ("plate.typ", PLATE.as_bytes()),
+        ("assets/logo.svg", LOGO),
+    ] {
+        root.insert(
+            path,
+            FileTreeNode::File {
+                contents: contents.to_vec(),
+            },
+        )
+        .expect("insert quill file");
+    }
+    Quill::from_tree(root).expect("load quill")
+}
+
+#[test]
+fn a_content_image_resolves_a_quill_asset() {
+    let data = serde_json::json!({
+        "body": content("![logo](assets/logo.svg)\n\n![rooted](/assets/logo.svg)"),
+    });
+
+    let session = TypstBackend
+        .open(&quill_with_logo(), &data)
+        .expect("an image island naming a quill asset compiles");
+    assert_eq!(session.page_count(), 1);
+
+    let result = session
+        .render(&RenderOptions::default().with_output_format(OutputFormat::Pdf))
+        .expect("render ok");
+    assert!(!result.artifacts[0].bytes.is_empty(), "produced a PDF");
+}

--- a/docs/quills/typst-backend.md
+++ b/docs/quills/typst-backend.md
@@ -112,6 +112,20 @@ my-quill/
 
 Then reference them by family name (`#set text(font: "CustomFont")`).
 
+## Images
+
+Files under `assets/` are reachable by their path from the Quill root, from the plate and from a `richtext` field alike:
+
+```typst
+#image("assets/logo.svg", width: 2cm)
+```
+
+```markdown
+![logo](assets/logo.svg)
+```
+
+A leading slash (`/assets/logo.svg`) names the same file.
+
 ## Typesetting
 
 Plate authors style output with Typst's standard `#set` directives:

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -141,7 +141,10 @@ reads and the shape the WASM boundary pins:
   above); `aligns` is one `none | left | center | right` per column. Import
   normalizes to a single column count: header, every row, and `aligns` padded
   to the widest, so `columns:` and `align:` agree.
-- **`image`** → `{ url, alt }`; `alt` is the empty string when the source omits it.
+- **`image`** → `{ url, alt }`; `alt` is the empty string when the source omits
+  it. A `url` naming a quill file resolves against the quill root
+  (`assets/logo.svg`, or `/assets/logo.svg` for the same file), the path a plate
+  names it by.
 
 The `KnownIslandType` dispatch (`crates/content/src/island.rs`) owns these
 shapes engine-side; the WASM surface pins them as `TableProps` / `ImageProps` /


### PR DESCRIPTION
A markdown image in a `richtext` field could never reach a quill asset. Content lowers into the helper package's `lib.typ`, Typst resolves `#image("path")` against the root of the file holding the call and never leaves it, and assets were only ever registered under the project root. So `[logo](assets/logo.svg)` failed the render outright, as did the rooted `/assets/logo.svg`, while the plate next to it resolved the same path fine.

`QuillWorld` now registers each asset under the helper package's `FileId` too, sharing one refcounted `Bytes`, so no payload is duplicated. The new `content_image_asset` test pins both spellings plus a plate-side `#image` (the regression guard on the project-root half), and it is a hard compile error without the change. CONVERT.md's `image` island entry and the Typst backend docs now state the rule: a content image names a quill asset by its path from the quill root. One correction to the issue's closing note: `find_files("assets/*")` already matches nested paths (the glob `*` spans `/` under the default options), so nested asset dirs are not a gap.

Closes #1518

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_