### PR TITLE
merge: land #1464, #1465, #1467 and #1566

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,16 @@
   `from_plaintext`, markdown import, and an `Op::Insert` through
   `apply_text_delta`. A space rather than a drop, both being Unicode
   whitespace, so the words either side stay parted.
+- fix(pdf): **a dict ending in a hex string parses to its real `>>`.** The
+  scanner stepped over literal strings and `%`-comments but read a hex string
+  as ordinary bytes, so the string's own `>` abutting the dict's `>>` closed
+  the dict one byte early: `<< /T <41>>>` read as ` /T <41`, every
+  `find_dict_value` on that inner swallowed the rest as one hex string, and a
+  `/Producer` stamp rewrote the `/Info` with an unterminated `<…` — a title
+  lost to any reader. `skip_string_or_comment` steps a `<` that no `<` follows
+  to just past its `>`, which the dict, array and `endobj` scans all inherit.
+  The trigger is real: pdf-writer's compact mode, which krilla and typst-pdf
+  use, writes a non-ASCII `/Title` or `/Author` exactly this way.
 
 ## v0.112.0 - 2026-09-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,9 +33,10 @@
   a clean validate. Arrays are compared element-wise against the same index of
   the shown literal, so a half-edited list names the element left behind; a
   typed dictionary and a variant container are walked per cell. A field
-  declaring no `example:` never fires: absence is `must_fill`'s question. The
-  `trigger` arg says which cell spoke (`field` or `body`) and `example` carries
-  the shown value.
+  declaring no `example:` never fires: absence is `must_fill`'s question, and
+  neither does a cell still carrying its marker, which `must_fill` already
+  names. The `trigger` arg says which cell spoke (`field` or `body`) and
+  `example` carries the shown value.
 
 - feat(core): **the values form: `reader.values()` reads a document as plain
   values and `writer.set_values(values)` writes them back.** A document has
@@ -466,6 +467,15 @@
   names the real fix: the line reads as prose, and body text belongs after the
   closing `~~~`, so close the block before it. A genuine plain scalar wrapped
   onto a second line keeps the block-scalar hint.
+- fix(core): **a leading space before a top-level key gets its own hint.** One
+  stray space folds the line into the preceding plain scalar, and YAML raises
+  the same `mapping values are not allowed` an unquoted `:` inside a value
+  raises — so the hint sent the reader hunting for a colon that is not in the
+  block, and four models quoted the `subject:` above it instead. Where the
+  flagged line starts with a space, reads as `key:` or `key: value`, and
+  follows a column-zero key line, the hint names the space: top-level fields
+  begin at column 0, remove the one before `date:`. Anything else keeps the
+  quote-the-colon advice.
 - fix(pdf): **a dict ending in a hex string parses to its real `>>`.** The
   scanner stepped over literal strings and `%`-comments but read a hex string
   as ordinary bytes, so the string's own `>` abutting the dict's `>>` closed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- feat(core): **`validation::example_unchanged`: a cell still holding the value
+  its schema showed.** `Quill::validate` warns (non-fatal, beside
+  `validation::must_fill`) where an authored value is the field's `example:`,
+  or a body is its `body.example` or the `Write <kind> body here.` placeholder
+  the blueprint generates for a kind declaring none. The blueprint seats a
+  defaultless field's example in its value cell under the `!must_fill` marker
+  and a seed commits one on every field that declares it, so dropping the
+  marker leaves a value that is present, type-valid, in-domain and nobody's
+  answer — a signed memo reading `Duty Title` under the commander's name, with
+  a clean validate. Arrays are compared element-wise against the same index of
+  the shown literal, so a half-edited list names the element left behind; a
+  typed dictionary and a variant container are walked per cell. A field
+  declaring no `example:` never fires: absence is `must_fill`'s question. The
+  `trigger` arg says which cell spoke (`field` or `body`) and `example` carries
+  the shown value.
+
 - feat(core): **the values form: `reader.values()` reads a document as plain
   values and `writer.set_values(values)` writes them back.** A document has
   three forms: *stored* (verbatim, quill-free), *values* (stored with every

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,17 @@
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
 
+- fix(core): **body prose left inside a card block is told to close the block,
+  not to wrap itself in a block scalar.** A closing `~~~` placed after the prose
+  body fails YAML on the first prose line, and `simple key expected` answered
+  every such line with the wrapped-scalar advice: rewriting the memo as
+  `body: |` keeps the body inside the block and fails again. The hint now reads
+  the flagged line the parser names — no `key:` outside quotes, sentence-shaped
+  or after a blank line, and not the tail of an unfinished `key: value` — and
+  names the real fix: the line reads as prose, and body text belongs after the
+  closing `~~~`, so close the block before it. A genuine plain scalar wrapped
+  onto a second line keeps the block-scalar hint.
+
 ## v0.112.0 - 2026-09-01
 
 - feat(content)!: **every vocabulary member spells its payload in `attrs`.** The

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -44,6 +44,18 @@ fn test_malformed_quill_reference_carries_code_and_grammar_hint() {
 }
 
 #[test]
+fn test_body_prose_inside_the_block_is_told_to_close_the_block() {
+    let md = "~~~card-yaml\n$quill: usaf_memo\n$kind: main\ntitle: Near-Miss Report\n\
+              88th Communications Squadron, Wright-Patterson AFB\n\
+              This memorandum documents a near-miss on the flight line.\n~~~\n";
+    let err = decompose(md).unwrap_err();
+    let hint = err.to_diagnostic().hint.expect("hint should be set");
+    assert!(hint.contains("reads as prose"), "got: {hint}");
+    assert!(hint.contains("88th Communications Squadron"), "got: {hint}");
+    assert!(!hint.contains("block scalar"), "got: {hint}");
+}
+
+#[test]
 fn test_root_dash_frontmatter_without_quill_reports_missing_quill() {
     let err = decompose("---\nquill: usaf_memo\ntitle: Memo\n---\n\nBody\n").unwrap_err();
     let msg = err.to_string();

--- a/crates/core/src/document/yaml_hints.rs
+++ b/crates/core/src/document/yaml_hints.rs
@@ -129,6 +129,14 @@ fn derive_hint(message: &str, content: &str) -> Option<String> {
 
     // A continuation line of a plain scalar read as a new key.
     if m.contains("simple key expected") || m.contains("simple key expect") {
+        if let Some(flagged) = flagged_prose_line(&m, content) {
+            return Some(format!(
+                "Line {} (\"{}\") has no `key:` and reads as prose. Body text belongs \
+                 after the closing `~~~`, not inside the block: close the block before it.",
+                flagged.number,
+                truncate_for_message(flagged.text)
+            ));
+        }
         return Some(
             "A second line of a value was read as a new mapping key (YAML \
              plain-scalar values stop at the next unindented line). For \
@@ -167,6 +175,99 @@ fn derive_hint(message: &str, content: &str) -> Option<String> {
     }
 
     None
+}
+
+/// A line of `content` the parser flagged, with its 1-indexed number.
+struct FlaggedLine<'a> {
+    number: usize,
+    text: &'a str,
+}
+
+/// The flagged line when it reads as body prose written inside the block rather
+/// than the wrapped continuation of a plain scalar: no `key:`, sentence-shaped,
+/// and not the tail of an unfinished field above it.
+fn flagged_prose_line<'a>(message: &str, content: &'a str) -> Option<FlaggedLine<'a>> {
+    let number = flagged_line_number(message)?;
+    let lines: Vec<&str> = content.lines().collect();
+    let text = lines.get(number.checked_sub(1)?)?.trim();
+    if text.is_empty() || has_colon_outside_quotes(text) {
+        return None;
+    }
+
+    let previous = number
+        .checked_sub(2)
+        .and_then(|i| lines.get(i))
+        .map(|l| l.trim());
+    let after_blank = matches!(previous, None | Some(""));
+    if !after_blank && !text.contains(' ') && !ends_a_sentence(text) {
+        return None;
+    }
+
+    // The competing reading: a plain scalar wrapped onto a second line. It needs
+    // an unfinished `key: value` directly above and nothing continuing below,
+    // and no sentence punctuation of its own.
+    let wrapped_scalar = !after_blank
+        && previous.is_some_and(looks_unterminated_scalar)
+        && !ends_a_sentence(text)
+        && !text.contains(',')
+        && lines.iter().rposition(|l| !l.trim().is_empty()) == Some(number - 1);
+
+    (!wrapped_scalar).then_some(FlaggedLine { number, text })
+}
+
+/// The 1-indexed line the parser named (`line 3 column 1`, `at line 17, column 1`).
+fn flagged_line_number(message: &str) -> Option<usize> {
+    let (_, rest) = message.split_once("line ")?;
+    rest.chars()
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .ok()
+}
+
+/// Whether `line` carries a `:` that YAML would read as a key separator.
+fn has_colon_outside_quotes(line: &str) -> bool {
+    let mut in_single = false;
+    let mut in_double = false;
+    for ch in line.chars() {
+        match ch {
+            '\'' if !in_double => in_single = !in_single,
+            '"' if !in_single => in_double = !in_double,
+            ':' if !in_single && !in_double => return true,
+            _ => {}
+        }
+    }
+    false
+}
+
+fn ends_a_sentence(line: &str) -> bool {
+    matches!(line.trim_end().chars().last(), Some('.' | '!' | '?'))
+}
+
+/// Whether `line` is a `key: <plain multi-word value>` a reader would take as
+/// running on: the shape whose next line is a scalar continuation, not a key.
+fn looks_unterminated_scalar(line: &str) -> bool {
+    let Some((key, value)) = line.split_once(':') else {
+        return false;
+    };
+    if key.is_empty() || key.contains(char::is_whitespace) || key.starts_with(['#', '-']) {
+        return false;
+    }
+    let value = value.trim();
+    if !value.contains(' ') || value.starts_with(['\'', '"', '|', '>', '[', '{', '&', '*', '#']) {
+        return false;
+    }
+    !matches!(value.chars().last(), Some('.' | '!' | '?' | ',' | ';'))
+}
+
+/// The line as quoted in a hint, elided past a readable prefix.
+fn truncate_for_message(text: &str) -> String {
+    const MAX: usize = 48;
+    if text.chars().count() <= MAX {
+        return text.to_string();
+    }
+    let head: String = text.chars().take(MAX).collect();
+    format!("{}…", head.trim_end())
 }
 
 /// The alias/anchor hint, naming the offending field when one is recognizable.
