### PR TITLE
refactor(typst): derive form-field specs once per compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,13 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- refactor(typst): **a compile's form fields cross to the PDF spine as one
+  derivation.** `Compiled` carries `field_specs: Vec<FieldSpec>` built with the
+  compile: `widget_regions` is `regions_of` over it and `render_document_pages`
+  stamps it directly, where each PDF render had rebuilt the specs from the
+  placements, page-height scan included. A placement naming a page outside the
+  document now fails the compile alongside the extraction errors it sits with,
+  instead of emptying the session's regions and surfacing at render.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -12,7 +12,7 @@ use crate::error_mapping::map_typst_errors;
 use crate::overlay;
 use crate::world::QuillWorld;
 use quillmark_core::{Artifact, Diagnostic, OutputFormat, RenderError, RenderResult};
-use quillmark_pdf::{stamp, StampOptions};
+use quillmark_pdf::{stamp, FieldSpec, StampOptions};
 
 pub(crate) fn render_options(pixel_per_pt: f32) -> RenderOptions {
     RenderOptions {
@@ -43,14 +43,14 @@ pub(crate) fn compile_document(
 /// 2x at 72pt/inch.
 const DEFAULT_PPI: f32 = 144.0;
 
-/// `field_placements` are stamped as AcroForm widgets by the PDF path only;
+/// `field_specs` are stamped as AcroForm widgets by the PDF path only;
 /// `producer` overrides the PDF `/Info` `/Producer` string.
 pub(crate) fn render_document_pages(
     document: &PagedDocument,
     pages: Option<&[usize]>,
     format: OutputFormat,
     ppi: Option<f32>,
-    field_placements: &[overlay::FieldPlacement],
+    field_specs: &[FieldSpec],
     producer: Option<&str>,
 ) -> Result<RenderResult, RenderError> {
     if format == OutputFormat::Pdf && pages.is_some() {
@@ -112,12 +112,11 @@ pub(crate) fn render_document_pages(
                     format!("PDF generation failed: {e:?}"),
                 )
             })?;
-            let field_specs = overlay::build_field_specs(document, field_placements)?;
             let producer = producer
                 .map(str::to_string)
                 .unwrap_or_else(overlay::default_producer);
             let opts = StampOptions::default().with_producer(producer);
-            let stamped = stamp(pdf, &field_specs, &opts)?;
+            let stamped = stamp(pdf, field_specs, &opts)?;
             Ok(RenderResult::new(
                 vec![Artifact::new(stamped, OutputFormat::Pdf)],
                 OutputFormat::Pdf,

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -57,12 +57,11 @@ struct TypstSession {
 /// query: a point hit or a region scan is a read of these tables.
 struct Compiled {
     document: typst_layout::PagedDocument,
-    /// Extracted from each committed compile; converted to spine `FieldSpec`s
-    /// on every render.
-    field_placements: Vec<overlay::FieldPlacement>,
-    /// The placements as regions, the single derivation `regions` and
-    /// `field_at` both read. Empty if the placements fail to resolve; a render
-    /// surfaces the same error.
+    /// This compile's form fields in the spine's coordinates: what a PDF render
+    /// stamps and what `widget_regions` projects.
+    field_specs: Vec<quillmark_pdf::FieldSpec>,
+    /// The specs as regions, the single derivation `regions` and `field_at`
+    /// both read.
     widget_regions: Vec<RenderedRegion>,
     /// The span scan's classification table: generated content-block windows
     /// then the plate's scalar reference-site windows.
@@ -98,17 +97,16 @@ fn recompile(
 
     let (document, compile_warnings) = compile::compile_document(world)?;
     let helper_source = helper_source(world)?;
-    let field_placements = overlay::extract(&document)?;
+    let placements = overlay::extract(&document)?;
+    let field_specs = overlay::build_field_specs(&document, &placements)?;
+    let widget_regions = quillmark_pdf::regions_of(&field_specs);
 
     let unclosed = overlay::unclosed_claims(&document);
     let hashes = page_hashes(&document);
     let warnings = session_warnings(world, compile_warnings, &unclosed);
-    let widget_regions = overlay::build_field_specs(&document, &field_placements)
-        .map(|specs| quillmark_pdf::regions_of(&specs))
-        .unwrap_or_default();
     Ok(Compiled {
         document,
-        field_placements,
+        field_specs,
         widget_regions,
         windows,
         helper_source,
@@ -255,7 +253,7 @@ impl SessionHandle for TypstSession {
             opts.pages.as_deref(),
             format,
             opts.ppi,
-            &self.live.field_placements,
+            &self.live.field_specs,
             opts.producer.as_deref(),
         )
     }
@@ -316,8 +314,7 @@ impl SessionHandle for TypstSession {
     /// Widgets first (one fixed-size box each), then span-tracked content in
     /// (page, field, site) order. `field` is not unique: page fragments, several
     /// scalar reference sites, or tracked content plus a bound widget all
-    /// repeat it, so consumers group by field. Widget regions are empty if the
-    /// placements fail to resolve; a render surfaces the same error.
+    /// repeat it, so consumers group by field.
     fn regions(&self) -> Vec<quillmark_core::RenderedRegion> {
         let mut regions = self.live.widget_regions.clone();
         regions.extend(self.scan().regions());
@@ -431,21 +428,18 @@ impl Backend for TypstBackend {
         let scalar_windows: Vec<overlay::FieldWindow> = {
             use typst::World as _;
             let main_id = world.main();
-            world
+            let plate = world
                 .source(main_id)
-                .ok()
-                .map(|src| {
-                    overlay::scalar_windows(&src, &schema_meta.root)
-                    .into_iter()
-                    .map(|(path, range)| overlay::FieldWindow {
-                        path,
-                        file: main_id,
-                        range,
-                        segments: Vec::new(),
-                    })
-                    .collect()
+                .expect("QuillWorld::source serves main by identity");
+            overlay::scalar_windows(&plate, &schema_meta.root)
+                .into_iter()
+                .map(|(path, range)| overlay::FieldWindow {
+                    path,
+                    file: main_id,
+                    range,
+                    segments: Vec::new(),
                 })
-                .unwrap_or_default()
+                .collect()
         };
         let live = recompile(&mut world, data.as_ref(), &schema_meta, &scalar_windows)?;
         let session = TypstSession {


### PR DESCRIPTION
`Compiled` kept `field_placements` and a `widget_regions` derived from them but not the `Vec<FieldSpec>` both the regions and the stamp path want, so every PDF render rebuilt the specs (page-height scan, coordinate flip, value coercion) from placements unchanged since the compile. It now stores `field_specs`, built once in `recompile`, with `widget_regions = regions_of(&field_specs)` and `render_document_pages` taking `&[FieldSpec]`.

Worth a look: the conversion's error now propagates from `recompile` rather than being swallowed into empty regions. That arm is unreachable (a placement's page is the introspector's, always in range) and it joins `overlay::extract`'s errors one line above, which already fail `open`; keeping the swallow would have been the larger change, since a single derivation would then let a PDF render succeed stamping no widgets. `open`'s `.ok().map(..).unwrap_or_default()` over `world.source(world.main())` becomes an `expect` naming the identity invariant.

Existing widget tests are the coverage (`sig_field.rs`, `field_appearance.rs`, `hit_tolerance.rs`); `cargo test --workspace` is green.

Closes #1540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_