### PR TITLE
fix(typst): code a compile diagnostic from a closed set, not its message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- fix(typst): **a compile diagnostic carries a code from a closed set.** The
+  code was the message up to its first `:`, so a missing asset minted
+  `typst::file not found (searched at assets/logo.png)` — the author's path
+  inside what consumers route on, one code per input — and a URL truncated
+  mid-value to `typst::file not found (searched at https`. Most Typst messages
+  hold no `:` at all, so the whole sentence became the code. The mapping now
+  classifies: `typst::file_not_found`, `typst::unknown_variable`,
+  `typst::type_error`, and `typst::compile` for every message the set does not
+  name, warnings included. Typst's sentence, and the path it searched, stay in
+  `message`.
 - fix(core): **an unclosed root `~~~` block is reported as unclosed.** A
   document that opens with `~~~` and `$quill` but never closes the fence drew
   the generic `parse::missing_quill` text, telling the author to open a block

--- a/crates/backends/typst/src/error_mapping.rs
+++ b/crates/backends/typst/src/error_mapping.rs
@@ -21,17 +21,44 @@ fn map_single_diagnostic(error: &SourceDiagnostic, world: &QuillWorld) -> Diagno
 
     let hint = error.hints.first().map(|h| h.v.to_string());
 
-    // Typst has no error codes; the message prefix stands in.
-    let code = Some(format!(
-        "typst::{}",
-        error.message.split(':').next().unwrap_or("error").trim()
-    ));
-
     let mut diag = Diagnostic::new(severity, error.message.to_string());
-    diag.code = code;
+    diag.code = Some(classify(&error.message).to_string());
     diag.location = location;
     diag.hint = hint;
     diag