@@ -361,6 +462,60 @@ mod tests {
         let hint = enriched.hint.expect("hint should be set");
         assert!(hint.contains("block scalar"));
         assert!(hint.contains("|"));
+    }
+
+    #[test]
+    fn hint_for_wrapped_scalar_survives_a_located_line() {
+        let enriched = enrich_yaml_error(
+            "error: line 2 column 1: simple key expected ':'",
+            "summary: This is a long\nsummary across multiple lines\n",
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("block scalar"), "{hint}");
+        assert!(!hint.contains("reads as prose"), "{hint}");
+    }
+
+    #[test]
+    fn hint_for_prose_inside_block_says_close_the_block() {
+        let content = "title: Near-Miss Report\ndate: 2026-03-14\n\
+                       88th Communications Squadron, Wright-Patterson AFB\n\
+                       This memorandum documents a near-miss on the flight line.\n";
+        let enriched = enrich_yaml_error("error: line 3 column 1: simple key expected ':'", content);
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("Line 3"), "{hint}");
+        assert!(hint.contains("88th Communications Squadron"), "{hint}");
+        assert!(hint.contains("reads as prose"), "{hint}");
+        assert!(hint.contains("`~~~`"), "{hint}");
+        assert!(!hint.contains("block scalar"), "{hint}");
+    }
+
+    #[test]
+    fn hint_for_prose_after_a_blank_line_says_close_the_block() {
+        let content = "title: Memo\n\nThis memorandum documents a near-miss on the flight line.\n";
+        let enriched = enrich_yaml_error("error: line 3 column 1: simple key expected ':'", content);
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("Line 3"), "{hint}");
+        assert!(hint.contains("reads as prose"), "{hint}");
+        assert!(!hint.contains("block scalar"), "{hint}");
+    }
+
+    #[test]
+    fn hint_for_prose_right_after_a_multi_word_field_says_close_the_block() {
+        let content = "title: Near-Miss Report\n88th Communications Squadron, Wright-Patterson AFB\n";
+        let enriched = enrich_yaml_error("error: line 2 column 1: simple key expected ':'", content);
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("reads as prose"), "{hint}");
+    }
+
+    #[test]
+    fn prose_hint_elides_a_long_line() {
+        let long = "This memorandum documents a near-miss that occurred during the flight line inspection.";
+        let content = format!("title: Memo\n\n{long}\n");
+        let enriched =
+            enrich_yaml_error("error: line 3 column 1: simple key expected ':'", &content);
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains('…'), "{hint}");
+        assert!(!hint.contains("inspection"), "{hint}");
     }
 
     #[test]

