### PR TITLE
fix(typst): put the form-field tag inside the widget box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(typst): **a `form-field` widget's rect is the box it prints in, whatever
+  the layout context.** The helper emitted its `<__qm_field__>` metadata beside
+  the box rather than inside it, and a tag's own position is the line's baseline
+  inline and the flow cursor's left edge in a block: an inline widget reported
+  a rect one box-height low, and one under `#align(center, ..)` or
+  `#align(right, ..)` reported the left margin. The tag rides in the box body,
+  whose origin is the box's top-left in every layout context, so
+  `session.regions()`, `fieldAt`, and the stamped AcroForm `/Rect` all land on
+  the widget. A plate that compensated for the offset shifts by that much.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/backends/typst/src/lib.typ.template
+++ b/crates/backends/typst/src/lib.typ.template
@@ -145,7 +145,11 @@
   let size-pt = if size == auto { none } else { abs-pt("size", size) }
   assert(size-pt == none or size-pt > 0,
     message: "form-field: size must be a positive length or auto, got " + repr(size))
-  [#metadata((
+  // The backend reads this tag's position as the widget's top-left, and only
+  // the box body's origin is that point in every layout context: a tag beside
+  // the box sits on the line's baseline inline, and at the flow cursor's left
+  // edge in a block.
+  box(width: width, height: height, stroke: none, fill: none)[#metadata((
     kind: "__qm_field__",
     name: name,
     field-type: type,
@@ -159,7 +163,6 @@
     size: size-pt,
     align: align,
   ))<__qm_field__>]
-  box(width: width, height: height, stroke: none, fill: none)
 }
 
 /// Emit an unsigned signature field. A thin wrapper over `form-field` with

--- a/crates/backends/typst/src/overlay/extract.rs
+++ b/crates/backends/typst/src/overlay/extract.rs
@@ -1,7 +1,9 @@
 //! Walk a compiled Typst document and return one `FieldPlacement` per
-//! `form-field` call. The helper emits a `<__qm_field__>`-labelled `metadata`
-//! followed by an invisible same-sized box. Metadata has zero size, so its
-//! `introspector.position()` equals the box's top-left: no frame walk.
+//! `form-field` call. The helper wraps a `<__qm_field__>`-labelled `metadata`
+//! inside an invisible box of the widget's size, where the tag is the body
+//! flow's first item and so lands at the body origin. That origin is the box's
+//! top-left in every layout context, so `introspector.position()` is the
+//! widget's top-left: no frame walk.
 
 use std::collections::HashMap;
 