+}
+
+/// Typst renders a type mismatch two ways: the cast machinery's
+/// `expected <a>, found <b>`, and the operand families of its `ops` module.
+fn is_type_error(message: &str) -> bool {
+    const OPERAND_MISMATCH: &[&str] = &[
+        "cannot add ",
+        "cannot apply ",
+        "cannot compare ",
+        "cannot divide ",
+        "cannot join ",
+        "cannot multiply ",
+        "cannot subtract ",
+    ];
+
+    (message.starts_with("expected ") && message.contains(", found "))
+        || OPERAND_MISMATCH.iter().any(|p| message.starts_with(p))
+}
+
+/// Typst has no error codes, so one is minted from the message's *shape*. The
+/// set is closed: an unrecognized message takes `typst::compile` rather than a
+/// code spelled by the message itself, which would carry author-supplied text
+/// into a routing key and leave that key unbounded.
+fn classify(message: &str) -> &'static str {
+    if message.starts_with("file not found (searched at ") {
+        "typst::file_not_found"
+    } else if message.starts_with("unknown variable: ") {
+        "typst::unknown_variable"
+    } else if is_type_error(message) {
+        "typst::type_error"
+    } else {
+        "typst::compile"
+    }
 }
 
 fn resolve_span_to_location(span: typst::syntax::DiagSpan, world: &QuillWorld) -> Option<Location> {
@@ -101,6 +128,60 @@ mod tests {
         Some(Quill::from_tree(tree).expect("load source"))
     }
 
+    /// Messages Typst 0.15.1 emits, taken from a compile of each case.
+    const REAL_MESSAGES: &[(&str, &str)] = &[
+        (
+            "file not found (searched at assets/marc.png)",
+            "typst::file_not_found",
+        ),
+        (
+            "file not found (searched at https:/example.com/x.png)",
+            "typst::file_not_found",
+        ),
+        ("unknown variable: general", "typst::unknown_variable"),
+        ("cannot add integer and string", "typst::type_error"),
+        ("expected length, found string", "typst::type_error"),
+        ("cannot apply 'not' to integer", "typst::type_error"),
+        ("unclosed delimiter", "typst::compile"),
+        ("expected expression", "typst::compile"),
+        ("unknown font family: nosuchfontfamily", "typst::compile"),
+    ];
+
+    #[test]
+    fn every_message_takes_a_code_from_the_closed_set() {
+        for (message, code) in REAL_MESSAGES {
+            assert_eq!(&classify(message), code, "classifying {message:?}");
+        }
+    }
+
+    /// The property the code exists for: a routing key a consumer can match and
+    /// a string table can hold, carrying none of the message it came from.
+    #[test]
+    fn a_code_is_a_slug_never_the_message() {
+        for (message, _) in REAL_MESSAGES {
+            let code = classify(message);
+            let slug = code.strip_prefix("typst::").expect("namespaced");
+            assert!(
+                !slug.is_empty() && slug.chars().all(|c| c.is_ascii_lowercase() || c == '_'),
+                "`{code}` is not a snake_case slug"
+            );
+            assert!(
+                !code.contains(message),
+                "`{code}` carries the message it was minted from"
+            );
+        }
+    }
+
+    /// An author-supplied path separates two messages of one shape; the code
+    /// they share is what a consumer routes on.
+    #[test]
+    fn a_path_in_the_message_does_not_reach_the_code() {
+        let a = classify("file not found (searched at assets/marc.png)");
+        let b = classify("file not found (searched at /etc/passwd)");
+        assert_eq!(a, b);
+        assert!(!a.contains("marc") && !a.contains("passwd"));
+    }
+
     #[test]
     fn columns_count_characters_not_bytes() {
         let text = "#let café = 1\n#(café + x)\n";
@@ -124,6 +205,38 @@ mod tests {
             mapped.hint.as_deref(),
             Some("try using a backslash escape: \\]"),
             "an existing Typst hint must not be overwritten"
+        );
+    }
+
+    /// The closed set holds against a real compile, not only against the
+    /// message table: Typst spells the path it searched into the message, and
+    /// the code stays the shape's.
+    #[test]
+    fn a_missing_file_codes_by_shape_through_a_compile() {
+        let Some(source) = source_with_plate(
+            "#set page(width: 200pt, height: 200pt)\n#image(\"assets/marc.png\")\n",
+        ) else {
+            return;
+        };
+
+        let diags = match TypstBackend.open(&source, &serde_json::json!({})) {
+            Ok(session) => session
+                .render(&RenderOptions::default().with_output_format(OutputFormat::Pdf))
+                .expect_err("a missing image should fail to compile")
+                .into_diagnostics(),
+            Err(err) => err.into_diagnostics(),
+        };
+
+        let diag = diags
+            .iter()
+            .find(|d| d.message.starts_with("file not found"))
+            .expect("expected a file-not-found diagnostic");
+
+        assert_eq!(diag.code.as_deref(), Some("typst::file_not_found"));
+        assert!(
+            diag.message.contains("assets/marc.png"),
+            "the searched path stays in the message: {}",
+            diag.message
         );
     }
 

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -177,7 +177,7 @@ impl Location {
 #[non_exhaustive]
 pub struct Diagnostic {
     pub severity: Severity,
-    /// Stable error code, e.g. `"parse::empty_input"` or `"typst::syntax"`.
+    /// Stable error code, e.g. `"parse::empty_input"` or `"typst::type_error"`.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub code: Option<String>,
     pub message: String,

--- a/docs/integration/error-handling.md
+++ b/docs/integration/error-handling.md
@@ -55,6 +55,8 @@ The `code` namespaces are the routing surface:
 
 Notable codes: `quill::name_mismatch` / `quill::version_mismatch` (a well-formed document paired with the wrong quill; see [Versioning](../quills/versioning.md)); `engine::backend_not_found` (the quill's declared backend is not registered); `parse::input_too_large`, which carries the two byte-sized [§8 caps](../reference/markdown-spec.md#8-limits) — document size and YAML payload size — distinguished only by its `max` arg, while the count caps arrive as `parse::too_many_cards` and `parse::too_many_fields` (args `count`, `max`) and the nesting cap as `parse::yaml_error_with_location`.
 
+A Typst compile classifies into four codes: `typst::file_not_found` (a file the quill's world refused — a missing asset is the common one), `typst::unknown_variable`, `typst::type_error`, and `typst::compile` for everything else, warnings included. They are a routing key only: which file was searched for, or which symbol was unknown, is read from `message`.
+
 ## Warnings vs errors
 
 Fatality is a two-value ladder: `Error` blocks the stage that emits it; `Warning` never does. There is no lint-level configuration and no warning-to-error promotion. Warnings ride the same `Diagnostic` currency on non-fatal channels:

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -110,7 +110,7 @@ families:
   Core cannot *detect* a plate dropping a construct — the absence of ink is
   not a signal a backend reports — so this family is a declaration, not an
   observation: nothing verifies it, and an undeclared drop stays silent.
-- **Compile warnings**: the Typst backend maps `typst::compile`'s non-fatal
+- **Compile warnings**: the Typst backend maps the compiler's non-fatal
   diagnostics (font fallback, overfull pages, …) through the same span
   resolution as errors. They are state of the session's current compile:
   exposed via `LiveSession::warnings()` (the `SessionHandle::warnings` seam,
@@ -147,7 +147,21 @@ Python and WASM bindings delegate to core types:
 Typst diagnostics mapped via `map_typst_errors()`:
 - Severity levels mapped (Error/Warning)
 - Spans resolved to file/line/column
-- Error codes: `"typst::<message-prefix>"` (the diagnostic message text up to the first `:`)
+- Error codes: a **closed set**, keyed off the message's shape
+
+Typst has no error codes of its own, so the mapping mints one. It classifies
+rather than quotes: `typst::file_not_found` (a file the world refused),
+`typst::unknown_variable` (a plate naming a symbol that is not in scope),
+`typst::type_error` (a value that is not what the position wanted), and
+`typst::compile` for every message the set does not name. Errors and warnings
+are classified alike.
+
+The residual bucket is what keeps the set closed, and a code spelled by the
+message instead is what it rules out: that would carry author-supplied text —
+a searched path, a symbol name — into a routing key, and give the key one
+value per input. Typst's sentence stays in `message`, which is where the
+searched path is read. Classification reads that English, so a reworded
+message degrades to `typst::compile` rather than minting a code of its own.
 
 See `crates/backends/typst/src/error_mapping.rs`.
 
@@ -363,7 +377,7 @@ Every `conform::*` row is reachable only through the content-field walk, so the 
 `validation::*`, `edit::*`, and `parse::*` are the codes an end user meets, and the table covers them. The rest carry no args, which is the domain's shape rather than a phase of the work:
 
 - **`quill::*`** is quill-authoring. Its reader is a template author debugging `Quill.yaml`, the one audience for whom canonical English is the deliverable. Three of its codes are `format!`-built per slot besides.
-- **`typst::*`** is an open set: the code is Typst's own message text up to the first `:` (`error_mapping.rs`), so it re-spells itself whenever Typst rewords a diagnostic and cannot key a string table at all.
+- **`typst::*`** is a closed set (`error_mapping.rs`), but a coarse one: the compile codes classify a Typst diagnostic without taking it apart, so the detail stays in the message that carries it.
 
 Because those codes carry no args, every consumer template falls back on them by the rule above. That is what makes a surface covering a third of the codes total rather than partial.
 


### PR DESCRIPTION
Closes #1587.

The `code` on every Typst compile diagnostic was the message up to its first `:`, so a missing asset minted `typst::file not found (searched at assets/logo.png)` — the author's path inside what consumers route on, one code per input — and a URL truncated mid-value to `typst::file not found (searched at https`.

Investigating first turned up that this is broader than the issue states: sampling typst 0.15.1's message templates, **530 of 605 hold no `:` at all**, so the whole sentence became the code; 281 of those interpolate a value. The colon-prefixed shape the derivation assumed is the exception. Reproducing six cases through real compiles, only `unknown variable: general` produced a prefix-shaped code — and that is the one shape the crate's own existing test exercises, which is plausibly how this survived.

## The change

`classify()` maps the message's *shape* to one of four codes: `typst::file_not_found`, `typst::unknown_variable`, `typst::type_error`, and `typst::compile` for everything the set does not name. Errors and warnings alike.

Each matcher is derived from Typst's own source rather than guessed: `FileError::NotFound`'s `Display` (`typst-library/src/diag.rs:650`), the two `unknown variable` sites (`foundations/scope.rs:425,442`), and for `type_error` the cast machinery's `expected …, found …` plus the seven operand verbs in `foundations/ops.rs`. A bare `cannot ` prefix is deliberately not matched — it spans 102 distinct messages including `cannot access file system from here`, which is not a type error.

Classification still reads Typst's English, but its failure mode is now the residual bucket rather than a minted code: a reworded message stops matching and lands in `typst::compile`.

## Docs

Three live sites, not only the one the issue named:

- `ERROR.md:150` — the message-prefix rule, replaced by the closed set.
- `ERROR.md:366` — already conceded the defect ("`typst::*` is an open set … cannot key a string table at all"); now states the closed set and that it is coarse.
- `ERROR.md:113` — read "the Typst backend maps `typst::compile`'s non-fatal diagnostics", meaning the Rust function. That collides with the new code name, so it is now "the compiler's".

Also the consumer-facing notable-codes list in `docs/integration/error-handling.md`, `CHANGELOG.md`, and the `"typst::syntax"` example at `core/src/error.rs:180` — a code no Typst message could produce, since none begins `syntax:`.

`docs/migrations/0.99-to-0.100.md` also describes the old rule and is left alone as history.

## Tests

- A table over the nine messages captured from real compiles.
- The invariant the code exists for: every code is a `[a-z_]+` slug carrying none of its message.
- Two different paths in one message shape yield one shared code.
- End-to-end: compile a missing `#image`, assert `typst::file_not_found` and that the searched path stays in `message`.

`cargo test --workspace`: 65 binaries, all green. Clippy clean on the changed file.

## Left out

**The searched path does not ride in `args`** (the issue's proposal 2). Verified by experiment: adding `| typst::file_not_found | path | structured |` to the canon table fails `error::args_canon::diagnostic_args_match_canon`, because `minted()` enumerates core-crate enums only and core cannot import the Typst backend. Unblocking it means moving that test to a crate that sees both (`crates/quillmark`), or splitting it so each crate verifies its own rows — a decision about where canon governance lives, not part of this fix. `ERROR.md`'s "the rest carry no args" therefore still holds and is untouched.

## For review

- `typst::type_error` has a small over-capture tail: `expected …, found …` also catches count errors like `expected 2 characters, found 3 characters`. Narrowing it means enumerating more English.
- Warnings share the mapper (`compile.rs:38`), so a font-fallback warning that got `typst::unknown font family` now gets `typst::compile`. If font fallback is worth routing on it wants its own bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hmCvcaBop1YbebMZjU2sG

---
_Generated by [Claude Code](https://claude.ai/code/session_015hmCvcaBop1YbebMZjU2sG)_