### PR TITLE
fix(cli): validate states each failure once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,13 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(cli): **`validate` states each failure once.** A failing run printed its
+  own summary and then a second copy through the error it returned, which
+  `main` labelled `[ERROR] Invalid argument:` — including on a load failure,
+  which is a quill config failure and not an argument the caller got wrong. The
+  command returns `CliError::Reported` once it has written the per-diagnostic
+  lines and the summary, and a load failure carries the loader's `RenderError`
+  the way every other subcommand does. Exit status stays 1 on every path.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/bindings/cli/src/commands/validate.rs
+++ b/crates/bindings/cli/src/commands/validate.rs
@@ -65,20 +65,7 @@ pub fn execute(args: ValidateArgs) -> Result<()> {
     let mut result = ValidationResult::new();
 
     // `_with_warnings` keeps the config warnings the plain loader drops.
-    let (quill, config_warnings) = match quillmark::quill_from_path_with_warnings(&args.quill_path) {
-        Ok(pair) => pair,
-        Err(e) => {
-            for diag in e.diagnostics() {
-                eprintln!("{}", diag.fmt_pretty());
-            }
-            // The branch covers every load failure, a missing directory and an
-            // unreadable `Quill.yaml` among them, so it names neither.
-            eprintln!("\nValidation failed: {} error(s)", e.diagnostics().len());
-            return Err(CliError::InvalidArgument(
-                "Quill could not be loaded".to_string(),
-            ));
-        }
-    };
+    let (quill, config_warnings) = quillmark::quill_from_path_with_warnings(&args.quill_path)?;
     let config = quill.config();
 
     result.issues.extend(config_warnings);
@@ -103,10 +90,7 @@ pub fn execute(args: ValidateArgs) -> Result<()> {
     print_validation_result(&result, args.verbose);
 
     if result.has_errors() {
-        Err(CliError::InvalidArgument(format!(
-            "Validation failed with {} error(s)",
-            result.count(Severity::Error)
-        )))
+        Err(CliError::Reported)
     } else {
         Ok(())
     }

--- a/crates/bindings/cli/src/errors.rs
+++ b/crates/bindings/cli/src/errors.rs
@@ -2,13 +2,15 @@ use quillmark_core::RenderError;
 use std::fmt;
 
 /// [`print_cli_error`] renders full diagnostics for the render and parse
-/// variants, a plain line for the rest.
+/// variants, a plain line for `Io` and `InvalidArgument`, and nothing for
+/// `Reported`, whose diagnostics the command has already written.
 #[derive(Debug)]
 pub enum CliError {
     Io(std::io::Error),
     Render(RenderError),
     Parse(quillmark_core::ParseError),
     InvalidArgument(String),
+    Reported,
 }
 
 impl fmt::Display for CliError {
@@ -18,6 +20,7 @@ impl fmt::Display for CliError {
             CliError::Render(e) => write!(f, "{}", e),
             CliError::Parse(e) => write!(f, "Parse error: {}", e),
             CliError::InvalidArgument(msg) => write!(f, "Invalid argument: {}", msg),
+            CliError::Reported => write!(f, "diagnostics reported"),
         }
     }
 }
@@ -58,6 +61,7 @@ pub fn print_cli_error(err: &CliError) {
         CliError::InvalidArgument(msg) => {
             eprintln!("[ERROR] Invalid argument: {}", msg);
         }
+        CliError::Reported => {}
     }
 }
 

--- a/crates/bindings/cli/tests/smoke.rs
+++ b/crates/bindings/cli/tests/smoke.rs
@@ -77,6 +77,72 @@ fn validate_accepts_a_shipped_quill() {
     ok(&["validate", quill.to_str().unwrap()]);
 }
 
+/// A quill directory carrying just `yaml`, for the failure paths no shipped
+/// fixture covers.
+fn quill_with_config(yaml: &str) -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    std::fs::write(dir.path().join("Quill.yaml"), yaml).expect("write Quill.yaml");
+    dir
+}
+
+/// One summary, not one per printer: the command writes its own, so the error
+/// it returns must not carry a second.
+#[test]
+fn a_failing_validate_prints_one_summary() {
+    let dir = quill_with_config(
+        r#"quill:
+  name: broken
+  version: 0.1.0
+  backend: typst
+  description: Names a plate that is not there
+typst:
+  plate_file: absent.typ
+main:
+  fields:
+    title:
+      description: title of document
+      type: string
+"#,
+    );
+
+    let out = run(&["validate", dir.path().to_str().unwrap()]);
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "a failing validate exited {:?}",
+        out.status.code()
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    let summaries = stderr
+        .lines()
+        .filter(|line| line.contains("Validation failed"))
+        .count();
+    assert_eq!(summaries, 1, "expected one summary line: {stderr}");
+}
+
+/// A config that will not load is a quill failure, and reads as one.
+#[test]
+fn an_unloadable_quill_is_not_an_invalid_argument() {
+    let dir = quill_with_config("quill:\n  name: broken\n  backend: typst\n");
+
+    let out = run(&["validate", dir.path().to_str().unwrap()]);
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "an unloadable quill exited {:?}",
+        out.status.code()
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("quill::missing_version"),
+        "the load diagnostics are missing: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Invalid argument"),
+        "a load failure is labelled an invalid argument: {stderr}"
+    );
+}
+
 /// The two commands that take `-o`.
 #[test]
 fn output_flag_writes_the_named_file() {


### PR DESCRIPTION
`quillmark validate` reported each failure twice: its own stderr summary, then a second one through the `CliError::InvalidArgument` it returned, and it gave a quill config failure the "Invalid argument" label. A crate-private `CliError::Reported` now means "the diagnostics are already on stderr"; `print_cli_error` prints nothing for it and `validate` returns it after its summary.

The load failure goes through `CliError::Render`, the variant `commands::load_quill` already hands every other subcommand for the same `RenderError`, which costs that path its `Validation failed: N error(s)` line and gains it consistency with `info` and `schema`. Exit status stays 1 on every path, and the `Quill.yaml not found in:` early return keeps `InvalidArgument`, which fits it. Two smoke cases pin the single summary line and the missing label; both were seen failing before the fix. The diff does not touch `render.rs`.

Closes #1534

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_