### PR TITLE
docs: state what the emitters, the PDF reader and the body hint do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,17 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- docs(content,pdf,core): **six internal docs state what the code does.**
+  `NestingTooDeep` and `SetContainers` name the Typst emitter as the recursive
+  one, markdown export walking an explicit stack; the PDF reader's input
+  contract reads `bounded-tree`, a `/Pages` tree of any depth reaching each node
+  once and staying under 100 000 nodes; `flat_nested_comments` links
+  `from_items_with_flat_nested`, which resolves; `build-wasm.sh` puts the
+  `rm -rf pkg` on this script never removing files, CI caching the wasm build
+  dir alone. `spec_conformance_probe` names its body case for the parse pass
+  that does the strip and covers `normalize_document` with a field-name NFC
+  case. The hint on a malformed `main.body` lists `unsupported`, reading the key
+  list off one const beside `BodyCardSchema`.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -842,8 +842,10 @@ pub enum Invariant {
     /// (an `Island`-tagged prose line projects to its resolved island alone).
     LineKindMismatch { line: usize, mismatch: LineKindMismatch },
     /// A line's container path is nested deeper than
-    /// [`MAX_NESTING_DEPTH`](crate::MAX_NESTING_DEPTH). Both emitters recurse
-    /// one frame per container, so an unbounded path overflows the stack.
+    /// [`MAX_NESTING_DEPTH`](crate::MAX_NESTING_DEPTH). The Typst emitter
+    /// recurses one frame per container and refuses a deeper path rather than
+    /// overflow the stack; markdown export walks an explicit stack and projects
+    /// any depth.
     NestingTooDeep {
         line: usize,
         depth: usize,

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -658,9 +658,9 @@ impl Content {
                     line.kind = kind.clone();
                 }
                 LineOp::SetContainers { line, containers } => {
-                    // Both emitters recurse one frame per container, so an
-                    // over-deep path is a stack overflow at render, not a render
-                    // error. Same cap as import.
+                    // The Typst emitter recurses one frame per container, so a
+                    // path past this cap is a render refusal rather than markup.
+                    // Same cap as import.
                     if containers.len() > crate::MAX_NESTING_DEPTH {
                         return Err(ApplyError::NestingTooDeep {
                             line: *line,

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -243,7 +243,8 @@ impl Payload {
         Self { items }
     }
 
-    /// The inverse of [`from_items_with_nested`](Self::from_items_with_nested):
+    /// The inverse of
+    /// [`from_items_with_flat_nested`](Self::from_items_with_flat_nested):
     /// re-prefix each nested comment's path with its owning item's key, for the
     /// storage DTO's payload-level sidecar.
     pub(crate) fn flat_nested_comments(&self) -> Vec<NestedComment> {

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -8,7 +8,10 @@ use serde::{Deserialize, Serialize};
 use crate::error::{Diagnostic, Severity, diag_args};
 use crate::value::QuillValue;
 
-use super::types::{RICHTEXT_INLINE_TOKEN_MSG, UI_ORDER_REMOVED_MSG, VARIANT_DISCRIMINANT_KEY};
+use super::types::{
+    BODY_CARD_SCHEMA_KEYS, RICHTEXT_INLINE_TOKEN_MSG, UI_ORDER_REMOVED_MSG,
+    VARIANT_DISCRIMINANT_KEY,
+};
 use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, UiCardSchema};
 
 /// Canonical string text for a bare scalar unambiguously representable as a
@@ -1923,7 +1926,10 @@ impl QuillConfig {
             main_obj_opt.and_then(|main_obj| main_obj.get("body")),
             "main.body",
             "quill::invalid_body",
-            "Valid keys under 'body' are: enabled, example.",
+            &format!(
+                "Valid keys under 'body' are: {}.",
+                BODY_CARD_SCHEMA_KEYS.join(", ")
+            ),
             &mut errors,
         );
 

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1951,6 +1951,31 @@ main:
 }
 
 #[test]
+fn test_main_body_malformed_hint_names_every_authored_key() {
+    let yaml_content = r#"
+quill:
+  name: bad_body
+  version: "1.0"
+  backend: typst
+  description: Bad body test
+
+main:
+  body:
+    unsuported: [Table]
+"#;
+
+    let err = QuillConfig::from_yaml_with_warnings(yaml_content).unwrap_err();
+    let hint = err
+        .iter()
+        .find(|d| d.code.as_deref() == Some("quill::invalid_body"))
+        .and_then(|d| d.hint.clone())
+        .expect("a malformed main.body carries a hint");
+    for key in ["enabled", "example", "unsupported"] {
+        assert!(hint.contains(key), "hint omits {key}: {hint}");
+    }
+}
+
+#[test]
 fn test_field_ui_title_is_valid() {
     let yaml_content = r#"
 quill:

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -109,6 +109,10 @@ impl std::fmt::Display for BlockConstruct {
     }
 }
 
+/// The keys [`BodyCardSchema`] deserializes, for the hint on a rejected
+/// `body:` section. `example_content` is `#[serde(skip)]` and unauthorable.
+pub(crate) const BODY_CARD_SCHEMA_KEYS: &[&str] = &["enabled", "example", "unsupported"];
+
 /// Body namespace configuration for a card kind
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/crates/core/tests/spec_conformance_probe.rs
+++ b/crates/core/tests/spec_conformance_probe.rs
@@ -2,21 +2,38 @@
 //! owner among the `document/tests/` unit modules.
 //!
 //! What those modules do not carry: the §8 input caps (sole coverage in the
-//! workspace) and the `normalize_document` pass.
+//! workspace), the bidi strip a card body takes at parse, and the
+//! `normalize_document` pass.
 
 use quillmark_core::normalize::normalize_document;
 use quillmark_core::Document;
 
 #[test]
-fn normalize_reaches_card_body() {
+fn parse_strips_a_bidi_control_from_a_card_body() {
     let md = "~~~card-yaml\n$quill: t\n$kind: main\n~~~\n\n~~~card-yaml\n$kind: x\n~~~\n\n<!-- c -->trailing\u{202D}text";
     let doc = Document::parse(md).unwrap().document;
-    let doc = normalize_document(doc).unwrap();
     let body = doc.cards()[0].body_markdown();
     assert!(
         body.contains("trailingtext"),
         "card body missing bidi-strip, got: {:?}",
         body
+    );
+}
+
+/// U+212A KELVIN SIGN composes to `K` under NFC: parse stores the authored key
+/// verbatim, and this pass is what folds it.
+#[test]
+fn normalize_document_folds_a_field_name_to_nfc() {
+    let md = "~~~card-yaml\n$quill: t\n$kind: main\n\u{212A}elvin: v\n~~~\n\nBody.";
+    let doc = Document::parse(md).unwrap().document;
+    assert!(
+        doc.main().payload().get("Kelvin").is_none(),
+        "parse stores the authored key"
+    );
+    let doc = normalize_document(doc).unwrap();
+    assert_eq!(
+        doc.main().payload().get("Kelvin").and_then(|v| v.as_str()),
+        Some("v")
     );
 }
 

--- a/crates/fuzz/src/pdf_fuzz.rs
+++ b/crates/fuzz/src/pdf_fuzz.rs
@@ -5,7 +5,7 @@
 //!
 //! The oracle is deliberately weak — a refusal is an acceptable answer. The
 //! reader's input contract (traditional-xref, unencrypted, inline-annots,
-//! flat-tree) refuses most well-formed PDFs too, so `Ok` is not assertable.
+//! bounded-tree) refuses most well-formed PDFs too, so `Ok` is not assertable.
 //!
 //! Two input populations, because they fail differently: arbitrary bytes almost
 //! never reach past the trailer scan, while a real form with one byte changed

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -6,11 +6,12 @@
 //! ## Input contract
 //!
 //! The base PDF must be traditional-xref, unencrypted, inline-annots,
-//! flat-tree: a classic `xref` table (not an xref *stream*), no `/Encrypt`, page
-//! `/Annots` written inline rather than as an indirect reference, and a page tree
-//! shallow enough to walk. That is the precise inverse of the scanner's error
-//! branches. `hayro-syntax` is read-only and exposes no byte spans, so it cannot
-//! drive a byte-splice append; hence this bespoke scanner.
+//! bounded-tree: a classic `xref` table (not an xref *stream*), no `/Encrypt`,
+//! page `/Annots` written inline rather than as an indirect reference, and a
+//! `/Pages` tree of any depth that reaches each node once and stays under
+//! 100 000 nodes. That is the precise inverse of the scanner's error branches.
+//! `hayro-syntax` is read-only and exposes no byte spans, so it cannot drive a
+//! byte-splice append; hence this bespoke scanner.
 
 use std::collections::{HashMap, HashSet};
 

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -102,8 +102,8 @@ impl StampOptions {
 /// a session-level query (see [`regions_of`]).
 ///
 /// `base` must satisfy the reader's input contract (traditional-xref,
-/// unencrypted, inline-annots, flat-tree) and carry no `/AcroForm` of its own,
-/// and each `rect` must already be final, finite, bottom-left PDF-point
+/// unencrypted, inline-annots, bounded-tree) and carry no `/AcroForm` of its
+/// own, and each `rect` must already be final, finite, bottom-left PDF-point
 /// geometry.
 pub fn stamp(
     base: Vec<u8>,

--- a/scripts/build-wasm.sh
+++ b/scripts/build-wasm.sh
@@ -53,10 +53,10 @@ echo "Building WASM modules for @quillmark/wasm... [profile: $MODE_LABEL]"
 
 cd "$(dirname "$0")/.."
 
-# Start from a clean pkg/. CI restores a cached pkg/ from a previous build
-# (restore-keys partial-matches an older release), and this script only ever
-# mkdir/cp/sed *into* pkg/; it never removes files. Without this, any file
-# dropped from the pkg layout between builds lingers and ships on `npm publish`.
+# Start from a clean pkg/. This script only ever mkdir/cp/sed *into* pkg/; it
+# never removes files, so a rebuild in a tree that built an earlier pkg layout
+# keeps every file that layout dropped, and `npm publish` ships them. CI caches
+# target/wasm32-unknown-unknown/<profile> alone, so its pkg/ is built fresh.
 rm -rf pkg
 
 # Check for required tools. The CLI's version must match the wasm-bindgen


### PR DESCRIPTION
Six docs and one author-facing hint claimed things the code does not do; each row here is the doc moving to what the code has. The two behaviour-adjacent rows: the `main.body` hint now lists `unsupported` (read off one const beside `BodyCardSchema`, so it cannot drift), and `spec_conformance_probe`'s `normalize_reaches_card_body`, which passed with its `normalize_document` call deleted, is renamed to the parse pass it actually pins, with a real `normalize_document` field-name NFC case added beside it. Both are covered by tests seen failing before the change.

Row 2 touches a third file the issue does not list, `crates/fuzz/src/pdf_fuzz.rs`, which spells the same reader contract and would otherwise be left naming a term no doc defines. `cargo doc` loses the `from_items_with_nested` broken-link warning.

Closes #1528

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_