--- a/crates/backends/typst/tests/widget_geometry.rs
+++ b/crates/backends/typst/tests/widget_geometry.rs
@@ -1,0 +1,129 @@
+//! Where a widget's region lands against where its box actually prints. Each
+//! case renders the widget page and a twin page identical but for a filled box
+//! of the widget's size in the widget's place, so the pixels that differ *are*
+//! the widget's box, measured rather than restated from the same metadata the
+//! region comes from.
+
+use quillmark_core::{Backend, LiveSession, RenderedRegion};
+use quillmark_typst::TypstBackend;
+
+mod common;
+use common::quill_with_plate as quill;
+
+const YAML: &str = r#"
+quill:
+  name: widget_geometry
+  version: 0.1.0
+  backend: typst
+  description: widget rect against rendered ink
+typst:
+  plate_file: plate.typ
+main:
+  fields:
+    inline_field:
+      type: string
+      description: a widget seated in a line of text
+    centered_field:
+      type: string
+      description: a widget under #align(center, ..)
+"#;
+
+/// Each widget page is followed by its twin: same text, same box, filled.
+const PLATE: &str = r#"
+#import "@local/quillmark-helper:0.1.0": form-field
+#set page(width: 200pt, height: 120pt, margin: 12pt)
+#set text(size: 20pt)
+
+Wide #form-field("inline", type: "text", field: "inline_field", width: 40pt, height: 12pt) text.
+
+#pagebreak()
+Wide #box(width: 40pt, height: 12pt, fill: black) text.
+
+#pagebreak()
+#align(center, form-field("centered", type: "text", field: "centered_field", width: 40pt, height: 12pt))
+
+#pagebreak()
+#align(center, box(width: 40pt, height: 12pt, fill: black))
+"#;
+
+const SCALE: f32 = 4.0;
+
+fn open() -> LiveSession {
+    TypstBackend
+        .open(&quill(YAML, PLATE), &serde_json::json!({}))
+        .expect("open")
+}
+
+/// The bounding box, in Typst top-left-origin points, of the pixels that differ
+/// between `page` and `twin`.
+fn diff_bbox(session: &LiveSession, page: usize, twin: usize) -> [f32; 4] {
+    let (w, h, a) = session.render_rgba(page, SCALE).expect("render page");
+    let (tw, th, b) = session.render_rgba(twin, SCALE).expect("render twin");
+    assert_eq!((w, h), (tw, th), "the twin pages render at the same size");
+
+    let (mut x0, mut y0, mut x1, mut y1) = (u32::MAX, u32::MAX, 0u32, 0u32);
+    for y in 0..h {
+        for x in 0..w {
+            let i = ((y * w + x) * 4) as usize;
+            if a[i..i + 4] != b[i..i + 4] {
+                x0 = x0.min(x);
+                y0 = y0.min(y);
+                x1 = x1.max(x + 1);
+                y1 = y1.max(y + 1);
+            }
+        }
+    }
+    assert!(x0 < x1 && y0 < y1, "the twin pages differ somewhere");
+    [
+        x0 as f32 / SCALE,
+        y0 as f32 / SCALE,
+        x1 as f32 / SCALE,
+        y1 as f32 / SCALE,
+    ]
+}
+
+fn region(session: &LiveSession, field: &str) -> RenderedRegion {
+    session
+        .regions()
+        .into_iter()
+        .find(|r| r.field == field)
+        .unwrap_or_else(|| panic!("{field} surfaces a region"))
+}
+
+/// A region is PDF bottom-left points; the rendered bbox is top-left. One
+/// rendered pixel of slack covers the partly-covered pixel at each edge.
+fn assert_region_covers_ink(session: &LiveSession, r: &RenderedRegion, ink: [f32; 4], what: &str) {
+    let (_, page_h) = session.page_size_pt(r.page).expect("page size");
+    let expected = [r.rect[0], page_h - r.rect[3], r.rect[2], page_h - r.rect[1]];
+    let tol = 1.0 / SCALE;
+    for (i, edge) in ["x0", "y0", "x1", "y1"].iter().enumerate() {
+        assert!(
+            (ink[i] - expected[i]).abs() <= tol,
+            "{what}: reported {edge} {} is {:.2}pt off the printed box's {:.2}pt \
+             (reported {expected:?}, printed {ink:?})",
+            expected[i],
+            ink[i] - expected[i],
+            ink[i],
+        );
+    }
+}
+
+/// An inline box hangs a full box-height above the line's own baseline, so no
+/// point the line supplies is the box's top-left.
+#[test]
+fn an_inline_widget_reports_the_rect_its_box_prints_in() {
+    let session = open();
+    let r = region(&session, "inline_field");
+    assert_eq!(r.page, 0, "the inline widget is on the first page");
+    assert_region_covers_ink(&session, &r, diff_bbox(&session, 0, 1), "inline widget");
+}
+
+/// A block-level tag is hoisted to the flow cursor, whose x is the left margin
+/// whatever the alignment does to the box beside it.
+#[test]
+fn a_centered_widget_reports_the_rect_its_box_prints_in() {
+    let session = open();
+    let r = region(&session, "centered_field");
+    assert_eq!(r.page, 2, "the centered widget is on the third page");
+    assert_region_covers_ink(&session, &r, diff_bbox(&session, 2, 3), "centered widget");
+}


### PR DESCRIPTION
`form-field` emitted its `<__qm_field__>` metadata beside the widget box, and the overlay reads that tag's position as the box's top-left, which it is not. An inline widget reported a rect one box-height low (the tag sits on the line's baseline, the box hangs above it), and `#align(center, ..)` or `#align(right, ..)` reported the left margin (a paragraph's leading tags are hoisted to the flow cursor). `session.regions()`, `fieldAt`, and the stamped AcroForm `/Rect` were wrong together.

The metadata now sits inside `box(..)[..]`, whose body origin is the box's top-left in every layout context, so `extract.rs` keeps its arithmetic and only its premise comment changes. Widget layout itself is untouched: `layout_box` forces the pod size on both fixed axes and a tag-only body sets no baseline, verified against vendored typst-layout 0.15.1 and by rendering. The two new tests in `widget_geometry.rs` measure the rect against a twin page carrying a filled box in the widget's place, so they check pixels rather than the metadata the region comes from; both fail before the change with exactly the issue's offsets (12pt low, 68pt left).

`usaf_memo` renders identically: its `place(..)` wrappers happened to make the tag and the box coincide, and they are kept for their own stated reasons. A third-party plate that compensated for the old offset shifts by that much, which the CHANGELOG entry notes.

Closes #1517

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_