--- a/crates/core/src/document/yaml_hints.rs
+++ b/crates/core/src/document/yaml_hints.rs
@@ -74,6 +74,9 @@ fn derive_hint(message: &str, content: &str) -> Option<String> {
 
     // An unquoted value containing `:` reads as a nested mapping key.
     if m.contains("mapping values are not allowed") {
+        if let Some(hint) = indented_top_level_key_hint(message, content) {
+            return Some(hint);
+        }
         if let Some((field, value)) = first_field_with_unquoted_colon(content) {
             return Some(format!(
                 "Unquoted values cannot contain `:` (it starts a nested mapping key). \
@@ -216,6 +219,47 @@ fn first_field_with_unquoted_prefix(content: &str, prefixes: &[char]) -> Option<
     None
 }
 
+/// The 1-based line number the parser flagged, read off the `line N column M`
+/// prefix of its message (`at line N, column M` is accepted too).
+fn flagged_line_number(message: &str) -> Option<usize> {
+    let rest = &message[message.find("line ")? + "line ".len()..];
+    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
+    digits.parse().ok()
+}
+
+/// `line` as a mapping key, when its shape is `key:` or `key: value`.
+fn mapping_key(line: &str) -> Option<&str> {
+    let (key, rest) = line.split_once(':')?;
+    let plain =
+        !key.is_empty() && !key.contains(' ') && !key.starts_with('#') && !key.starts_with('-');
+    (plain && (rest.is_empty() || rest.starts_with(' '))).then_some(key)
+}
+
+/// The hint for a top-level key indented by a stray leading space: YAML folds
+/// such a line into the preceding plain scalar and reports the same "mapping
+/// values are not allowed" as an unquoted colon does, with no colon in sight.
+fn indented_top_level_key_hint(message: &str, content: &str) -> Option<String> {
+    let number = flagged_line_number(message)?;
+    let lines: Vec<&str> = content.lines().collect();
+    let flagged = lines.get(number.checked_sub(1)?)?;
+    if !flagged.starts_with(' ') {
+        return None;
+    }
+    let key = mapping_key(flagged.trim_start())?;
+    let previous = lines[..number - 1]
+        .iter()
+        .rev()
+        .find(|l| !l.trim().is_empty())?;
+    if previous.starts_with([' ', '\t']) {
+        return None;
+    }
+    mapping_key(previous)?;
+    Some(format!(
+        "Line {number} starts with a space. Top-level fields must begin at \
+         column 0; remove the leading space before `{key}:`."
+    ))
+}
+
 /// The first `key: <value>` line whose unquoted value contains a second `:`,
 /// which is what raises "mapping values are not allowed in this context".
 fn first_field_with_unquoted_colon(content: &str) -> Option<(String, String)> {
@@ -307,6 +351,77 @@ mod tests {
         assert!(hint.contains("system_name"));
         assert!(hint.contains("Node.js Service: Order Processing API"));
         assert!(hint.contains("Quote"));
+    }
+
+    #[test]
+    fn hint_for_indented_key_names_the_leading_space() {
+        let content = concat!(
+            "subject: Near-Miss Involving Aerospace Ground Equipment Tug on the Flightline\n",
+            " date: 2026-04-02\n",
+            "authority_line: \"\"\n"
+        );
+        let enriched = enrich_yaml_error(
+            "error: line 2 column 6: mapping values are not allowed in this context",
+            content,
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("Line 2 starts with a space"), "{hint}");
+        assert!(hint.contains("`date:`"), "{hint}");
+        assert!(!hint.contains("double quotes"), "{hint}");
+    }
+
+    #[test]
+    fn hint_for_indented_bare_key_names_the_leading_space() {
+        let content = "subject: Near-Miss On The Flightline\n distribution:\nauthority_line: \"\"\n";
+        let enriched = enrich_yaml_error(
+            "error: line 2 column 14: mapping values are not allowed in this context",
+            content,
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("Line 2 starts with a space"), "{hint}");
+        assert!(hint.contains("`distribution:`"), "{hint}");
+    }
+
+    #[test]
+    fn hint_for_unquoted_colon_survives_the_indent_branch() {
+        let enriched = enrich_yaml_error(
+            "error: line 1 column 13: mapping values are not allowed in this context",
+            "field: value: with colon\n",
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("field"), "{hint}");
+        assert!(hint.contains("value: with colon"), "{hint}");
+        assert!(hint.contains("Quote"), "{hint}");
+    }
+
+    #[test]
+    fn indented_key_hint_reads_the_real_parser_message() {
+        let content = concat!(
+            "subject: Near-Miss Involving Aerospace Ground Equipment Tug on the Flightline\n",
+            " date: 2026-04-02\n",
+            "authority_line: \"\"\n"
+        );
+        let raw = serde_saphyr::from_str_with_options::<serde_json::Value>(
+            content,
+            crate::document::limits::yaml_parse_options(),
+        )
+        .expect_err("the indented key should not parse")
+        .to_string();
+        let hint = enrich_yaml_error(&raw, content)
+            .hint
+            .expect("hint should be set");
+        assert!(hint.contains("Line 2 starts with a space"), "{hint}");
+        assert!(hint.contains("`date:`"), "{hint}");
+    }
+
+    #[test]
+    fn indented_key_after_a_prose_line_falls_through() {
+        let enriched = enrich_yaml_error(
+            "error: line 2 column 6: mapping values are not allowed in this context",
+            "a long plain scalar with no colon\n date: 2026-04-02\n",
+        );
+        let hint = enriched.hint.expect("hint should be set");
+        assert!(hint.contains("double quotes"), "{hint}");
     }
 
     #[test]

--- a/crates/core/src/document/yaml_hints.rs
+++ b/crates/core/src/document/yaml_hints.rs
@@ -218,7 +218,8 @@ fn flagged_prose_line<'a>(message: &str, content: &'a str) -> Option<FlaggedLine
     (!wrapped_scalar).then_some(FlaggedLine { number, text })
 }
 
-/// The 1-indexed line the parser named (`line 3 column 1`, `at line 17, column 1`).
+/// The 1-indexed line the parser named, read off the `line N column M` prefix
+/// of its message (`at line N, column M` is accepted too).
 fn flagged_line_number(message: &str) -> Option<usize> {
     let (_, rest) = message.split_once("line ")?;
     rest.chars()
@@ -318,14 +319,6 @@ fn first_field_with_unquoted_prefix(content: &str, prefixes: &[char]) -> Option<
         }
     }
     None
-}
-
-/// The 1-based line number the parser flagged, read off the `line N column M`
-/// prefix of its message (`at line N, column M` is accepted too).
-fn flagged_line_number(message: &str) -> Option<usize> {
-    let rest = &message[message.find("line ")? + "line ".len()..];
-    let digits: String = rest.chars().take_while(char::is_ascii_digit).collect();
-    digits.parse().ok()
 }
 
 /// `line` as a mapping key, when its shape is `key:` or `key: value`.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -727,6 +727,21 @@ mod args_canon {
             "both `validation::must_fill` triggers must carry one key set"
         );
         add("validation::must_fill", marker.args);
