### PR TITLE
fix(cli): render parses through the bound door

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(cli): **`render` parses a `MARKDOWN_FILE` through the bound door, so
+  `conform::*` and `plate::unsupported_construct` warnings reach stderr.** The
+  command called `Document::parse`, the transport door, which runs neither the
+  conform walk nor the declined-construct walk: a `usaf_memo` body carrying a
+  `***` rendered with an empty stderr where every other surface warns. It calls
+  `Quill::parse` instead, and the existing splice carries that door's warnings
+  into `RenderResult.warnings` unchanged. Rendered bytes are the same — the
+  coercion pass already ran in `compile_data` — and a `$quill` naming another
+  quill refuses at parse rather than at compile, with the same diagnostics and
+  the same exit 1. The seeded path (no `MARKDOWN_FILE`) is unchanged.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -2,7 +2,7 @@ use crate::commands::load_quill;
 use crate::errors::{CliError, Result};
 use crate::output::{derive_output_path, page_output_path, write_output};
 use clap::Parser;
-use quillmark::{Document, Quillmark};
+use quillmark::Quillmark;
 use quillmark_core::{OutputFormat, RenderOptions};
 use std::fs;
 use std::path::PathBuf;
@@ -69,7 +69,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             }
 
             let markdown = fs::read_to_string(markdown_path)?;
-            let output = Document::parse(&markdown)?;
+            let output = quill.parse(&markdown)?;
 
             if args.verbose {
                 eprintln!("Markdown parsed successfully");

--- a/crates/bindings/cli/src/errors.rs
+++ b/crates/bindings/cli/src/errors.rs
@@ -42,6 +42,17 @@ impl From<quillmark_core::ParseError> for CliError {
     }
 }
 
+impl From<quillmark_core::BoundParseError> for CliError {
+    fn from(err: quillmark_core::BoundParseError) -> Self {
+        use quillmark_core::BoundParseError as E;
+        match err {
+            E::Parse(e) => CliError::Parse(e),
+            E::Mismatch(e) => CliError::Render(e),
+            other => CliError::InvalidArgument(other.to_string()),
+        }
+    }
+}
+
 pub type Result<T> = std::result::Result<T, CliError>;
 
 pub fn print_cli_error(err: &CliError) {

--- a/crates/bindings/cli/tests/smoke.rs
+++ b/crates/bindings/cli/tests/smoke.rs
@@ -222,6 +222,37 @@ fn multi_page_stdout_is_refused() {
     );
 }
 
+/// `render` parses through the bound door, so a construct the quill declares
+/// its plate does not typeset reaches stderr instead of vanishing: `usaf_memo`
+/// declares `body.unsupported: [rule]`, and a `***` leaves the page unmarked.
+#[test]
+fn a_declined_construct_warns_on_stderr() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let doc = dir.path().join("rule.md");
+    std::fs::write(
+        &doc,
+        "~~~card-yaml\n$quill: usaf_memo\n$kind: main\n~~~\n\none\n\n***\n\ntwo\n",
+    )
+    .expect("write the input document");
+
+    let memo = quillmark_fixtures::quills_path("usaf_memo");
+    let out_pdf = dir.path().join("rule.pdf");
+    let out = run(&[
+        "render",
+        memo.to_str().unwrap(),
+        doc.to_str().unwrap(),
+        "-o",
+        out_pdf.to_str().unwrap(),
+    ]);
+
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(out.status.success(), "render exited nonzero: {stderr}");
+    assert!(
+        stderr.contains("plate::unsupported_construct"),
+        "the declined construct raised no warning: {stderr}"
+    );
+}
+
 /// Exit 1 rather than any non-zero code: a panic exits differently, so a script
 /// reading the status can tell a refusal from a crash.
 #[test]


### PR DESCRIPTION
`render` parsed a `MARKDOWN_FILE` through `Document::parse`, the transport door, so the conform walk and the declined-construct walk never ran and their warnings never reached stderr: a `usaf_memo` body containing `***` rendered with an empty stderr and exit 0. It now parses through `Quill::parse`, the bound door, whose `Parsed.warnings` the existing splice and `print_warnings` path already knew how to carry.

`BoundParseError` maps in `errors.rs` (with a wildcard arm for the `#[non_exhaustive]` enum) so `render.rs` moves only two lines, which matters because four other open issues edit that file. Rendered bytes are unchanged and a `$quill` mismatch still exits 1 with the same diagnostics, just raised at parse instead of at compile; the seeded path is untouched. A new smoke case asserts stderr names `plate::unsupported_construct` and was seen failing before the fix.

Closes #1507

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_