### PR TITLE
refactor(core): render FieldViolation through one message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,15 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- refactor(core): **`FieldViolation` spells its own message, once.** The parse,
+  wire and storage boundaries each re-spelled the three field-invariant
+  reasons, and the wording had drifted apart ("invalid data-field name `x`:
+  field names must match…" vs `invalid field name "x": must match…` vs a keyless
+  "field names must match…"). `Display` gives the reason alone — the form
+  `WireError::InvalidField` carries beside its own `key` — and
+  `FieldViolation::message(key)` names the key inline, which all three
+  boundaries wrap. The parse path's dead `FillOnMapping` arm goes with the
+  match it lived in: `validate_field` returns `InvalidName` / `TooDeep` only.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -344,22 +344,8 @@ pub(super) fn decompose_with_warnings(
 /// Validate a user field entering the payload from the parse path, mapping a
 /// violation to `ParseError::InvalidStructure` (spec §10).
 fn validate_parsed_field(key: &str, value: &serde_json::Value) -> Result<(), ParseError> {
-    use crate::document::edit::{validate_field, FieldViolation};
-    validate_field(key, value).map_err(|v| match v {
-        FieldViolation::InvalidName => ParseError::InvalidStructure(format!(
-            "invalid data-field name `{}`: field names must match [A-Za-z_][A-Za-z0-9_]*",
-            key
-        )),
-        FieldViolation::TooDeep => ParseError::InvalidStructure(format!(
-            "field `{}` nests deeper than the maximum of {} levels",
-            key,
-            crate::document::limits::MAX_YAML_DEPTH
-        )),
-        FieldViolation::FillOnMapping => ParseError::InvalidStructure(format!(
-            "`!must_fill` on key `{}` targets a mapping; `!must_fill` is supported on scalars and sequences only",
-            key
-        )),
-    })
+    crate::document::edit::validate_field(key, value)
+        .map_err(|v| ParseError::InvalidStructure(v.message(key)))
 }
 
 /// Take the typed `$` item for `key` out of `typed`, leaving its slot empty.

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -678,21 +678,7 @@ impl TryFrom<PayloadItemV0_92_0> for PayloadItem {
                 nested_fills,
             } => {
                 use super::edit::{validate_field, validate_fill_targets, FieldViolation};
-                let malformed = |v: FieldViolation| {
-                    StorageError::Malformed(match v {
-                        FieldViolation::InvalidName => {
-                            format!("invalid field name {key:?}: must match [A-Za-z_][A-Za-z0-9_]*")
-                        }
-                        FieldViolation::TooDeep => format!(
-                            "field {key:?} nests deeper than the maximum of {} levels",
-                            crate::document::limits::MAX_YAML_DEPTH
-                        ),
-                        FieldViolation::FillOnMapping => format!(
-                            "`!must_fill` on field {key:?} targets a mapping; `!must_fill` is \
-                             supported on scalars and sequences only"
-                        ),
-                    })
-                };
+                let malformed = |v: FieldViolation| StorageError::Malformed(v.message(&key));
                 validate_field(&key, &value).map_err(malformed)?;
                 let mut qv = QuillValue::from_json(value);
                 for path in nested_fills {

--- a/crates/core/src/document/edit.rs
+++ b/crates/core/src/document/edit.rs
@@ -296,7 +296,10 @@ impl EditError {
 /// A field-level invariant violation, shared by every payload ingestion path.
 ///
 /// Each boundary maps it to its own error type (`ParseError`, `StorageError`,
-/// `WireError`, `EditError`), so the invariant is enforced once, here.
+/// `WireError`, `EditError`), so the invariant is enforced once, here. Its
+/// [`Display`](std::fmt::Display) is the reason alone, for a boundary carrying
+/// the offending key itself; [`message`](Self::message) names the key inline
+/// for the boundaries whose error type does not.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum FieldViolation {
@@ -309,6 +312,33 @@ pub enum FieldViolation {
     /// and a block mapping opens on the next line, with no tag position of its
     /// own (spec §3.4).
     FillOnMapping,
+}
+
+impl FieldViolation {
+    /// The reason with `key` named inline: the rendering
+    /// [`WireError::InvalidField`](crate::document::wire::WireError::InvalidField)
+    /// composes from its own key and this `Display`.
+    pub fn message(&self, key: &str) -> String {
+        format!("invalid field {key:?}: {self}")
+    }
+}
+
+impl std::fmt::Display for FieldViolation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FieldViolation::InvalidName => {
+                f.write_str("field names must match [A-Za-z_][A-Za-z0-9_]*")
+            }
+            FieldViolation::TooDeep => write!(
+                f,
+                "nests deeper than the maximum of {} levels",
+                crate::document::limits::MAX_YAML_DEPTH
+            ),
+            FieldViolation::FillOnMapping => f.write_str(
+                "`!must_fill` targets a mapping; `!must_fill` is supported on scalars and sequences only",
+            ),
+        }
+    }
 }
 
 /// A payload-level invariant violation: [`FieldViolation`]'s seam one level up,

--- a/crates/core/src/document/tests/edit_tests.rs
+++ b/crates/core/src/document/tests/edit_tests.rs
@@ -1228,3 +1228,48 @@ fn storage_dto_refuses_a_multi_line_comment() {
     .unwrap_err();
     assert!(err.to_string().contains("one line"), "got: {err}");
 }
+
+/// One violation, the three ingestion boundaries that spell it: parse, wire,
+/// storage. Each renders the text `FieldViolation` owns, naming the key.
+#[test]
+fn every_ingestion_boundary_renders_one_violation_text() {
+    use crate::document::edit::FieldViolation;
+
+    let expected = FieldViolation::InvalidName.message("bad name");
+
+    let parse_err =
+        Document::parse("~~~card-yaml\n$quill: test_quill\n$kind: main\nbad name: v\n~~~\n")
+            .unwrap_err();
+    assert!(
+        parse_err.to_string().contains(&expected),
+        "parse: {parse_err}"
+    );
+
+    let mut wire = crate::document::CardWire::new("main".to_string(), serde_json::json!(""));
+    wire.payload_items = vec![crate::document::PayloadItemWire::Field {
+        key: "bad name".to_string(),
+        value: serde_json::json!("v"),
+        fill: false,
+        nested_fills: Vec::new(),
+    }];
+    let wire_err = Card::try_from(wire).unwrap_err();
+    assert!(wire_err.to_string().contains(&expected), "wire: {wire_err}");
+
+    let storage_err = serde_json::from_value::<Document>(serde_json::json!({
+        "schema": "quillmark/document@0.92.0",
+        "main": {
+            "payload": {"items": [
+                {"type": "quill", "value": "q@1.0"},
+                {"type": "kind", "value": "main"},
+                {"type": "field", "key": "bad name", "value": "v"}
+            ]},
+            "body": ""
+        },
+        "cards": []
+    }))
+    .unwrap_err();
+    assert!(
+        storage_err.to_string().contains(&expected),
+        "storage: {storage_err}"
+    );
+}

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -345,22 +345,9 @@ fn validate_wire_fill_targets(
 }
 
 fn wire_field_error(key: &str, v: super::edit::FieldViolation) -> WireError {
-    use super::edit::FieldViolation;
     WireError::InvalidField {
         key: key.to_string(),
-        reason: match v {
-            FieldViolation::InvalidName => {
-                "field names must match [A-Za-z_][A-Za-z0-9_]*".to_string()
-            }
-            FieldViolation::TooDeep => format!(
-                "nests deeper than the maximum of {} levels",
-                crate::document::limits::MAX_YAML_DEPTH
-            ),
-            FieldViolation::FillOnMapping => {
-                "`!must_fill` targets a mapping; it is supported on scalars and sequences only"
-                    .to_string()
-            }
-        },
+        reason: v.to_string(),
     }
 }
 


### PR DESCRIPTION
`FieldViolation` had no rendering of its own, so the parse, wire and storage boundaries each re-spelled its three reasons and had already drifted apart. It now carries a keyless `Display` (the reason alone, the form `WireError::InvalidField` wants beside its own `key` field) and a `message(key)` helper that names the key inline, exactly the text that error's `Display` composes, and all three sites wrap it. The parse path's unreachable `FillOnMapping` arm disappears with the match it lived in, since `validate_field` returns only `InvalidName` / `TooDeep`. `edit_error_from_violation` is deliberately left alone: it maps to typed `EditError` variants and spells no prose.

Reviewer notes: the emitted message text changes at the parse and storage boundaries (no diagnostic code changes), and the "targets a mapping" sentence at `assemble.rs`'s two hand-rolled fill guards and `prescan.rs` does not route through `FieldViolation`, so it stays as it is. The new cross-boundary test was seen failing on the old parse wording.

Closes #1525

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_