+        // Two constructors again, one per cell a blueprint writes a value into.
+        let field_example = crate::quill::compose::example_unchanged_warning(
+            &path,
+            &serde_json::json!("Duty Title"),
+        );
+        let body_example = crate::quill::compose::body_example_unchanged_warning(
+            &crate::path::DocPath::main().body(),
+            "Write main body here.",
+        );
+        assert_eq!(
+            field_example.args.keys().collect::<Vec<_>>(),
+            body_example.args.keys().collect::<Vec<_>>(),
+            "both `validation::example_unchanged` triggers must carry one key set"
+        );
+        add("validation::example_unchanged", field_example.args);
         // Built at the variant walk rather than from an error type: a stranded
         // value is well-formed, so there is nothing to fail.
         add(

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -70,9 +70,16 @@ fn body_text(card: &CardSchema, fallback_kind: &str) -> String {
         return String::new();
     }
     let example = card.body.as_ref().and_then(|b| b.example.as_deref());
-    let fallback = format!("Write {} body here.", fallback_kind);
+    let fallback = body_placeholder(fallback_kind);
     let text = example.unwrap_or(fallback.as_str());
     format!("\n{}\n", text)
+}
+
+/// The body text a kind declaring no `body.example` shows. Shared with the
+/// `validation::example_unchanged` walk, which recognizes it in a document: the
+/// two are one string or the placeholder ships unnoticed.
+pub(super) fn body_placeholder(kind: &str) -> String {
+    format!("Write {kind} body here.")
 }
 
 /// Build the root card: `$quill` (with the `# keep verbatim` inline reminder),

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -239,7 +239,9 @@ impl Quill {
     /// value a cell holds. The blueprint seats a defaultless field's `example:`
     /// in its value cell, so dropping the marker leaves a schema-valid,
     /// in-domain value nobody chose — `Duty Title` under a commander's name —
-    /// and every other check reads it as authored content.
+    /// and every other check reads it as authored content. A cell still
+    /// carrying its marker is the marker's to report, by the same precedence:
+    /// `must_fill` already names it, and the value it holds adds nothing.
     ///
     /// Field values, defaults, and presentation order are not part of this
     /// surface: read them from the [`Document`] payload and the quill schema
@@ -258,7 +260,11 @@ impl Quill {
                 .filter(|d| !claimed.contains(&d.path)),
         );
         diags.extend(validate_variants(self.config(), doc));
-        diags.extend(validate_examples(self.config(), doc));
+        diags.extend(
+            validate_examples(self.config(), doc)
+                .into_iter()
+                .filter(|d| !claimed.contains(&d.path)),
+        );
         diags.extend(self.validate_seed(doc));
         diags
     }

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -216,8 +216,8 @@ impl Quill {
     /// `validation::*` diagnostics verbatim (same code, `path`, `hint`) so
     /// consumers route on the code without parsing message text: type
     /// mismatches, unknown card kinds, body-on-disabled-body, and the non-fatal
-    /// `validation::must_fill` warning, the only non-fatal one; the rest are
-    /// blockers.
+    /// warnings (`validation::must_fill`, `validation::out_of_variant`,
+    /// `validation::example_unchanged`); the rest are blockers.
     ///
     /// **A blocker here means the document does not render.** Values are judged
     /// in the form the render floor builds from them (`conform_value` at
@@ -234,6 +234,12 @@ impl Quill {
     /// content — so both run, and the `trigger` arg tells a consumer which
     /// fired. Where both would fire on one path (a bare marker on an unauthored
     /// cell) the marker wins: its hint is the actionable one.
+    ///
+    /// `validation::example_unchanged` answers what `must_fill` cannot: *which*
+    /// value a cell holds. The blueprint seats a defaultless field's `example:`
+    /// in its value cell, so dropping the marker leaves a schema-valid,
+    /// in-domain value nobody chose — `Duty Title` under a commander's name —
+    /// and every other check reads it as authored content.
     ///
     /// Field values, defaults, and presentation order are not part of this
     /// surface: read them from the [`Document`] payload and the quill schema
@@ -252,6 +258,7 @@ impl Quill {
                 .filter(|d| !claimed.contains(&d.path)),
         );
         diags.extend(validate_variants(self.config(), doc));
+        diags.extend(validate_examples(self.config(), doc));
         diags.extend(self.validate_seed(doc));
         diags
     }
@@ -1011,8 +1018,208 @@ pub(crate) fn unauthored_warning(path: &DocPath) -> Diagnostic {
     )
 }
 
