### PR TITLE
refactor(core): one spelling of the richtext shape-mismatch message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- refactor(core): **every surface that refuses a non-content richtext value
+  spells one sentence.** `Codec::decode_field` builds the shape-mismatch
+  message and names the shape that arrived (`expected a richtext content
+  object or a markdown string, got a number`); the wire `$body` reader and the
+  richtext write coercion route through it instead of carrying their own
+  copies, so the schema-bound read and the strict projection name the shape
+  too. `Card::store_ext` bounds `$ext` depth through
+  `value::depth_check_meta_map`, the check the wire and the storage DTO run.
+  Every diagnostic code is unchanged.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -397,7 +397,9 @@ pub(crate) fn field_decode(
 }
 
 /// Depth-bound the values of an `$ext` / `$seed` map: the map itself is level
-/// 1, so its values carry the rest of the budget.
+/// 1, so its values carry the rest of the budget. The iterator form of
+/// [`crate::value::depth_check_meta_map`], for the merge that must clear the
+/// bound before it owns a map.
 fn check_meta_depth<'v>(
     values: impl IntoIterator<Item = &'v serde_json::Value>,
 ) -> Result<(), EditError> {
@@ -743,7 +745,8 @@ impl Card {
         &mut self,
         value: serde_json::Map<String, serde_json::Value>,
     ) -> Result<(), EditError> {
-        check_meta_depth(value.values())?;
+        let value =
+            crate::value::depth_check_meta_map(value, |max| EditError::ValueTooDeep { max })?;
         self.payload_mut().set_ext(value);
         Ok(())
     }

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -96,6 +96,23 @@ impl Codec {
         }
     }
 
+    /// The shape-mismatch message for a value in neither accepted encoding,
+    /// naming the shape that arrived. Every surface that refuses an unshaped
+    /// richtext value spells this one sentence.
+    pub(crate) fn unshaped_message(self, value: &serde_json::Value) -> String {
+        format!(
+            "expected a {} content object or {}, got {}",
+            self.name(),
+            self.string_form(),
+            match value {
+                serde_json::Value::Bool(_) => "a boolean",
+                serde_json::Value::Number(_) => "a number",
+                serde_json::Value::Array(_) => "an array",
+                _ => "an unsupported value",
+            }
+        )
+    }
+
     /// [`decode_value`](Self::decode_value) closed over the shapes a stored field
     /// can hold: a null is the empty content (null ≡ absent), and anything
     /// neither object nor string is a decode failure.
@@ -106,11 +123,7 @@ impl Codec {
         match self.decode_value(value) {
             Some(result) => result,
             None if value.is_null() => Ok(Normalized::empty()),
-            None => Err(ContentDecodeError::NotContent(format!(
-                "expected a {} content object or {}",
-                self.name(),
-                self.string_form()
-            ))),
+            None => Err(ContentDecodeError::NotContent(self.unshaped_message(value))),
         }
     }
 

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1001,6 +1001,35 @@ fn store_field_rejects_value_past_depth_limit() {
         .is_err());
 }
 
