### PR TITLE
fix(cli): let --quiet silence every --verbose line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,11 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(cli): **`--quiet` silences `--verbose` entirely.** Seven of the nine
+  `--verbose` lines in `render` printed regardless of `--quiet`, only the two
+  after the compile checking it, so `--verbose --quiet` still narrated the
+  load and the parse. `execute` resolves the pair once up front, and the help
+  text's "Suppress all non-error output" is what the flag does.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/bindings/cli/src/commands/render.rs
+++ b/crates/bindings/cli/src/commands/render.rs
@@ -45,13 +45,14 @@ pub struct RenderArgs {
 // Progress chatter goes to stderr: under `--stdout` the artifact owns stdout,
 // and a `--verbose` line there would land inside the emitted PDF.
 pub fn execute(args: RenderArgs) -> Result<()> {
-    if args.verbose {
+    let verbose = args.verbose && !args.quiet;
+    if verbose {
         eprintln!("Loading quill from: {}", args.quill.display());
     }
 
     let quill = load_quill(&args.quill)?;
 
-    if args.verbose {
+    if verbose {
         eprintln!("Quill loaded: {}", quill.name());
     }
 
@@ -64,14 +65,14 @@ pub fn execute(args: RenderArgs) -> Result<()> {
                 )));
             }
 
-            if args.verbose {
+            if verbose {
                 eprintln!("Reading markdown from: {}", markdown_path.display());
             }
 
             let markdown = fs::read_to_string(markdown_path)?;
             let output = Document::parse(&markdown)?;
 
-            if args.verbose {
+            if verbose {
                 eprintln!("Markdown parsed successfully");
             }
             (
@@ -81,13 +82,13 @@ pub fn execute(args: RenderArgs) -> Result<()> {
             )
         } else {
             // No input file: the seed renders without any caller-supplied values.
-            if args.verbose {
+            if verbose {
                 eprintln!("Using seeded document from quill");
             }
             (quill.seed_document(), Vec::new(), None)
         };
 
-    if args.verbose {
+    if verbose {
         eprintln!("Render-ready quill for backend: {}", quill.backend_id());
     }
 
@@ -96,7 +97,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
         .parse::<OutputFormat>()
         .map_err(|e| CliError::InvalidArgument(e.to_string()))?;
 
-    if args.verbose {
+    if verbose {
         eprintln!("Rendering to format: {:?}", output_format);
     }
 
@@ -118,7 +119,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
                 e
             )))
         })?;
-        if args.verbose && !args.quiet {
+        if verbose {
             eprintln!("JSON data written to: {}", data_path.display());
         }
     }
@@ -173,7 +174,7 @@ pub fn execute(args: RenderArgs) -> Result<()> {
         }
     }
 
-    if args.verbose && !args.quiet {
+    if verbose {
         eprintln!("Rendering completed successfully");
     }
 

--- a/crates/bindings/cli/tests/smoke.rs
+++ b/crates/bindings/cli/tests/smoke.rs
@@ -266,3 +266,27 @@ fn unknown_format_fails_loudly() {
     );
 }
 
+
+/// `--quiet` wins over `--verbose`: no progress line reaches stderr.
+#[test]
+fn quiet_silences_verbose() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let out_path = dir.path().join("out.pdf");
+    let quill = taro();
+
+    let out = run(&[
+        "render",
+        quill.to_str().unwrap(),
+        "-o",
+        out_path.to_str().unwrap(),
+        "--verbose",
+        "--quiet",
+    ]);
+    assert!(out.status.success(), "exited {:?}", out.status.code());
+    assert!(
+        out.stderr.is_empty(),
+        "--quiet let --verbose through:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out.stdout.is_empty(), "--quiet let the destination line through");
+}

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -31,7 +31,7 @@ The file must open with a `~~~` block containing a `$quill:` key identifying the
 - `-f <FORMAT>` / `--format <FORMAT>`: Output format: `pdf`, `svg`, `png` (default: `pdf`)
 - `--output-data <DATA_FILE>`: Write compiled JSON data to a file
 - `-v` / `--verbose`: Show detailed processing information on stderr
-- `--quiet`: Suppress warnings and the output-destination line
+- `--quiet`: Suppress all non-error output: `--verbose` chatter, warnings and the output-destination line
 - `--stdout`: Write the artifact to stdout instead of a file (and ignore `-o`); refused when the render produces more than one page
 
 **Streams:** under `--stdout` the artifact owns stdout, and progress, warnings, and errors all go to stderr, so `quillmark render ./my-quill input.md --stdout --verbose > out.pdf` writes a valid PDF. Without `--stdout`, the one stdout line is `Output written to: <path>`, which `--quiet` suppresses.


### PR DESCRIPTION
`render` guarded seven of its nine `--verbose` lines on `args.verbose` alone and only the two after the compile on `args.verbose && !args.quiet`, so `--verbose --quiet` still narrated the quill load, the document parse and the format on stderr while the help text promised "Suppress all non-error output". (The issue counts five leaking lines; that is what the seeded path shows, the markdown-file path has two more.)

`execute` resolves the pair once (`verbose = args.verbose && !args.quiet`) and every progress line reads that. A local flag rather than a clap `conflicts_with`, because the latter would turn `--verbose --quiet` into a usage error exiting 2, which is the exit-code question #1509 has open. The reference page's `--quiet` line now says what the flag suppresses. The smoke case runs `--verbose --quiet` and pins an empty stderr and stdout; it fails before the fix. The `render.rs` change is mechanical (`args.verbose` → `verbose`), so it composes with the other open CLI PRs.

Closes #1533

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LppcU1prsmLoQhkrDrMVmv)_