+/// Surface every cell and body the document leaves at the value its schema
+/// *shows*, across the main card and every composable card.
+///
+/// The blueprint seats a defaultless field's `example:` in the value cell under
+/// the `!must_fill` marker (`prose/canon/BLUEPRINT.md` § "Placeholder value
+/// precedence"), and the marker is the only thing distinguishing it from an
+/// answer: an example is present, type-valid and in-domain, so coercion,
+/// validation and the unauthored predicate all read it as content. Drop the
+/// marker and a memo ships `Duty Title` under a signature block with a clean
+/// validate. This walk reads the same declarations the blueprint stamps from,
+/// and says the cell still holds what the schema showed.
+///
+/// It is about *which* value, never *whether* one was authored, so it declines
+/// the cells [`validate_unauthored`] owns: a field declaring no `example:` has
+/// nothing to compare against and is silent here whatever it holds.
+fn validate_examples(config: &QuillConfig, doc: &Document) -> Vec<Diagnostic> {
+    let mut diags = Vec::new();
+    for (schema, card, path) in schema_cards(config, doc) {
+        let Some(schema) = schema else { continue };
+        let payload = card.payload();
+        for (name, field) in &schema.fields {
+            collect_example_field(field, payload.get(name), &path.field(name), &mut diags);
+        }
+        collect_body_example(schema, card, &path, &mut diags);
+    }
+    diags
+}
+
+/// Warn at each cell whose value is the one its own declaration shows.
+///
+/// The recursion is [`collect_unauthored_field`]'s, for the same reason: the
+/// cells it reaches are where the blueprint stamps its values. A **typed
+/// dictionary** and a **variant container** are namespaces, so each member is
+/// judged against its own `example:`; an **array** is judged element-wise
+/// against the same index of the array literal its field shows, so an author who
+/// edited the first line and left the second still hears about the second.
+/// Absence is not this walk's business: an absent cell holds no value to
+/// recognize.
+fn collect_example_field(
+    field: &FieldSchema,
+    value: Option<&QuillValue>,
+    path: &DocPath,
+    out: &mut Vec<Diagnostic>,
+) {
+    let Some(present) = value.filter(|v| !v.as_json().is_null()) else {
+        return;
+    };
+    let json = present.as_json();
+
+    if field.is_variant_bearing() {
+        let authored = FieldSchema::authored_member(Some(json));
+        let shown = field
+            .example
+            .as_ref()
+            .and_then(|e| FieldSchema::authored_member(Some(e.as_json())));
+        if let Some(shown) = shown.filter(|s| Some(*s) == authored) {
+            out.push(example_unchanged_warning(
+                &path.field(VARIANT_DISCRIMINANT_KEY),
+                shown,
+            ));
+        }
+        if let Some(fields) = field.variant_fields(&field.selected_member(Some(json))) {
+            for (name, schema) in fields {
+                let cell = json
+                    .as_object()
+                    .and_then(|o| o.get(name))
+                    .map(|j| QuillValue::from_json(j.clone()));
+                collect_example_field(schema, cell.as_ref(), &path.field(name), out);
+            }
+        }
+        return;
+    }
+
+    if let (FieldType::Object, Some(props)) = (&field.r#type, &field.properties) {
+        for (name, prop) in props {
+            let pv = json
+                .as_object()
+                .and_then(|o| o.get(name))
+                .map(|j| QuillValue::from_json(j.clone()));
+            collect_example_field(prop, pv.as_ref(), &path.field(name), out);
+        }
+        return;
+    }
+
+    if let (FieldType::Array, Some(items)) = (&field.r#type, &field.items) {
+        // The array's own `example:` is the whole literal, so the element's
+        // counterpart is the one at its index; an element that is not the shown
+        // one still descends, since a typed table's cells carry examples of
+        // their own.
+        let shown = field.example.as_ref().and_then(|e| e.as_json().as_array());
+        for (index, element) in json.as_array().into_iter().flatten().enumerate() {
+            let at = path.index(index);
+            match shown.and_then(|eg| eg.get(index)).filter(|eg| *eg == element) {
+                Some(eg) => out.push(example_unchanged_warning(&at, eg)),
+                None => collect_example_field(
+                    items,
+                    Some(&QuillValue::from_json(element.clone())),
+                    &at,
+                    out,
+                ),
+            }
+        }
+        return;
+    }
+
+    if let Some(shown) = shown_example(field, json) {
+        out.push(example_unchanged_warning(path, shown.as_json()));
+    }
+}
+
+/// The `example:` `value` is still sitting at, `None` where the field declares
+/// none or the document wrote something else. A prose field shows its example
+/// twice — the markdown literal a blueprint inlines and the imported content a
+/// seed commits ([`FieldSchema::example_content`]) — and they are one
+/// declaration, so either match reports the declaration.
+fn shown_example<'a>(field: &'a FieldSchema, value: &serde_json::Value) -> Option<&'a QuillValue> {
+    let example = field.example.as_ref()?;
+    let matched = example.as_json() == value
+        || field
+            .example_content
+            .as_ref()
+            .is_some_and(|content| content.as_json() == value);
+    matched.then_some(example)
+}
+
+/// Warn when a card's body is the text the blueprint writes into it: the
+/// configured `body.example`, or the placeholder generated for a kind that
+/// declares none ([`super::blueprint::body_placeholder`]).
+///
+/// The comparison is against the markdown projection, the form the blueprint
+/// emitted and an author edits, re-imported so a body that only round-tripped
+/// through the content model (`__b__` → `**b**`) still counts as untouched.
+fn collect_body_example(
+    schema: &CardSchema,
+    card: &Card,
+    base: &DocPath,
+    out: &mut Vec<Diagnostic>,
+) {
+    if !schema.body_enabled() {
+        return;
+    }
+    let authored = card.body_markdown();
+    let authored = authored.trim();
+    if authored.is_empty() {
+        return;
+    }
+    let shown = match schema.body.as_ref().and_then(|b| b.example.as_deref()) {
+        Some(example) => example.to_string(),
+        None => super::blueprint::body_placeholder(&schema.name),
+    };
+    if authored == shown.trim() || canonical_markdown(&shown).as_deref() == Some(authored) {
+        out.push(body_example_unchanged_warning(&base.body(), shown.trim()));
+    }
+}
+
+/// `shown` through the content model and back, the round trip a body takes on
+/// its way into a document. `None` where the text does not import, which a
+/// generated placeholder and a load-validated example never do.
+fn canonical_markdown(shown: &str) -> Option<String> {
+    let content = crate::document::import_body(shown).ok()?;
+    Some(quillmark_content::export::to_markdown(&content).trim().to_string())
+}
+
+pub(crate) fn example_unchanged_warning(path: &DocPath, example: &serde_json::Value) -> Diagnostic {
+    let path = path.to_string();
+    let literal = serde_json::to_string(example).unwrap_or_else(|_| "null".to_string());
+    Diagnostic::new(
+        Severity::Warning,
+        format!("Field `{path}` still holds the schema's example value `{literal}`."),
+    )
+    .with_code("validation::example_unchanged".to_string())
+    .with_path(path)
+    .with_arg("example", example.clone())
+    .with_arg("trigger", "field".into())
+    .with_hint(
+        "Author the value this document means. An `example:` shows a cell's shape, never its \
+         content."
+            .to_string(),
+    )
+}
+
+pub(crate) fn body_example_unchanged_warning(path: &DocPath, example: &str) -> Diagnostic {
+    let path = path.to_string();
+    Diagnostic::new(
+        Severity::Warning,
+        format!("Body `{path}` still holds the text the blueprint wrote there."),
+    )
+    .with_code("validation::example_unchanged".to_string())
+    .with_path(path)
+    .with_arg("example", example.into())
+    .with_arg("trigger", "body".into())
+    .with_hint(
+        "Write the body this document means, in place of the example or placeholder text."
+            .to_string(),
+    )
+}
+
 #[cfg(test)]
 mod must_fill_tests;
