### PR TITLE
fix(core): collapse a main description before testing it for emptiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(core): **a blank `main.description` emits no description line in the
+  blueprint.** The main card tested the raw string for emptiness and collapsed
+  whitespace afterwards, so `main: { description: "   " }` passed the test and
+  landed as a bare `# ` above the first field. The collapse now runs first, the
+  same order every other description takes, and a description that collapses to
+  nothing falls through to `quill.description`.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -32,12 +32,8 @@ impl QuillConfig {
     ///
     /// [`Document`]: crate::Document
     pub fn blueprint(&self) -> String {
-        let main_desc = self
-            .main
-            .description
-            .as_deref()
-            .filter(|s| !s.is_empty())
-            .or_else(|| Some(self.description.as_str()).filter(|s| !s.is_empty()));
+        let main_desc = collapse_opt(self.main.description.as_deref())
+            .or_else(|| collapse_opt(Some(self.description.as_str())));
 
         let main = build_main_card(
             &self.main,
@@ -52,13 +48,8 @@ impl QuillConfig {
 
 /// Whitespace-collapse a description into a single line; `None` when it
 /// collapses to empty.
-fn collapse(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
-}
-
-fn collapse_opt(text: &Option<String>) -> Option<String> {
-    text.as_deref()
-        .map(collapse)
+fn collapse_opt(text: Option<&str>) -> Option<String> {
+    text.map(|t| t.split_whitespace().collect::<Vec<_>>().join(" "))
         .filter(|clean| !clean.is_empty())
 }
 
@@ -84,7 +75,7 @@ pub(super) fn body_placeholder(kind: &str) -> String {
 
 /// Build the root card: `$quill` (with the `# keep verbatim` inline reminder),
 /// `$kind: main`, the optional description own-line comment, then the fields.
-fn build_main_card(card: &CardSchema, quill_ref: &str, description: Option<&str>) -> Card {
+fn build_main_card(card: &CardSchema, quill_ref: &str, description: Option<String>) -> Card {
     let reference = quill_ref
         .parse()
         .expect("quill name@version is always a valid QuillReference");
@@ -96,7 +87,7 @@ fn build_main_card(card: &CardSchema, quill_ref: &str, description: Option<&str>
         },
     ];
     if let Some(desc) = description {
-        items.push(PayloadItem::comment(collapse(desc)));
+        items.push(PayloadItem::comment(desc));
     }
     append_fields(&mut items, card);
     Card::from_parts(
@@ -121,7 +112,7 @@ fn build_card(card: &CardSchema) -> Card {
         PayloadItem::comment("composable (0..N)"),
         PayloadItem::comment("sample card; delete if not needed"),
     ];
-    if let Some(desc) = collapse_opt(&card.description) {
+    if let Some(desc) = collapse_opt(card.description.as_deref()) {
         items.push(PayloadItem::comment(desc));
     }
     append_fields(&mut items, card);
@@ -233,7 +224,7 @@ fn eg_hinted(field: &FieldSchema) -> bool {
 /// `eg_hinted`, while typed containers always surface it (their example never
 /// inlines).
 fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool) {
-    if let Some(desc) = collapse_opt(&field.description) {
+    if let Some(desc) = collapse_opt(field.description.as_deref()) {
         items.push(PayloadItem::comment(desc));
     }
     if eg_when {
@@ -299,7 +290,7 @@ fn build_property_mapping(
     let mut fills = Vec::new();
     for prop in props.values().map(|b| b.as_ref()) {
         let slot = map.len();
-        if let Some(desc) = collapse_opt(&prop.description) {
+        if let Some(desc) = collapse_opt(prop.description.as_deref()) {
             nested.push(NestedComment {
                 container_path: prefix.to_vec(),
                 position: slot,
@@ -809,6 +800,27 @@ main:
         .blueprint();
         assert!(t.starts_with("~~~\n$quill: taro@0.1.0 # keep verbatim\n$kind: main\n# x\n"));
         assert!(t.contains("\nWrite main body here.\n"));
+    }
+
+    /// A description that collapses to nothing is no description: the main card
+    /// falls through to the quill's own rather than emitting an empty comment.
+    #[test]
+    fn a_whitespace_only_main_description_emits_no_empty_comment() {
+        let t = cfg(r#"
+quill: { name: taro, version: 0.1.0, backend: typst, description: A taro order form. }
+main:
+  description: "   "
+  fields:
+    flavor: { type: string, default: taro }
+"#)
+        .blueprint();
+        assert!(
+            t.starts_with(
+                "~~~\n$quill: taro@0.1.0 # keep verbatim\n$kind: main\n# A taro order form.\n"
+            ),
+            "{t}"
+        );
+        assert!(!t.contains("\n#\n") && !t.contains("\n# \n"), "{t}");
     }
 
     #[test]

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -2016,11 +2016,9 @@ impl QuillConfig {
 
         // Warn when `body.example` is set together with `body.enabled: false`:
         // the example has no effect since the body editor is disabled.
-        let warn_example_unused = |label: &str,
-                                   body: &Option<BodyCardSchema>|
-         -> Option<Diagnostic> {
-            let body = body.as_ref()?;
-            if body.enabled == Some(false) && body.example.is_some() {
+        let warn_example_unused = |label: &str, card: &CardSchema| -> Option<Diagnostic> {
+            let body = card.body.as_ref()?;
+            if !card.body_enabled() && body.example.is_some() {
                 Some(
                     Diagnostic::new(
                         Severity::Warning,
@@ -2050,7 +2048,7 @@ impl QuillConfig {
             .collect();
 
         for (label, card) in &labeled {
-            if let Some(d) = warn_example_unused(label, &card.body) {
+            if let Some(d) = warn_example_unused(label, card) {
                 warnings.push(d);
             }
         }
@@ -2228,8 +2226,7 @@ fn populate_card_content(card: &mut CardSchema, label: &str, errors: &mut Vec<Di
     for (name, field) in card.fields.iter_mut() {
         populate_field_content(field, label, name, errors);
     }
-    let body_enabled = card.body.as_ref().is_none_or(|b| b.enabled != Some(false));
-    if body_enabled {
+    if card.body_enabled() {
         if let Some(body) = card.body.as_mut() {
             if let Some(example) = body.example.clone() {
                 match crate::document::import_body(&example) {


### PR DESCRIPTION
Closes #1529.

## The change

The blueprint's main-card path tested `main.description` for emptiness on the raw string and collapsed whitespace afterwards, the opposite order from `collapse_opt`. `main: { description: "   " }` therefore passed the test and landed as a bare `# ` line above the first field. `collapse_opt` now takes `Option<&str>` instead of `&Option<String>` and serves the main path too, so the collapse runs first everywhere; a description that collapses to nothing falls through to `quill.description`. `build_main_card` receives the already-collapsed `Option<String>` and the standalone `collapse` helper is gone: one predicate, one function.

The loader's two hand-spelled `enabled` predicates now read `CardSchema::body_enabled()`. Both sites hold a `CardSchema`, so the canonical predicate applies directly: the `quill::body_example_unused` closure takes `&CardSchema` rather than `&Option<BodyCardSchema>` and asks `!card.body_enabled()`, and `populate_card_content` asks `card.body_enabled()`. Behavior is identical on every combination of `body` absent / `enabled` absent / `true` / `false`.

## Docs

None. `prose/canon/BLUEPRINT.md` already states the description is whitespace-collapsed and makes no claim about the main fallback ordering, so nothing went stale.

## Verification

- `cargo test --workspace`: green.
- `cargo clippy -p quillmark-core`: warning set identical to `origin/main` at the same sites (pre-existing `collapsible_if` and `type_complexity`); no new warnings.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- Bindings not built: the change is core Rust reached by the workspace tests.

## For review

One new test, `a_whitespace_only_main_description_emits_no_empty_comment`, guards the blueprint behavior: the whitespace-only `main.description` falls through to `quill.description` and no empty comment line is emitted.

No test for the `body_enabled` sites. Site one is already covered by `body_example_with_body_disabled_emits_warning`. Site two only skips populating `body.example_content`, a `#[serde(skip)]` internal cache with no observable effect (`seed` independently gates on `body_enabled()`), so a test there would pin an internal rather than a property that can break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_