### PR TITLE
docs: state what a text ingress admits, and that nothing reports it

### DIFF
--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -347,6 +347,13 @@ export interface CardAddr {
  * A text-splice change set over the USV content (CodeMirror `ChangeSet`
  * semantics), returned by `revise` and by the `rebase` codec. Map a stored
  * position through it with `mapPos`.
+ *
+ * Applying one **admits** an `insert` string rather than storing it verbatim.
+ * `\r` and the Unicode bidi controls drop. A U+2028 or U+2029 line separator
+ * becomes a space, a downstream lexer reading one as a line break and no escape
+ * neutralizing it. Nothing reports the substitution: the apply succeeds either
+ * way, so a caller that needs to know compares the applied text against what it
+ * sent.
  */
 export interface Delta {
     ops: ({ retain: number } | { insert: string } | { delete: number })[];

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -348,12 +348,9 @@ export interface CardAddr {
  * semantics), returned by `revise` and by the `rebase` codec. Map a stored
  * position through it with `mapPos`.
  *
- * Applying one **admits** an `insert` string rather than storing it verbatim.
- * `\r` and the Unicode bidi controls drop. A U+2028 or U+2029 line separator
- * becomes a space, a downstream lexer reading one as a line break and no escape
- * neutralizing it. Nothing reports the substitution: the apply succeeds either
- * way, so a caller that needs to know compares the applied text against what it
- * sent.
+ * Applying one admits an `insert` string rather than storing it verbatim: `\r`
+ * and the Unicode bidi controls drop, and a U+2028 or U+2029 line separator
+ * becomes a space. Nothing reports the substitution.
  */
 export interface Delta {
     ops: ({ retain: number } | { insert: string } | { delete: number })[];

--- a/crates/content/src/normalize.rs
+++ b/crates/content/src/normalize.rs
@@ -34,7 +34,9 @@ pub(crate) fn is_line_separator(c: char) -> bool {
 /// because it pairs with a `\n` that stays; a line separator becomes a space,
 /// both being Unicode whitespace, so dropping one would join the words it parts.
 /// No downstream escape can neutralize a separator — a `\` before whitespace is
-/// Typst's own linebreak — so the content refuses it.
+/// Typst's own linebreak — so it cannot survive in the text. Nothing reports the
+/// substitution; [`Content::validate`](crate::Content::validate) refuses only a
+/// separator that reached a content without passing an ingress.
 #[inline]
 pub(crate) fn admit_char(c: char) -> Option<char> {
     match c {

--- a/crates/content/src/normalize.rs
+++ b/crates/content/src/normalize.rs
@@ -34,9 +34,7 @@ pub(crate) fn is_line_separator(c: char) -> bool {
 /// because it pairs with a `\n` that stays; a line separator becomes a space,
 /// both being Unicode whitespace, so dropping one would join the words it parts.
 /// No downstream escape can neutralize a separator — a `\` before whitespace is
-/// Typst's own linebreak — so it cannot survive in the text. Nothing reports the
-/// substitution; [`Content::validate`](crate::Content::validate) refuses only a
-/// separator that reached a content without passing an ingress.
+/// Typst's own linebreak — so it cannot survive in the text.
 #[inline]
 pub(crate) fn admit_char(c: char) -> Option<char> {
     match c {

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -14,7 +14,7 @@ do the heavy compilation.
 
 ## Data Flow
 
-1. **Parse**: card-yaml block extraction, bidi stripping, HTML fence normalization
+1. **Parse**: card-yaml block extraction, bidi stripping, line-separator spacing, HTML fence normalization
 2. **Normalize**: Type coercion, schema defaults, field validation
 3. **Compile**: Backend's `open()` receives the quill + JSON data and returns a `LiveSession`; `LiveSession::render()` produces artifacts
 


### PR DESCRIPTION
Resolves #1585 as documented behavior. The substitution is unchanged: a U+2028/U+2029 line separator still becomes a space at every text ingress, and no warning channel is added.

## Why not a warning

The issue asked for an upstream decision on whether the boundary should be silent, and ranked a diagnostic first. Threading a report out would touch `applyChange` → `apply_body_change`/`apply_field_change` → content's `apply_field_change` → `apply_text_delta`, turning a call that returns nothing into one every caller must decide about. That cost lands on consumers who will almost always ignore it, for a char that is rare and whose substitution leaves the render correct. The decision is that this is the boundary's to make; what was missing is that it says so anywhere a consumer looks.

## Changes

`crates/content/src/normalize.rs` — `admit_char`'s doc closed on "so the content refuses it". That is what `validate` does to a hand-built content, not what this function does to one passing an ingress: it rewrites the separator and returns. One clause, replaced with the conclusion the reason above it actually supports.

`crates/bindings/wasm/src/engine.rs` — the TS `Delta` said nothing about admission, leaving the one fact a consumer cannot reach from the type: an `insert` string is admitted, not stored, and nothing announces the difference. `IslandOp` already names the slot char a `delta` insert may not carry, so the surface now distinguishes the char that throws from the chars that are quietly exchanged.

`prose/canon/ARCHITECTURE.md` — the Parse stage named bidi stripping and omitted separator spacing, a normalization at the same seam.

## Verification

`cargo test --workspace` green. `cargo doc -p quillmark-content --document-private-items` clean. `cargo check -p quillmark-wasm` compiles; its 11 warnings are pre-existing tsify ones.

No behavior change — the diff is three doc edits, +4/-9 after a tightening pass.

## Not addressed

The issue's closing paragraph raises the code-span export pad and the bare-`-` comment re-siting as the same question. Both change authored bytes on emit rather than destroying a character, and the issue scoped them out; they remain open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PJB6on7Z3VqkL5fHF6vFWq

---
_Generated by [Claude Code](https://claude.ai/code/session_01PJB6on7Z3VqkL5fHF6vFWq)_