### PR TITLE
fix(cli): derive the output filename from the parsed format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,11 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(cli): **`-f PDF` writes `example.pdf`.** `--format` parses
+  case-insensitively, but the derived output filename, the `example.<fmt>`
+  fallback and the multi-page `--stdout` refusal interpolated the flag as
+  typed, so `-f PDF` wrote `example.PDF` and `-f Svg` named `Svg` in its
+  message. All three read the parsed format's lowercase id.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -148,7 +148,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             return Err(CliError::InvalidArgument(format!(
                 "{} renders {} pages, one artifact each, and --stdout carries one; \
                  drop --stdout to write the pages as files",
-                args.format,
+                output_format,
                 result.artifacts.len()
             )));
         }
@@ -156,9 +156,9 @@ pub fn execute(args: RenderArgs) -> Result<()> {
     } else {
         let output_path = args.output.unwrap_or_else(|| {
             if let Some(ref path) = markdown_path_for_output {
-                derive_output_path(path, &args.format)
+                derive_output_path(path, output_format.as_str())
             } else {
-                PathBuf::from(format!("example.{}", args.format))
+                PathBuf::from(format!("example.{}", output_format))
             }
         });
         if let [artifact] = result.artifacts.as_slice() {

--- a/crates/bindings/cli/tests/smoke.rs
+++ b/crates/bindings/cli/tests/smoke.rs
@@ -266,3 +266,31 @@ fn unknown_format_fails_loudly() {
     );
 }
 
+
+/// `--format` parses case-insensitively, and the derived filename takes the
+/// parsed format's id, not the flag as typed.
+#[test]
+fn format_casing_does_not_reach_the_output_filename() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let quill = taro();
+
+    let out = cli()
+        .current_dir(dir.path())
+        .args(["render", quill.to_str().unwrap(), "-f", "PDF", "--quiet"])
+        .output()
+        .expect("the built binary is executable");
+    assert!(
+        out.status.success(),
+        "render -f PDF exited {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        dir.path().join("example.pdf").is_file(),
+        "example.pdf missing; dir holds {:?}",
+        std::fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name())
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
`--format` parses case-insensitively through `OutputFormat::from_str`, but three sites in `render` interpolated the raw flag: the derived output path, the `example.<fmt>` fallback, and the multi-page `--stdout` refusal. `-f PDF` therefore wrote `example.PDF`, and a document named `memo.md` rendered with `-f Svg` landed as `memo.Svg`.

All three now read the parsed `OutputFormat`, whose `Display` and `as_str` are the lowercase id every binding shares. This is the minimal fix from the issue; declaring `format: OutputFormat` on `RenderArgs` via a clap `value_parser` is left for after #1509 settles the usage-error exit code, since it would move a bad `-f` from exit 1 to exit 2. The new smoke case renders with `-f PDF` and pins `example.pdf`; before the fix it fails with `example.PDF`. The change is three lines in `render.rs`, so it composes with the other open CLI PRs.

Closes #1508

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_