### PR TITLE
fix(fuzz): pin the wide-payload property to an exact field count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,14 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(fuzz): **the wide-payload property requires the parse to succeed and to
+  keep every field.** `fuzz_decompose_large_payload` swallowed a parse `Err`
+  and asserted `payload().len() <= size`, a bound `Payload::len` cannot
+  exceed, so a parse that refused the input or dropped every field passed. It
+  expects the parse and pins `len() == size`, which holds at every generated
+  width since all sit under `MAX_FIELD_COUNT`. The README's `parse_fuzz.rs`
+  row names what the file generates and `conform_fuzz.rs` gets the row it
+  lacked.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/fuzz/README.md
+++ b/crates/fuzz/README.md
@@ -14,12 +14,13 @@ The crate is excluded from `default-members`, so a bare `cargo test` skips it; `
 | Module | Target |
 |---|---|
 | `coerce_fuzz.rs` | `QuillConfig::coerce_payload`: no panic on arbitrary `(FieldSchema, Value)` pairs, well-formed error paths, idempotent successful coercions |
+| `conform_fuzz.rs` | `Quill::conform` over generated field values: idempotence on bytes and diagnostics, convergence with the strict typed write, and the markdown loop as a fixed point after one pass. Regressions in `proptest-regressions/conform_fuzz.txt` |
 | `convert_fuzz.rs` | Markdown → Typst: `escape_string` / `escape_markup` in `quillmark-typst`, and the import-then-lower render path |
 | `decode_fuzz.rs` | The four JSON decode lanes (storage DTO, card wire, canonical content, op wire) where arbitrary JSON yields `Err`, never a panic |
 | `emit_roundtrip_fuzz.rs` | `parse → emit → re-parse` stability, and idempotence on the canonical form |
-| `parse_fuzz.rs` | card-yaml payloads: malformed YAML, composable card kinds, nested structures, Unicode and special characters |
+| `parse_fuzz.rs` | `Document::parse` on a card-yaml payload of generated width: every one of the `fieldN: valueN` lines reaches the parsed payload |
 | `pdf_fuzz.rs` | `quillmark-pdf`'s byte-level PDF reads (`page_media_boxes`, `PdfUpdate::begin`, `stamp`): arbitrary bytes, and a real AcroForm truncated, single-byte-corrupted, or spliced, yield `Err`, never a panic |
 
-The properties these hold: escaped output never breaks out of its Typst string or markup context, deeply nested and oversize input parses without panicking, arbitrary Unicode survives, and the hand-rolled PDF reader refuses corrupt bytes rather than panicking.
+The properties these hold: escaped output never breaks out of its Typst string or markup context, deeply nested and oversize markdown lowers to Typst without panicking, arbitrary Unicode survives the escapers and the parse → emit round trip, a wide payload keeps every field across a parse, and the hand-rolled PDF reader refuses corrupt bytes rather than panicking.
 
 A new escaping, parsing, or decoding surface gets a fuzz target here.

--- a/crates/fuzz/src/parse_fuzz.rs
+++ b/crates/fuzz/src/parse_fuzz.rs
@@ -12,9 +12,9 @@ proptest! {
         let markdown =
             format!("~~~card-yaml\n$quill: test_quill\n$kind: main\n{}\n~~~\n\nContent", payload);
 
-        let result = Document::parse(&markdown).map(|p| p.document);
-        if let Ok(doc) = result {
-            assert!(doc.main().payload().len() <= size);
-        }
+        let doc = Document::parse(&markdown)
+            .expect("a well-formed payload parses")
+            .document;
+        prop_assert_eq!(doc.main().payload().len(), size);
     }
 }


### PR DESCRIPTION
`fuzz_decompose_large_payload` guarded nothing but "no panic": a parse `Err` was swallowed by `if let Ok(doc)`, and `payload().len() <= size` is a bound `Payload::len` cannot exceed, so a parser that dropped every field passed. It now expects the parse and pins `len() == size`, which holds at every generated width because all of them are under `MAX_FIELD_COUNT`. To show the new assertion is live it was run mutated to `size + 1` (fails), and the old body was run against an input whose parse always errs (passes), the exact vacuity the issue describes.

The README is corrected alongside: the `parse_fuzz.rs` row described malformed YAML, card kinds, nesting and Unicode that the file never generates, `conform_fuzz.rs` had no row at all, and the closing paragraph's nesting and oversize claims belong to `convert_fuzz.rs`, which is where they now sit.

Closes #1536

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_