### PR TITLE
fix(core): spell a ParseError's English once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(core): **a `ParseError` spells its English once.** `to_diagnostic()`
+  renders the variant's `Display` instead of a second copy of the same
+  sentence, and the copies had drifted: `InvalidStructure` displayed under an
+  `Invalid YAML structure: ` prefix the diagnostic dropped. A Rust caller
+  formatting `{err}` from `Document::parse` now reads that variant without the
+  prefix, matching the message every binding and the CLI have always shown.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -319,7 +319,9 @@ pub enum ParseError {
     #[error("Too many cards: {count} (max: {max})")]
     TooManyCards { count: usize, max: usize },
 
-    #[error("Invalid YAML structure: {0}")]
+    /// A card-yaml block is not a well-formed document structure. The message
+    /// is minted at the site that refused it. Code `parse::invalid_structure`.
+    #[error("{0}")]
     InvalidStructure(String),
 
     /// Markdown input was empty or whitespace-only. Code `parse::empty_input`.
@@ -416,61 +418,43 @@ impl ParseError {
         }
     }
 
+    /// This error as a [`Diagnostic`]: the `Display` rendering as `message`,
+    /// under the variant's `parse::*` code, with the location, hint and
+    /// [`args`](Self::args) the variant carries. The `#[error]` attribute is
+    /// the one place a variant's English is spelled.
     pub fn to_diagnostic(&self) -> Diagnostic {
+        let base = Diagnostic::new(Severity::Error, self.to_string());
         let diag = match self {
-            ParseError::InputTooLarge { size, max } => Diagnostic::new(
-                Severity::Error,
-                format!("Input too large: {} bytes (max: {} bytes)", size, max),
-            )
-            .with_code("parse::input_too_large".to_string()),
-            ParseError::TooManyFields { count, max } => Diagnostic::new(
-                Severity::Error,
-                format!(
-                    "Too many fields in one card-yaml block: {} (max: {})",
-                    count, max
-                ),
-            )
-            .with_code("parse::too_many_fields".to_string()),
-            ParseError::TooManyCards { count, max } => Diagnostic::new(
-                Severity::Error,
-                format!("Too many cards: {} (max: {})", count, max),
-            )
-            .with_code("parse::too_many_cards".to_string()),
-            ParseError::InvalidStructure(msg) => Diagnostic::new(Severity::Error, msg.clone())
-                .with_code("parse::invalid_structure".to_string()),
-            ParseError::EmptyInput(msg) => Diagnostic::new(Severity::Error, msg.clone())
-                .with_code("parse::empty_input".to_string()),
-            ParseError::MissingQuill(msg) => Diagnostic::new(Severity::Error, msg.clone())
-                .with_code("parse::missing_quill".to_string()),
-            ParseError::BodyImport(msg) => Diagnostic::new(Severity::Error, msg.clone())
-                .with_code("parse::body_import".to_string()),
-            ParseError::InvalidQuillReference { value, reason } => Diagnostic::new(
-                Severity::Error,
-                format!("Invalid $quill reference '{}': {}", value, reason),
-            )
-            .with_code("parse::invalid_quill_reference".to_string())
-            .with_hint(crate::version::quill_ref_hint().to_string()),
+            ParseError::InputTooLarge { .. } => {
+                base.with_code("parse::input_too_large".to_string())
+            }
+            ParseError::TooManyFields { .. } => {
+                base.with_code("parse::too_many_fields".to_string())
+            }
+            ParseError::TooManyCards { .. } => base.with_code("parse::too_many_cards".to_string()),
+            ParseError::InvalidStructure(_) => {
+                base.with_code("parse::invalid_structure".to_string())
+            }
+            ParseError::EmptyInput(_) => base.with_code("parse::empty_input".to_string()),
+            ParseError::MissingQuill(_) => base.with_code("parse::missing_quill".to_string()),
+            ParseError::BodyImport(_) => base.with_code("parse::body_import".to_string()),
+            ParseError::InvalidQuillReference { .. } => base
+                .with_code("parse::invalid_quill_reference".to_string())
+                .with_hint(crate::version::quill_ref_hint().to_string()),
             ParseError::YamlErrorWithLocation {
-                message,
-                line,
-                column,
-                block_index,
-                hint,
+                line, column, hint, ..
             } => {
-                let mut d = Diagnostic::new(
-                    Severity::Error,
-                    format!("YAML error in {}: {}", block_label(*block_index), message),
-                )
-                .with_code("parse::yaml_error_with_location".to_string())
-                .with_location(Location::new(
-                    DOCUMENT_FILE.to_string(),
-                    *line as u32,
-                    *column as u32,
-                ));
-                if let Some(h) = hint {
-                    d = d.with_hint(h.clone());
+                let d = base
+                    .with_code("parse::yaml_error_with_location".to_string())
+                    .with_location(Location::new(
+                        DOCUMENT_FILE.to_string(),
+                        *line as u32,
+                        *column as u32,
+                    ));
+                match hint {
+                    Some(h) => d.with_hint(h.clone()),
+                    None => d,
                 }
-                d
             }
         };
         diag.with_args(self.args())
@@ -579,9 +563,43 @@ pub fn print_errors(err: &RenderError) {
     }
 }
 
+/// One sample per [`ParseError`] variant.
+#[cfg(test)]
+fn parse_error_samples() -> Vec<ParseError> {
+    vec![
+        ParseError::InputTooLarge { size: 2, max: 1 },
+        ParseError::TooManyFields { count: 2, max: 1 },
+        ParseError::TooManyCards { count: 2, max: 1 },
+        ParseError::InvalidStructure("x".into()),
+        ParseError::EmptyInput("x".into()),
+        ParseError::MissingQuill("x".into()),
+        ParseError::BodyImport("x".into()),
+        ParseError::InvalidQuillReference {
+            value: "a@b".into(),
+            reason: "x".into(),
+        },
+        ParseError::YamlErrorWithLocation {
+            message: "x".into(),
+            line: 3,
+            column: 1,
+            block_index: 1,
+            hint: None,
+        },
+    ]
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// One spelling per variant: the `#[error]` attribute, which the
+    /// diagnostic renders rather than restates.
+    #[test]
+    fn parse_diagnostic_message_is_the_display_rendering() {
+        for err in super::parse_error_samples() {
+            assert_eq!(err.to_diagnostic().message, err.to_string(), "{err:?}");
+        }
+    }
 
     #[test]
     fn test_diagnostic_with_source_chain() {
@@ -609,7 +627,6 @@ mod tests {
 mod args_canon {
     use std::collections::BTreeMap;
 
-    use super::ParseError;
     use crate::document::EditError;
     use crate::quill::{CoercionError, ValidationError};
 
@@ -734,26 +751,7 @@ mod args_canon {
             );
         }
 
-        for e in [
-            ParseError::InputTooLarge { size: 2, max: 1 },
-            ParseError::TooManyFields { count: 2, max: 1 },
-            ParseError::TooManyCards { count: 2, max: 1 },
-            ParseError::InvalidStructure("x".into()),
-            ParseError::EmptyInput("x".into()),
-            ParseError::MissingQuill("x".into()),
-            ParseError::BodyImport("x".into()),
-            ParseError::InvalidQuillReference {
-                value: "a@b".into(),
-                reason: "x".into(),
-            },
-            ParseError::YamlErrorWithLocation {
-                message: "x".into(),
-                line: 3,
-                column: 1,
-                block_index: 1,
-                hint: None,
-            },
-        ] {
+        for e in super::parse_error_samples() {
             let diag = e.to_diagnostic();
             add(diag.code.as_deref().expect("parse errors carry a code"), diag.args);
         }

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -22,7 +22,11 @@ severity.
 
 **`Diagnostic`**: severity, optional error `code`, `message`, optional `location` (text anchor: file/line/column), optional `path` (document-model anchor, dotted/bracketed path into the typed `Document`, set by schema validation/coercion), optional `hint`, `source_chain` (omitted from serialization when empty). `location` and `path` are independent and may co-exist.
 
-**`ParseError`**: parsing-stage error enum, `InputTooLarge`, `TooManyFields`, `TooManyCards`, `InvalidStructure`, `EmptyInput`, `MissingQuill`, `InvalidQuillReference`, `YamlErrorWithLocation`; converts to `Diagnostic` via `to_diagnostic()`. The `InvalidQuillReference` case (`parse::invalid_quill_reference`) attaches the canonical `$quill` grammar (`quill_ref_hint()`) as the diagnostic hint. That hint is the single source of truth for the reference grammar: bindings surface it verbatim (e.g. WASM `Document.quillRefHint`) rather than re-stating the rule.
+**`ParseError`**: parsing-stage error enum, `InputTooLarge`, `TooManyFields`, `TooManyCards`, `InvalidStructure`, `EmptyInput`, `MissingQuill`, `BodyImport`, `InvalidQuillReference`, `YamlErrorWithLocation`; converts to `Diagnostic` via `to_diagnostic()`. The `InvalidQuillReference` case (`parse::invalid_quill_reference`) attaches the canonical `$quill` grammar (`quill_ref_hint()`) as the diagnostic hint. That hint is the single source of truth for the reference grammar: bindings surface it verbatim (e.g. WASM `Document.quillRefHint`) rather than re-stating the rule.
+
+The diagnostic's `message` is the variant's `Display` rendering, so the
+`#[error]` attribute is the one place a variant's English is spelled and a Rust
+caller formatting `{err}` reads the same sentence a binding reads off `message`.
 
 **`YamlError`**: the one adapter every `serde-saphyr` error passes through. Sanitizes the message (the engine appends its own Rust API names (`from_multiple`, `DuplicateKeyPolicy`) which `yaml_hints::enrich_yaml_error` strips), derives the hint, and carries the 1-indexed line/column the engine located; `to_diagnostic(code, file)` renders all three. The emit side has no input to point at, so it carries neither position nor hint.
 


### PR DESCRIPTION
Closes #1521.

## The change

`ParseError::to_diagnostic()` builds its message from `self.to_string()`. Each match arm now contributes only what the `#[error]` attribute cannot: the `parse::*` code, the `Location` and hint on `YamlErrorWithLocation`, the grammar hint on `InvalidQuillReference`. The attribute is the one place a variant's English is spelled.

Of the two drifts the issue names, one had already been repaired: `YamlErrorWithLocation` shares `block_label()` on both sides, so the strings agreed and only the `format!` was duplicated. The other stands: `InvalidStructure` displayed under an `Invalid YAML structure: ` prefix the diagnostic dropped. The prefix goes. The assembler mints a full sentence at each of its ~20 refusal sites ("A composable card-yaml block must not declare `$quill`: …"), so the prefix read as a stutter, and ERROR.md makes the diagnostic's `message` the canonical rendering. Nothing in the workspace, the bindings, or `docs/` referenced that string.

This is user-observable for a Rust caller formatting `{err}` from `Document::parse` or `Quill::parse`: that one variant loses the prefix and now matches what every binding and the CLI have always shown. No diagnostic code, arg key, or diagnostic message changes, so the changelog entry is `fix(core)` without `!`.

One test guards the class: `parse_diagnostic_message_is_the_display_rendering` asserts message equals `Display` across one sample per variant. The sample list moves to a shared `parse_error_samples()`, which `diagnostic_args_match_canon` already needed.

## Docs

ERROR.md's `ParseError` entry states the new invariant, and its variant list gains `BodyImport`, which it had been missing.

## Verification

- `cargo test --workspace`: green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: canon spine OK (its 700-char line budget shaped the ERROR.md edit into its own paragraph).
- `cargo clippy -p quillmark-core --all-targets`: no warning in `error.rs`.
- No binding built: the change is in core, and both bindings reach it through `to_diagnostic()`, which the Rust tests cover.

## For review

Dropping the `InvalidStructure` prefix is the judgment call. The alternative — keeping it in the attribute and letting it into the diagnostic — would change the message every binding shows, which is the wider break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_