+/// The `$ext` map is itself a level, so its values carry `MAX_YAML_DEPTH - 1`:
+/// the wholesale store and the namespace merge bound the merged map identically.
+#[test]
+fn store_ext_charges_the_map_its_own_level() {
+    let mut doc =
+        crate::document::Document::parse("~~~\n$quill: q@1.0\n$kind: main\n~~~\n").unwrap().document;
+    let map = |depth: usize| {
+        let mut m = serde_json::Map::new();
+        m.insert("a".to_string(), deep_value(depth));
+        m
+    };
+
+    doc.main_mut().store_ext(map(99)).expect("99 levels under a map is exactly the limit");
+    let err = doc.main_mut().store_ext(map(100)).unwrap_err();
+    assert!(
+        matches!(err, crate::document::EditError::ValueTooDeep { max: 100 }),
+        "expected ValueTooDeep, got {err:?}"
+    );
+    assert_eq!(err.code(), "edit::value_too_deep");
+    assert_eq!(
+        doc.main().ext().and_then(|m| m.get("a")),
+        Some(&deep_value(99)),
+        "the refused map leaves the stored one untouched"
+    );
+
+    doc.main_mut().store_ext_namespace("ns", deep_value(99)).expect("the merge bound matches");
+    assert!(doc.main_mut().store_ext_namespace("ns", deep_value(100)).is_err());
+}
+
 #[test]
 fn storage_dto_rejects_value_past_depth_limit() {
     let stored = serde_json::json!({

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -302,30 +302,15 @@ impl TryFrom<CardWire> for Card {
 }
 
 /// Read a [`CardWire::body`] into a [`Content`] content. The body is the source
-/// of truth in two accepted encodings: a **content object** (an editor / a
-/// re-serialized card) is deserialized and validated; a **markdown string** (an
-/// LLM / markdown writer) is imported. `null`/absent is the empty content; any
-/// other shape is an invalid `$body`.
+/// of truth and reads through the richtext codec whatever the schema declares,
+/// so its accepted encodings are [`super::Codec::decode_field`]'s.
 fn body_from_wire(body: &JsonValue) -> Result<Normalized, WireError> {
-    let invalid = |reason: String| WireError::InvalidField {
-        key: "$body".to_string(),
-        reason,
-    };
-    match super::Codec::Richtext.decode_value(body) {
-        Some(result) => result.map_err(|e| invalid(e.into_message())),
-        None => match body {
-            JsonValue::Null => Ok(Normalized::empty()),
-            other => Err(invalid(format!(
-                "expected a richtext content object or a markdown string, got {}",
-                match other {
-                    JsonValue::Bool(_) => "a boolean",
-                    JsonValue::Number(_) => "a number",
-                    JsonValue::Array(_) => "an array",
-                    _ => "an unsupported value",
-                }
-            ))),
-        },
-    }
+    super::Codec::Richtext
+        .decode_field(body)
+        .map_err(|e| WireError::InvalidField {
+            key: "$body".to_string(),
+            reason: e.into_message(),
+        })
 }
 
 /// Validate a wire field against the payload invariant (see
@@ -543,6 +528,39 @@ mod tests {
         })
         .unwrap_err();
         assert!(matches!(err, WireError::InvalidQuillReference { .. }));
+    }
+
+    /// `$body` reads through the richtext codec: a null is the empty content, a
+    /// markdown string imports, and any other shape is refused under the codec's
+    /// own sentence, naming the shape that arrived.
+    #[test]
+    fn card_wire_body_reads_through_the_richtext_codec() {
+        let with_body = |body: JsonValue| Card::try_from(CardWire::new("note".to_string(), body));
+
+        assert_eq!(
+            with_body(JsonValue::Null).unwrap().body(),
+            &quillmark_content::Normalized::empty()
+        );
+        assert_eq!(
+            Codec::Richtext.project(with_body(json!("hi *there*")).unwrap().body()),
+            "hi *there*"
+        );
+
+        let err = with_body(json!(true)).unwrap_err();
+        assert!(
+            matches!(&err, WireError::InvalidField { key, reason }
+                if key == "$body"
+                    && reason
+                        == "expected a richtext content object or a markdown string, got a boolean"),
+            "got {err:?}"
+        );
+        for (body, tail) in [(json!(3), "a number"), (json!([]), "an array")] {
+            let err = with_body(body).unwrap_err();
+            assert!(
+                matches!(&err, WireError::InvalidField { reason, .. } if reason.ends_with(tail)),
+                "got {err:?}"
+            );
+        }
     }
 
     /// Construction accepts a kind the mutators reject: `make_card` is

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -631,15 +631,7 @@ impl QuillConfig {
                                 path,
                                 json_value,
                                 "richtext",
-                                format!(
-                                    "expected a richtext content object or a markdown string, got {}",
-                                    match json_value {
-                                        serde_json::Value::Bool(_) => "a boolean",
-                                        serde_json::Value::Number(_) => "a number",
-                                        serde_json::Value::Array(_) => "an array",
-                                        _ => "an unsupported value",
-                                    }
-                                ),
+                                crate::document::Codec::Richtext.unshaped_message(json_value),
                             ),
                             E::NotInline => inline_err(),
                         });

--- a/crates/core/src/reader.rs
+++ b/crates/core/src/reader.rs
@@ -632,11 +632,14 @@ card_kinds:
         doc.main_mut()
             .store_field("subject", QuillValue::from_json(serde_json::json!(3)))
             .unwrap();
-        let view = TypedReader::new(&config, &doc);
-        assert!(matches!(
-            view.get("subject"),
-            Err(EditError::FieldDecode { field, .. }) if field == "subject"
-        ));
+        let err = TypedReader::new(&config, &doc).get("subject").unwrap_err();
+        assert!(
+            matches!(&err, EditError::FieldDecode { field, message, .. }
+                if field == "subject"
+                    && message
+                        == "expected a richtext content object or a markdown string, got a number"),
+            "got {err:?}"
+        );
     }
 
     /// The string lane, which decoded through the markdown codec until it read

--- a/crates/core/src/writer.rs
+++ b/crates/core/src/writer.rs
@@ -673,6 +673,25 @@ card_kinds:
         assert!(doc.main().payload().get("notafield").is_none());
     }
 
+    /// A richtext write refuses a value in neither accepted encoding under the
+    /// codec's own sentence, the one the wire and the schema-bound read spell.
+    #[test]
+    fn set_rejects_a_non_content_shape_by_naming_it() {
+        let config = config();
+        let mut doc = blank_doc();
+        let mut ed = TypedWriter::new(&config, &mut doc);
+        let err = ed
+            .set("subject", QuillValue::from_json(serde_json::json!(true)))
+            .unwrap_err();
+        assert_eq!(err.code(), "edit::field_decode");
+        assert!(
+            matches!(&err, EditError::FieldDecode { message, .. }
+                if message
+                    == "expected a richtext content object or a markdown string, got a boolean"),
+            "got {err:?}"
+        );
+    }
+
     #[test]
     fn set_all_is_all_or_nothing() {
         let config = config();


### PR DESCRIPTION
`body_from_wire` re-implemented `Codec::decode_field`, and the coercion floor carried a third copy of the same "expected a richtext content object or a markdown string, got …" sentence. `Codec::unshaped_message` now spells it once and all three sites call it. The wire and coercion messages come out byte-identical; the one cross-surface change is that the schema-bound read and the strict projection gain the ", got a number" tail on `EditError::FieldDecode.message`, which is strictly more informative, was pinned by no test, and moves no diagnostic code.

`Card::store_ext` swaps to `value::depth_check_meta_map`, whose wrapped-object check is the same bound; `check_meta_depth` stays because `merge_meta_namespace` must clear the bound before it owns the merged map. New guards pin the sentence at each of the three sites and the `$ext` depth bound at its exact edge (99 levels pass, 100 raise `ValueTooDeep { max: 100 }`).

Closes #1527

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_