+
+#[cfg(test)]
+mod example_unchanged_tests;
 
 #[cfg(test)]
 mod tests {

--- a/crates/core/src/quill/compose/example_unchanged_tests.rs
+++ b/crates/core/src/quill/compose/example_unchanged_tests.rs
@@ -1,0 +1,245 @@
+//! The value axis's other half: a cell holding the value its schema showed.
+
+use crate::quill::quill_from_yaml;
+use crate::{Document, Quill};
+
+fn unchanged(quill: &Quill, md: &str) -> Vec<(String, String)> {
+    let doc = Document::parse(md).expect("parse").document;
+    let mut out: Vec<(String, String)> = quill
+        .validate(&doc)
+        .iter()
+        .filter(|d| d.code.as_deref() == Some("validation::example_unchanged"))
+        .map(|d| {
+            (
+                d.path.clone().expect("every example_unchanged anchors at a path"),
+                d.args["trigger"].as_str().expect("trigger arg").to_string(),
+            )
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn paths(quill: &Quill, md: &str) -> Vec<String> {
+    unchanged(quill, md).into_iter().map(|(p, _)| p).collect()
+}
+
+const MEMO: &str = r#"
+quill: { name: eg, version: 1.0.0, backend: typst, description: examples }
+main:
+  body:
+    example: The first paragraph. Top-level paragraphs are auto-numbered.
+  fields:
+    subject:  { type: string, example: Duty Title }
+    memo_for: { type: array, items: { type: string }, example: [ORG1/SYMBOL, ORG2/SYMBOL] }
+    freeform: { type: string }
+    status:   { type: string, default: draft, example: final }
+    signer:
+      type: object
+      properties:
+        name:  { type: string, example: FIRST M. LAST }
+        grade: { type: string, example: "Rank, USAF" }
+card_kinds:
+  indorsement:
+    fields:
+      from: { type: string, example: FIRST M. LAST }
+"#;
+
+fn md(fields: &str) -> String {
+    format!("~~~card-yaml\n$quill: eg@1.0.0\n$kind: main\n{fields}~~~\n")
+}
+
+fn with_body(fields: &str, body: &str) -> String {
+    format!("{}\n{body}\n", md(fields))
+}
+
+#[test]
+fn a_cell_left_at_its_example_warns_and_an_authored_one_does_not() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(
+        unchanged(&quill, &md("subject: Duty Title\n")),
+        [("main.subject".to_string(), "field".to_string())]
+    );
+    assert!(paths(&quill, &md("subject: Airfield closure\n")).is_empty());
+}
+
+#[test]
+fn a_field_declaring_no_example_never_warns() {
+    let quill = quill_from_yaml(MEMO);
+
+    for value in ["freeform: Duty Title\n", "freeform: \"\"\n", "freeform: x\n"] {
+        assert!(
+            paths(&quill, &md(value)).is_empty(),
+            "nothing to recognize: {value}"
+        );
+    }
+}
+
+/// The seed commits an example whether or not the field is obliged, so the
+/// warning is keyed on the value, not on the obligation axis.
+#[test]
+fn a_defaulted_fields_example_warns_too() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(paths(&quill, &md("status: final\n")), ["main.status"]);
+    assert!(paths(&quill, &md("status: signed\n")).is_empty());
+}
+
+#[test]
+fn an_array_warns_at_the_element_left_behind() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(
+        paths(&quill, &md("memo_for: [AF/A1, ORG2/SYMBOL]\n")),
+        ["main.memo_for[1]"],
+        "a partially edited array warns at the untouched element, not the container"
+    );
+    assert_eq!(
+        paths(&quill, &md("memo_for: [ORG1/SYMBOL, ORG2/SYMBOL]\n")),
+        ["main.memo_for[0]", "main.memo_for[1]"]
+    );
+    assert!(paths(&quill, &md("memo_for: [AF/A1, AF/A2]\n")).is_empty());
+}
+
+/// Position is part of the value: an example element the author moved is one
+/// they handled.
+#[test]
+fn an_array_compares_index_for_index() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert!(paths(&quill, &md("memo_for: [ORG2/SYMBOL, AF/A1]\n")).is_empty());
+}
+
+#[test]
+fn a_typed_dictionary_warns_at_the_property_that_holds_the_example() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(
+        paths(
+            &quill,
+            &md("signer:\n  name: FIRST M. LAST\n  grade: Col, USAF\n")
+        ),
+        ["main.signer.name"]
+    );
+}
+
+#[test]
+fn a_composable_card_is_judged_per_instance() {
+    let quill = quill_from_yaml(MEMO);
+    let root = md("subject: Airfield closure\n");
+    let card = "\n~~~card-yaml\n$kind: indorsement\nfrom: FIRST M. LAST\n~~~\nReviewed.\n";
+
+    assert_eq!(
+        paths(&quill, &format!("{root}{card}{card}")),
+        [
+            "cards.indorsement[0].from",
+            "cards.indorsement[1].from"
+        ]
+    );
+}
+
+#[test]
+fn a_body_left_at_the_schemas_example_warns() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert_eq!(
+        unchanged(
+            &quill,
+            &with_body(
+                "subject: Airfield closure\n",
+                "The first paragraph. Top-level paragraphs are auto-numbered."
+            )
+        ),
+        [("main.body".to_string(), "body".to_string())]
+    );
+    assert!(paths(
+        &quill,
+        &with_body("subject: Airfield closure\n", "The runway closes Friday.")
+    )
+    .is_empty());
+}
+
+#[test]
+fn a_body_left_at_the_generated_placeholder_warns() {
+    let quill = quill_from_yaml(MEMO);
+    let root = md("subject: Airfield closure\n");
+
+    let placeholder =
+        "\n~~~card-yaml\n$kind: indorsement\nfrom: Ada\n~~~\nWrite indorsement body here.\n";
+    assert_eq!(
+        paths(&quill, &format!("{root}{placeholder}")),
+        ["cards.indorsement[0].body"],
+        "a kind declaring no `body.example` still shows text, and it is recognizable"
+    );
+
+    let written = "\n~~~card-yaml\n$kind: indorsement\nfrom: Ada\n~~~\nConcur.\n";
+    assert!(paths(&quill, &format!("{root}{written}")).is_empty());
+}
+
+#[test]
+fn an_empty_body_is_not_an_example() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert!(paths(&quill, &md("subject: Airfield closure\n")).is_empty());
+}
+
+/// The blueprint stamps a body it emitted through the content model, so the
+/// comparison meets it there rather than byte-for-byte.
+#[test]
+fn a_body_that_only_round_tripped_still_counts_as_untouched() {
+    let quill = quill_from_yaml(
+        r#"
+quill: { name: rt, version: 1.0.0, backend: typst, description: round trip }
+main:
+  body:
+    example: Write __this__ over.
+  fields:
+    subject: { type: string }
+"#,
+    );
+    let md = "~~~card-yaml\n$quill: rt@1.0.0\n$kind: main\nsubject: S\n~~~\n\nWrite **this** over.\n";
+
+    assert_eq!(paths(&quill, md), ["main.body"]);
+}
+
+const VARIANT: &str = r#"
+quill: { name: vr, version: 1.0.0, backend: typst, description: variants }
+main:
+  fields:
+    classification:
+      type: enum
+      values: [UNCLASSIFIED, CUI]
+      example: CUI
+      variants:
+        CUI:
+          controlled_by: { type: string, example: ORG1/SYMBOL }
+          category:      { type: string }
+"#;
+
+fn vr(fields: &str) -> String {
+    format!("~~~card-yaml\n$quill: vr@1.0.0\n$kind: main\n{fields}~~~\n")
+}
+
+#[test]
+fn the_walk_reaches_the_selected_worlds_cells() {
+    let quill = quill_from_yaml(VARIANT);
+
+    assert_eq!(
+        paths(
+            &quill,
+            &vr("classification:\n  value: CUI\n  controlled_by: ORG1/SYMBOL\n  category: PRVCY\n")
+        ),
+        ["main.classification.controlled_by", "main.classification.value"],
+        "the discriminant and its live world are both cells the blueprint stamped"
+    );
+
+    assert!(
+        paths(
+            &quill,
+            &vr("classification:\n  value: UNCLASSIFIED\n  controlled_by: ORG1/SYMBOL\n")
+        )
+        .is_empty(),
+        "a stranded value belongs to `out_of_variant`, not to this walk"
+    );
+}

--- a/crates/core/src/quill/compose/example_unchanged_tests.rs
+++ b/crates/core/src/quill/compose/example_unchanged_tests.rs
@@ -64,6 +64,16 @@ fn a_cell_left_at_its_example_warns_and_an_authored_one_does_not() {
     assert!(paths(&quill, &md("subject: Airfield closure\n")).is_empty());
 }
 
