### PR TITLE
fix(cli): create parent directories for schema -o and blueprint -o

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,19 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(cli): **`schema -o` and `blueprint -o` create the parent directories
+  their path names, as `render -o` does.** Both wrote with a bare `fs::write`,
+  so `schema ./q -o nested/dir/s.yaml` failed with "No such file or
+  directory" while the same path under `render -o` succeeded. The CLI's
+  `write_output` splits into `write_stdout(bytes)` and `write_file(path,
+  bytes, announce)` — dropping the unreachable arm that refused neither
+  stdout nor a path — and all three `-o` flags route through `write_file`.
+  `schema` and `blueprint` pass `announce: false` and stay silent on stdout;
+  `render` announces unless `--quiet`.
+- refactor(quillmark): **`Quillmark::render` resolves the backend once.** It
+  called `supported_formats` and `open`, each resolving the quill's backend
+  separately; it now holds the resolved backend and asks it for both. Same
+  diagnostics in the same order.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/bindings/cli/src/commands/blueprint.rs
+++ b/crates/bindings/cli/src/commands/blueprint.rs
@@ -1,7 +1,7 @@
 use crate::commands::load_quill;
-use crate::errors::{CliError, Result};
+use crate::errors::Result;
+use crate::output::write_file;
 use clap::Parser;
-use std::fs;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -21,7 +21,7 @@ pub fn execute(args: BlueprintArgs) -> Result<()> {
     let blueprint = quill.config().blueprint();
 
     if let Some(output_path) = args.output {
-        fs::write(&output_path, blueprint).map_err(CliError::Io)?;
+        write_file(&output_path, blueprint.as_bytes(), false)?;
     } else {
         println!("{}", blueprint);
     }

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -1,6 +1,6 @@
 use crate::commands::load_quill;
 use crate::errors::{CliError, Result};
-use crate::output::{derive_output_path, page_output_path, write_output};
+use crate::output::{derive_output_path, page_output_path, write_file, write_stdout};
 use clap::Parser;
 use quillmark::{Document, Quillmark};
 use quillmark_core::{OutputFormat, RenderOptions};
@@ -152,7 +152,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
                 result.artifacts.len()
             )));
         }
-        write_output(true, None, args.quiet, &result.artifacts[0].bytes)?;
+        write_stdout(&result.artifacts[0].bytes)?;
     } else {
         let output_path = args.output.unwrap_or_else(|| {
             if let Some(ref path) = markdown_path_for_output {
@@ -162,13 +162,13 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             }
         });
         if let [artifact] = result.artifacts.as_slice() {
-            write_output(false, Some(&output_path), args.quiet, &artifact.bytes)?;
+            write_file(&output_path, &artifact.bytes, !args.quiet)?;
         } else {
             // Every page numbered, page one included: an unnumbered file beside
             // numbered ones reads as the whole document.
             for (i, artifact) in result.artifacts.iter().enumerate() {
                 let path = page_output_path(&output_path, i + 1);
-                write_output(false, Some(&path), args.quiet, &artifact.bytes)?;
+                write_file(&path, &artifact.bytes, !args.quiet)?;
             }
         }
     }

--- a/crates/bindings/cli/src/commands/schema.rs
+++ b/crates/bindings/cli/src/commands/schema.rs
@@ -1,7 +1,7 @@
 use crate::commands::load_quill;
 use crate::errors::{CliError, Result};
+use crate::output::write_file;
 use clap::Parser;
