### PR TITLE
Make the binding-build gate govern the commands it applies to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,8 +14,8 @@ Comments default to none, and one earns its place only where the code cannot car
 
 ## Tests
 
-- `cargo test --workspace`: the working loop, run freely.
-- Binding surfaces compile in minutes and PR CI runs both on every push. Build one locally only to reproduce a red CI job, or when the change is in that binding's own code and no Rust test reaches it.
+`cargo test --workspace` is the working loop; run it freely. The binding surfaces below compile in minutes and PR CI runs both on every push: build one locally only to reproduce a red CI job, or for a change in that binding's own code no Rust test reaches.
+
 - WASM: `./scripts/build-wasm.sh --ci && cd crates/bindings/wasm && npm test`. `--ci` is the fast-compile profile; bare `build-wasm.sh` is the publish build.
 - Python: `cd crates/bindings/python && uv venv && source .venv/bin/activate && uv pip install maturin pytest && maturin develop && pytest`. `maturin develop` builds debug.
 - `uv run` in that directory syncs the project first, and the sync is maturin's PEP 517 backend building release: `uv run maturin --version` compiles the extension to print a version string. The flow above is CI's (`.github/workflows/ci.yml`) and never syncs.


### PR DESCRIPTION
The gate sat as a bullet beside the WASM and Python commands rather than
above them, so a reader who jumped to the WASM line met a runnable command
with no condition on it.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SZJerxPkeyUosZcUwtRdLH