+/// A marked cell is `must_fill`'s to report: the blueprint writes marker and
+/// example together, so the pair would otherwise say the same thing twice.
+#[test]
+fn a_cell_still_carrying_its_marker_is_left_to_must_fill() {
+    let quill = quill_from_yaml(MEMO);
+
+    assert!(paths(&quill, &md("subject: !must_fill Duty Title\n")).is_empty());
+    assert_eq!(paths(&quill, &md("subject: Duty Title\n")), ["main.subject"]);
+}
+
 #[test]
 fn a_field_declaring_no_example_never_warns() {
     let quill = quill_from_yaml(MEMO);

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -174,9 +174,9 @@ pub(crate) fn append_incremental_update(
 /// A header is `<id> <generation> obj` at a token boundary, so `19 0 obj` is not
 /// found inside `519 0 obj`, at any generation (re-saved PDFs carry non-zero
 /// ones). A later occurrence overwrites an earlier one, so a lookup answers with
-/// the live copy. Literal strings, `%`-comments and stream bodies are skipped, so
-/// header bytes inside a string value or inside stream data cannot shadow the
-/// real object.
+/// the live copy. Strings, `%`-comments and stream bodies are skipped, so header
+/// bytes inside a string value or inside stream data cannot shadow the real
+/// object.
 pub struct ObjectIndex<'a> {
     pdf: &'a [u8],
     starts: HashMap<u32, usize>,
@@ -275,10 +275,9 @@ fn obj_header_id(rest: &[u8]) -> Option<u32> {
     std::str::from_utf8(&rest[..digits]).ok()?.parse().ok()
 }
 
-/// The index just past the `endobj` closing the body at `from`. Literal
-/// `( … )` strings, `%`-comments and stream bodies are skipped so those bytes
-/// inside a string value, a comment or stream data cannot truncate the object
-/// early.
+/// The index just past the `endobj` closing the body at `from`. Strings,
+/// `%`-comments and stream bodies are skipped so those bytes inside a string
+/// value, a comment or stream data cannot truncate the object early.
 fn find_endobj_end(pdf: &[u8], from: usize) -> Option<usize> {
     let needle = b"endobj";
     let mut i = from;
@@ -384,13 +383,16 @@ fn skip_ws_and_comments(b: &[u8], start: usize) -> usize {
     }
 }
 
-/// If `b[i]` opens a literal string or a `%`-comment, the index just past it, so
-/// a scanner steps over raw `<<`/`>>`/`[`/`]`/`endobj` bytes without reading them
-/// as structure. Hex strings need no handling: a well-formed one holds only hex
-/// digits. `None` when `b[i]` is neither, and the caller advances one byte.
+/// If `b[i]` opens a string — literal or hex — or a `%`-comment, the index just
+/// past it, so a scanner steps over raw `<<`/`>>`/`[`/`]`/`endobj` bytes without
+/// reading them as structure. A hex string's closing `>` is one of those:
+/// against the enclosing dict's `>>` it forms a `>>` that is not the dict's. A
+/// `<` followed by `<` opens a dict, not a hex string. `None` when `b[i]` opens
+/// none of them, and the caller advances one byte.
 fn skip_string_or_comment(b: &[u8], i: usize) -> Option<usize> {
     match b.get(i)? {
         b'(' => Some(skip_pdf_string(b, i)),
+        b'<' if b.get(i + 1) != Some(&b'<') => Some(skip_pdf_hex_string(b, i)),
         b'%' => {
             let mut j = i + 1;
             while j < b.len() && b[j] != b'\n' && b[j] != b'\r' {
@@ -576,10 +578,10 @@ pub fn extract_outer_dict(obj_bytes: &[u8]) -> Option<&[u8]> {
     Some(&obj_bytes[open + 2..close])
 }
 
-/// The index of the `>>` matching the `<<` at `open`. Literal strings and
-/// `%`-comments are skipped: either can carry `<<` / `>>` as raw bytes that
-/// would otherwise skew the nesting depth. `Err` carries the index the scan ran
-/// out at, for a caller that reads an unbalanced dict leniently.
+/// The index of the `>>` matching the `<<` at `open`. Strings and `%`-comments
+/// are skipped: any of them can carry `<<` / `>>` as raw bytes that would
+/// otherwise skew the nesting depth. `Err` carries the index the scan ran out
+/// at, for a caller that reads an unbalanced dict leniently.
 fn dict_end(b: &[u8], open: usize) -> Result<usize, usize> {
     let mut depth = 0i32;
     let mut i = open;
@@ -878,6 +880,18 @@ mod tests {
         let dict = extract_outer_dict(obj).expect("dict parses");
         let mb = find_dict_value(dict, "MediaBox").expect("/MediaBox survives the comment");
         assert_eq!(parse_rect_array(mb), Some([0.0, 0.0, 1.0, 2.0]));
+    }
+
+    #[test]
+    fn outer_dict_ends_after_a_trailing_hex_string() {
+        for (obj, inner) in [
+            (&b"<< /T <41>>>"[..], &b" /T <41>"[..]),
+            (b"<< /T <>>>", b" /T <>"),
+            (b"<< /T (a)>>", b" /T (a)"),
+            (b"<< /D << /T <41>>>>>", b" /D << /T <41>>>"),
+        ] {
+            assert_eq!(extract_outer_dict(obj), Some(inner));
+        }
     }
 
     #[test]

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -3,7 +3,7 @@
 //! values land in `/V` and the viewer synthesizes appearances.
 
 use pdf_writer::writers::Form;
-use pdf_writer::{Content, Finish, Name, Pdf, Rect, Ref};
+use pdf_writer::{Content, Finish, Name, Pdf, Rect, Ref, Settings, TextStr};
 use quillmark_pdf::{regions_of, stamp, FieldSpec, FieldType, StampOptions};
 
 /// An `n`-page US-Letter base satisfying the spine's input contract.
@@ -233,6 +233,69 @@ fn producer_only_no_fields_stamps_info_producer() {
     assert_eq!(
         info.get(b"Producer").unwrap().as_str().unwrap(),
         b"Quillmark test"
+    );
+}
+
+/// A one-page base whose compact `/Info` ends in a hex-encoded `/Title` —
+/// what pdf-writer's compact mode emits for a non-ASCII title written last.
+fn build_base_with_hex_title_info(title: &str) -> Vec<u8> {
+    let mut pdf = Pdf::with_settings(Settings { pretty: false });
+    let catalog_id = Ref::new(1);
+    let page_tree_id = Ref::new(2);
+    let page_id = Ref::new(3);
+    let content_id = Ref::new(4);
+    let info_id = Ref::new(5);
+    let rect = Rect::new(0.0, 0.0, 612.0, 792.0);
+    pdf.catalog(catalog_id).pages(page_tree_id);
+    {
+        let mut pages = pdf.pages(page_tree_id);
+        pages.kids([page_id]).count(1).media_box(rect);
+    }
+    pdf.page(page_id)
+        .parent(page_tree_id)
+        .media_box(rect)
+        .contents(content_id);
+    let mut content = Content::new();
+    content.set_line_width(1.0);
+    content.rect(72.0, 700.0, 200.0, 20.0);
+    content.stroke();
+    pdf.stream(content_id, &content.finish());
+    pdf.document_info(info_id)
+        .producer(TextStr("Base"))
+        .title(TextStr(title));
+    pdf.finish()
+}
+
+#[test]
+fn producer_stamp_preserves_a_trailing_hex_title() {
+    let title = "Résumé";
+    let result = stamp(
+        build_base_with_hex_title_info(title),
+        &[],
+        &StampOptions::default().with_producer("Quillmark test".into()),
+    )
+    .expect("stamp ok");
+
+    let doc = lopdf::Document::load_mem(&result).expect("lopdf reparse");
+    let info_ref = doc
+        .trailer
+        .get(b"Info")
+        .expect("trailer /Info")
+        .as_reference()
+        .expect("/Info indirect");
+    let info = doc.get_object(info_ref).unwrap().as_dict().unwrap();
+    assert_eq!(
+        info.get(b"Producer").unwrap().as_str().unwrap(),
+        b"Quillmark test"
+    );
+    let mut utf16be = vec![0xFE, 0xFF];
+    for unit in title.encode_utf16() {
+        utf16be.extend_from_slice(&unit.to_be_bytes());
+    }
+    assert_eq!(
+        info.get(b"Title").unwrap().as_str().unwrap(),
+        utf16be.as_slice(),
+        "the hex /Title survives the /Producer rewrite"
     );
 }
 

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -228,7 +228,10 @@ left at its `body.example` or at the `Write <kind> body here.` placeholder
 generated for a kind declaring none. Its `trigger` arg says which cell spoke
 (`field` or `body`); `example` carries the shown value in its JSON shape. A
 field declaring no `example:` never fires: there is nothing to recognize, and
-absence is `must_fill`'s question.
+absence is `must_fill`'s question. A cell still carrying its `!must_fill`
+marker never fires either: the blueprint writes marker and example together, so
+the marker already names the cell and by the same precedence its hint is the
+actionable one.
 
 Implementation: `crates/core/src/quill/validation.rs` (the `ValidationError`
 `Display` impl, for `validation::type_mismatch`) and

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -86,8 +86,9 @@ families:
   *render floor* also refuses it (`validation::type_mismatch`); the floor is
   more lenient than the write, and what it adopts is valid.
 - **Validation warnings**: `Quill::validate(doc)` returns every
-  `validation::*` diagnostic, mixing severities; `validation::must_fill` and
-  the `$seed` checks are the non-fatal ones. This is the editor-facing
+  `validation::*` diagnostic, mixing severities; `validation::must_fill`,
+  `validation::out_of_variant`, `validation::example_unchanged` and the `$seed`
+  checks are the non-fatal ones. This is the editor-facing
   surface; the render pipeline blank-fills instead of warning on incomplete
   documents. A **fatal** row here means the document does not render: values
   are judged in the form the render floor builds from them
@@ -210,10 +211,25 @@ the schema obliges the cell (see [SCHEMAS.md](SCHEMAS.md) § "Native
 validation"). An incomplete document therefore produces no *fatal* field-level
 diagnostic, and warns exactly where a human has yet to make a call.
 
+`validation::example_unchanged` (non-fatal) asks the other question: not
+*whether* a cell was authored but *which* value it holds. The blueprint seats a
+defaultless field's `example:` in its value cell under the `!must_fill` marker,
+and a seed commits one on every field that declares it, so a dropped marker
+leaves a value that is present, type-valid, in-domain, and nobody's answer.
+It fires where the authored value is the shown one — element-wise inside an
+array, so a half-edited list still names the leftover element — and on a body
+left at its `body.example` or at the `Write <kind> body here.` placeholder
+generated for a kind declaring none. Its `trigger` arg says which cell spoke
+(`field` or `body`); `example` carries the shown value in its JSON shape. A
+field declaring no `example:` never fires: there is nothing to recognize, and
+absence is `must_fill`'s question.
+
 Implementation: `crates/core/src/quill/validation.rs` (the `ValidationError`
 `Display` impl, for `validation::type_mismatch`) and
 `crates/core/src/quill/compose.rs` (`validate_fills`/`fill_warning` and
-`validate_unauthored`/`unauthored_warning`, for `validation::must_fill`).
+`validate_unauthored`/`unauthored_warning`, for `validation::must_fill`;
+`validate_examples`/`example_unchanged_warning`, for
+`validation::example_unchanged`).
 
 ## Document-model paths
 
@@ -315,6 +331,7 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `validation::body_disabled` | `card` | structured |
 | `validation::coercion_failed` | `value`, `target` | structured, coarser |
 | `validation::must_fill` | `trigger` | structured |
+| `validation::example_unchanged` | `example`, `trigger` | structured |
 | `validation::out_of_variant` | `variant`, `selected` | structured |
 | `validation::not_inline` | — | code-determined |
 | `validation::not_plain` | — | code-determined |


### PR DESCRIPTION
Reviewed #1464, #1465, #1467, #1471 and #1566. Four land here; #1471 does not — see below.

Landing them through one branch rather than four merge buttons because #1464 and #1465 break each other in a way git does not flag.

## What's here

| PR | |
|---|---|
| #1464 | body prose inside a card block is told to close the block |
| #1465 | a leading space before a top-level key gets its own hint |
| #1467 | `validation::example_unchanged` |
| #1566 | PDF: skip hex strings when scanning for a dict's end |

## Two cross-PR fixes

**#1464 + #1465 do not compile together.** Both add a `flagged_line_number` to `yaml_hints.rs`, in different places, so git merges them with no conflict and the tree stops compiling (`E0428`). GitHub reports both as mergeable; the second one merged would have broken `main`. One copy survives — the two were the same function, and #1465's description called this out.

**#1467 warned twice on one cell.** `validate_examples` ran unfiltered, so a cell still carrying its `!must_fill` marker drew both the marker's warning and the value's:

```
validation::must_fill          | main.subject | Field `main.subject` is marked `!must_fill`…
validation::example_unchanged  | main.subject | Field `main.subject` still holds the schema's example…
```

The blueprint writes marker and example together, so every untouched document said everything twice. It now passes through the `claimed` set `validate_unauthored` already uses — the precedence the module documents, where the marker's hint is the actionable one. The marker-dropped case, which is what #1467 exists for, is untouched. Pinned by `a_cell_still_carrying_its_marker_is_left_to_must_fill`; canon and CHANGELOG updated to match.

#1465 also shipped without a CHANGELOG entry; it has one here.

## Not landing: #1471

`serde-saphyr` 1.2.0 makes `MAX_YAML_DEPTH` unenforceable. `quill_yaml_deep_nesting_is_rejected` does not fail — the process **aborts on a stack overflow**, before the budget's depth check can refuse the input:

```
1.1.0   depth 100: OK    depth 101: ERR budget breached: Depth { depth: 101 }
1.2.0   depth  90: OK    depth 100: thread has overflowed its stack / SIGABRT
```

That limit exists to stop exactly this, and card-yaml is untrusted input, so an abort is reachable from a document — uncatchable in the Rust API and fatal to the WASM and Python hosts. The bump is `serde-saphyr` 1.1.0 → 1.2.0 with `granit-parser` 1.1.0 → 1.2.0 under it; 1.2.0's `Budget::parser_options` newly raises `block_nesting_limit` to `max(255, max_depth + 1)` to let the first over-limit container through and report `BudgetBreach::Depth`, but the stack gives out before that container is reached. Left open for an upstream report rather than merged; capping `MAX_YAML_DEPTH` under the overflow instead would change a documented public contract that the bindings enforce identically.

## Verification

`cargo test --workspace` green on this branch: 65 test binaries, 0 failures. Both #1566 tests confirmed failing with its one-line fix reverted and passing with it. Clippy unchanged from `main` (CI does not gate on it, per `ci.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014NXC5axPvSAgp365qXFVkz

---
_Generated by [Claude Code](https://claude.ai/code/session_014NXC5axPvSAgp365qXFVkz)_