-use std::fs;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -24,7 +24,7 @@ pub fn execute(args: SchemaArgs) -> Result<()> {
         .map_err(|e| CliError::InvalidArgument(format!("Failed to serialize schema: {}", e)))?;
 
     if let Some(output_path) = args.output {
-        fs::write(&output_path, schema_yaml).map_err(CliError::Io)?;
+        write_file(&output_path, schema_yaml.as_bytes(), false)?;
     } else {
         println!("{}", schema_yaml);
     }

--- a/crates/bindings/cli/src/output.rs
+++ b/crates/bindings/cli/src/output.rs
@@ -3,31 +3,22 @@ use std::fs;
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
-/// Write `bytes` to stdout, or to `output_path` (creating parent directories),
-/// announcing the destination unless `quiet`. Stdout wins when both are set;
-/// neither set is an argument error.
-pub fn write_output(
-    use_stdout: bool,
-    output_path: Option<&Path>,
-    quiet: bool,
-    bytes: &[u8],
-) -> Result<()> {
-    if use_stdout {
-        io::stdout().write_all(bytes)?;
-        return Ok(());
-    }
-    let Some(path) = output_path else {
-        return Err(crate::errors::CliError::InvalidArgument(
-            "No output path configured and stdout output not selected".to_string(),
-        ));
-    };
+/// Write `bytes` to stdout.
+pub fn write_stdout(bytes: &[u8]) -> Result<()> {
+    io::stdout().write_all(bytes)?;
+    Ok(())
+}
+
+/// Write `bytes` to `path`, creating its parent directories, naming the
+/// destination on stdout when `announce`.
+pub fn write_file(path: &Path, bytes: &[u8], announce: bool) -> Result<()> {
     if let Some(parent) = path.parent() {
         if !parent.exists() {
             fs::create_dir_all(parent)?;
         }
     }
     fs::write(path, bytes)?;
-    if !quiet {
+    if announce {
         println!("Output written to: {}", path.display());
     }
     Ok(())

--- a/crates/bindings/cli/tests/smoke.rs
+++ b/crates/bindings/cli/tests/smoke.rs
@@ -91,6 +91,22 @@ fn output_flag_writes_the_named_file() {
     }
 }
 
+/// `-o` names a directory that does not exist yet, as `render -o` allows, and
+/// the file still lands there without a word on stdout.
+#[test]
+fn output_flag_creates_parent_directories() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let quill = taro();
+
+    for (cmd, name) in [("schema", "s.yaml"), ("blueprint", "b.md")] {
+        let path = dir.path().join("nested").join(cmd).join(name);
+        let stdout = ok(&[cmd, quill.to_str().unwrap(), "-o", path.to_str().unwrap()]);
+        assert!(stdout.is_empty(), "{cmd} -o wrote to stdout: {stdout}");
+        let written = std::fs::read_to_string(&path).expect("the -o file exists");
+        assert!(!written.trim().is_empty(), "{cmd} -o wrote an empty file");
+    }
+}
+
 /// The one command that reaches a backend, seeded (no markdown argument).
 #[test]
 fn render_writes_a_pdf() {

--- a/crates/quillmark/src/orchestration/engine.rs
+++ b/crates/quillmark/src/orchestration/engine.rs
@@ -83,8 +83,9 @@ impl Quillmark {
         doc: &Document,
         opts: &RenderOptions,
     ) -> Result<RenderResult, RenderError> {
-        let default_format = self.supported_formats(quill)?.first().copied();
-        let session = self.open(quill, doc)?;
+        let backend = self.resolve_backend(quill)?;
+        let default_format = backend.supported_formats().first().copied();
+        let session = backend.open(quill, &quill.compile_checked(doc)?)?;
         // Clone-and-narrow so a new RenderOptions field is carried through by
         // default; only `output_format` gets the backend-default fallback.
         let mut resolved = opts.clone();


### PR DESCRIPTION
`schema -o` and `blueprint -o` wrote with a bare `fs::write`, so a path naming a directory that does not exist yet failed with "No such file or directory" where `render -o` created it and succeeded. All three now route through one `write_file`, which the CLI's `write_output` splits into alongside `write_stdout`, dropping that function's unreachable "neither stdout nor a path" arm.

The one judgement call: `write_file` takes `announce: bool` rather than `quiet: bool`, because neither `SchemaArgs` nor `BlueprintArgs` has a `--quiet` flag to pass; those two pass `false` and stay silent as today, `render` passes `!args.quiet` and announces as today. `render.rs` changes only its three call-site lines plus the import, since other open PRs touch that file.

Second finding from the same issue: `Quillmark::render` resolved the quill's backend twice (once via `supported_formats`, once via `open`) and now holds it once; no behavior change, same diagnostics in the same order. The new smoke case fails on `main` with the issue's exact error.

Closes #1535

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_