### PR TITLE
refactor(core): state the default PPI once as RenderOptions::DEFAULT_PPI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,13 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- refactor(core,typst,pdfform): **the default PPI is stated once, as
+  `RenderOptions::DEFAULT_PPI`.** Each raster backend carried its own
+  `DEFAULT_PPI = 144.0` const, one of them documented as mirroring a core
+  constant that did not exist, so changing the default meant editing three
+  files. `RenderOptions::ppi_or_default()` resolves the option against that
+  constant and both backends call it. Additive on the core API; the resolved
+  value is unchanged.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -35,9 +35,6 @@ use {
 const FORM_PDF: &str = "form.pdf";
 const FORM_JSON: &str = "form.json";
 
-/// 2× at 72 pt/in, matching the core `RenderOptions::ppi` default.
-const DEFAULT_PPI: f32 = 144.0;
-
 const SUPPORTED_FORMATS: &[OutputFormat] =
     &[OutputFormat::Pdf, OutputFormat::Svg, OutputFormat::Png];
 
@@ -164,7 +161,7 @@ impl SessionHandle for PdfformSession {
             return self.render_svg();
         }
         if format == OutputFormat::Png {
-            let scale = opts.ppi.unwrap_or(DEFAULT_PPI) / 72.0;
+            let scale = opts.ppi_or_default() / 72.0;
             return self.render_png(scale);
         }
 

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -40,16 +40,13 @@ pub(crate) fn compile_document(
     }
 }
 
-/// 2x at 72pt/inch.
-const DEFAULT_PPI: f32 = 144.0;
-
 /// `field_placements` are stamped as AcroForm widgets by the PDF path only;
 /// `producer` overrides the PDF `/Info` `/Producer` string.
 pub(crate) fn render_document_pages(
     document: &PagedDocument,
     pages: Option<&[usize]>,
     format: OutputFormat,
-    ppi: Option<f32>,
+    ppi: f32,
     field_placements: &[overlay::FieldPlacement],
     producer: Option<&str>,
 ) -> Result<RenderResult, RenderError> {
@@ -93,7 +90,7 @@ pub(crate) fn render_document_pages(
             Ok(RenderResult::new(artifacts, OutputFormat::Svg))
         }
         OutputFormat::Png => {
-            let scale = ppi.unwrap_or(DEFAULT_PPI) / 72.0;
+            let scale = ppi / 72.0;
             let opts = render_options(scale);
             let mut artifacts = Vec::with_capacity(selected_indices.len());
             for idx in selected_indices {

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -254,7 +254,7 @@ impl SessionHandle for TypstSession {
             &self.live.document,
             opts.pages.as_deref(),
             format,
-            opts.ppi,
+            opts.ppi_or_default(),
             &self.live.field_placements,
             opts.producer.as_deref(),
         )

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -92,6 +92,14 @@ mod tests {
         }
     }
 
+    #[test]
+    fn ppi_falls_back_to_the_default() {
+        assert_eq!(RenderOptions::default().ppi_or_default(), 144.0);
+        assert_eq!(
+            RenderOptions::default().with_ppi(300.0).ppi_or_default(),
+            300.0
+        );
+    }
 }
 
 /// An artifact produced by rendering.
@@ -132,7 +140,8 @@ pub struct RenderOptions {
     pub output_format: Option<OutputFormat>,
     /// Pixels per inch for raster output formats (e.g., PNG).
     /// Ignored for vector/document formats (PDF, SVG).
-    /// Defaults to 144.0 (2x at 72pt/inch) when `None`.
+    /// `None` resolves to [`RenderOptions::DEFAULT_PPI`] through
+    /// [`ppi_or_default`](RenderOptions::ppi_or_default).
     pub ppi: Option<f32>,
     /// Optional 0-based page indices to render (e.g., `vec![0, 2]` for
     /// the first and third pages). `None` renders all pages. Any index
@@ -157,6 +166,15 @@ pub struct RenderOptions {
 }
 
 impl RenderOptions {
+    /// The pixels per inch every raster backend uses when [`ppi`](Self::ppi) is
+    /// `None`: 2x at 72 pt/inch.
+    pub const DEFAULT_PPI: f32 = 144.0;
+
+    /// [`ppi`](Self::ppi), or [`DEFAULT_PPI`](Self::DEFAULT_PPI).
+    pub fn ppi_or_default(&self) -> f32 {
+        self.ppi.unwrap_or(Self::DEFAULT_PPI)
+    }
+
     pub fn with_output_format(mut self, output_format: OutputFormat) -> Self {
         self.output_format = Some(output_format);
         self


### PR DESCRIPTION
Both raster backends hard-coded `DEFAULT_PPI = 144.0`, one of them documented as mirroring a core constant that never existed; core only said "Defaults to 144.0" in the `ppi` field's rustdoc. `RenderOptions` now owns `DEFAULT_PPI` plus `ppi_or_default()`, both backends call the method, and the field doc points at the constant, so the number is stated once.

Additive on the published core surface and no behavior change: the resolved scale is identical on both paths. The Typst backend's `render_document_pages` takes `ppi: f32` instead of `Option<f32>` because it cannot name `quillmark_core::RenderOptions` (it imports `typst_render::RenderOptions` under that name), so its one caller resolves the default. A core unit test pins that an unset `ppi` answers 144.0 and that `with_ppi(300.0)` overrides it. The two docs pages stating 144 stay correct and are untouched.

Closes #1538

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_