### PR TITLE
fix(core)!: parse `main:` as strictly as a card kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- fix(core)!: **`main:` parses under the same strict card-schema shape as a
+  card kind.** A `main:` that is not a mapping, an unknown key under it
+  (`feilds:`, `title:`), and a `main.fields` that is not a mapping all loaded
+  as a main card with zero fields and no diagnostic; each is now
+  `quill::invalid_card_schema`. `main` and `card_kinds.<name>` accept
+  `description`, `fields`, `ui`, and `body` only, and a malformed `ui` or
+  `body` block under either reports `quill::invalid_ui` or
+  `quill::invalid_body` with the hint naming that block's keys, where a card
+  kind drew the whole-card `quill::invalid_card_schema`.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -9,7 +9,7 @@ use crate::error::{Diagnostic, Severity, diag_args};
 use crate::value::QuillValue;
 
 use super::types::{
-    BODY_CARD_SCHEMA_KEYS, RICHTEXT_INLINE_TOKEN_MSG, UI_ORDER_REMOVED_MSG,
+    BODY_CARD_SCHEMA_KEYS, RICHTEXT_INLINE_TOKEN_MSG, UI_CARD_SCHEMA_KEYS, UI_ORDER_REMOVED_MSG,
     VARIANT_DISCRIMINANT_KEY,
 };
 use super::{BodyCardSchema, CardSchema, FieldSchema, FieldType, GroupRegistry, UiCardSchema};
@@ -101,16 +101,16 @@ impl QuillConfig {
     }
 }
 
-#[derive(Debug, Deserialize)]
+/// One card-schema block: the `main:` section or a `card_kinds.<name>:` entry.
+/// It fixes the key set and each block's outer shape; `fields`, `ui`, and `body`
+/// stay raw so their own parsers can report per-block diagnostics.
+#[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct CardSchemaDef {
     pub description: Option<String>,
-    // Declared so `deny_unknown_fields` accepts a `fields:` block on a card.
-    // Fields are parsed separately via `parse_fields` (per-field diagnostics).
-    #[allow(dead_code)]
     pub fields: Option<serde_json::Map<String, serde_json::Value>>,
-    pub ui: Option<UiCardSchema>,
-    pub body: Option<BodyCardSchema>,
+    pub ui: Option<serde_json::Value>,
+    pub body: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
@@ -1522,6 +1522,39 @@ impl QuillConfig {
         }
     }
 
+    /// Parse one card-schema block (`main:` or a `card_kinds.<name>:` entry).
+    /// `None` plus a diagnostic when the block is not a mapping or carries an
+    /// unknown key, so a typo is reported rather than loading as an empty card.
+    fn parse_card_schema_def(
+        value: &serde_json::Value,
+        label: &str,
+        errors: &mut Vec<Diagnostic>,
+    ) -> Option<CardSchemaDef> {
+        // Checked ahead of serde, which reads a sequence of the right length as
+        // a struct's fields in declaration order.
+        if !value.is_object() {
+            errors.push(
+                Diagnostic::new(
+                    Severity::Error,
+                    format!("'{label}' must be an object (mapping of card-schema keys)"),
+                )
+                .with_code("quill::invalid_card_schema".to_string()),
+            );
+            return None;
+        }
+
+        match serde_json::from_value::<CardSchemaDef>(value.clone()) {
+            Ok(def) => Some(def),
+            Err(e) => {
+                errors.push(
+                    Diagnostic::new(Severity::Error, format!("Failed to parse '{label}': {e}"))
+                        .with_code("quill::invalid_card_schema".to_string()),
+                );
+                None
+            }
+        }
+    }
+
     /// Parse fields from a JSON map into `FieldSchema`s (both `main.fields` and
     /// a card kind's `fields`). Declaration order rides the map itself: the
     /// source map preserves key order (serde_json's `preserve_order`) and the
@@ -1825,11 +1858,20 @@ impl QuillConfig {
             .map(|s| s.to_string())
             .unwrap_or_else(|| "Unknown".to_string());
 
+        let ui_hint = format!(
+            "Valid keys under 'ui' are: {}.",
+            UI_CARD_SCHEMA_KEYS.join(", ")
+        );
+        let body_hint = format!(
+            "Valid keys under 'body' are: {}.",
+            BODY_CARD_SCHEMA_KEYS.join(", ")
+        );
+
         let ui_section: Option<UiCardSchema> = Self::parse_section(
             quill_section.get("ui"),
             "quill.ui",
             "quill::invalid_ui",
-            "Valid keys under 'ui' are: title, groups.",
+            &ui_hint,
             &mut errors,
         );
 
@@ -1884,46 +1926,35 @@ impl QuillConfig {
             }
         }
 
-        let main_obj_opt = quill_yaml_val.get("main").and_then(|v| v.as_object());
+        let main_def = quill_yaml_val
+            .get("main")
+            .and_then(|main_val| Self::parse_card_schema_def(main_val, "main", &mut errors))
+            .unwrap_or_default();
 
-        // Extract main.fields (optional)
-        let fields = if let Some(fields_map) = main_obj_opt
-            .and_then(|main_obj| main_obj.get("fields"))
-            .and_then(|v| v.as_object())
-        {
-            Self::parse_fields(fields_map, "field schema", &mut errors)
-        } else {
-            IndexMap::new()
+        let fields = match &main_def.fields {
+            Some(fields_map) => Self::parse_fields(fields_map, "field schema", &mut errors),
+            None => IndexMap::new(),
         };
 
-        // Extract main.ui (optional). Fail loudly on malformed UI metadata rather
-        // than silently dropping it; see `quill.ui` handling above.
         let main_ui: Option<UiCardSchema> = Self::parse_section(
-            main_obj_opt.and_then(|main_obj| main_obj.get("ui")),
+            main_def.ui.as_ref(),
             "main.ui",
             "quill::invalid_ui",
-            "Valid keys under 'ui' are: title, groups.",
+            &ui_hint,
             &mut errors,
         );
 
-        // Extract main.body (optional). Fail loudly on malformed body metadata.
         let main_body: Option<BodyCardSchema> = Self::parse_section(
-            main_obj_opt.and_then(|main_obj| main_obj.get("body")),
+            main_def.body.as_ref(),
             "main.body",
             "quill::invalid_body",
-            &format!(
-                "Valid keys under 'body' are: {}.",
-                BODY_CARD_SCHEMA_KEYS.join(", ")
-            ),
+            &body_hint,
             &mut errors,
         );
 
-        // Extract main.description (optional, authored under `main:` like any
-        // other card kind). This is independent of `quill.description`.
-        let main_description = main_obj_opt
-            .and_then(|main_obj| main_obj.get("description"))
-            .and_then(|v| v.as_str())
-            .map(|s| s.to_string());
+        // `main.description` describes the main card's schema, independent of
+        // `quill.description`.
+        let main_description = main_def.description;
         Self::validate_description_singleline(main_description.as_deref(), "main", &mut errors);
 
         // The main entry-point card.
@@ -1965,37 +1996,37 @@ impl QuillConfig {
                             continue;
                         }
 
-                        // Parse card basic info using serde
-                        let card_def: CardSchemaDef =
-                            match serde_json::from_value(card_value.clone()) {
-                                Ok(d) => d,
-                                Err(e) => {
-                                    errors.push(
-                                        Diagnostic::new(
-                                            Severity::Error,
-                                            format!(
-                                                "Failed to parse card_kind '{}': {}",
-                                                card_name, e
-                                            ),
-                                        )
-                                        .with_code("quill::invalid_card_schema".to_string()),
-                                    );
-                                    continue;
-                                }
+                        let label = format!("card_kinds.{}", card_name);
+                        let card_def =
+                            match Self::parse_card_schema_def(card_value, &label, &mut errors) {
+                                Some(d) => d,
+                                None => continue,
                             };
 
-                        // Parse card fields
-                        let card_fields = if let Some(card_fields_table) =
-                            card_value.get("fields").and_then(|v| v.as_object())
-                        {
-                            Self::parse_fields(
+                        let card_fields = match &card_def.fields {
+                            Some(card_fields_table) => Self::parse_fields(
                                 card_fields_table,
                                 &format!("card_kind '{}' field", card_name),
                                 &mut errors,
-                            )
-                        } else {
-                            IndexMap::new()
+                            ),
+                            None => IndexMap::new(),
                         };
+
+                        let card_ui: Option<UiCardSchema> = Self::parse_section(
+                            card_def.ui.as_ref(),
+                            &format!("{}.ui", label),
+                            "quill::invalid_ui",
+                            &ui_hint,
+                            &mut errors,
+                        );
+
+                        let card_body: Option<BodyCardSchema> = Self::parse_section(
+                            card_def.body.as_ref(),
+                            &format!("{}.body", label),
+                            "quill::invalid_body",
+                            &body_hint,
+                            &mut errors,
+                        );
 
                         Self::validate_description_singleline(
                             card_def.description.as_deref(),
@@ -2006,8 +2037,8 @@ impl QuillConfig {
                             name: card_name.clone(),
                             description: card_def.description,
                             fields: card_fields,
-                            ui: card_def.ui,
-                            body: card_def.body,
+                            ui: card_ui,
+                            body: card_body,
                         });
                     }
                 }

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -1975,6 +1975,73 @@ main:
     }
 }
 
+fn config_with_sections(sections: &str) -> Result<QuillConfig, Vec<Diagnostic>> {
+    let yaml_content = format!(
+        r#"
+quill:
+  name: strict
+  version: "1.0"
+  backend: typst
+  description: Strict card-schema parsing
+
+{sections}
+"#
+    );
+    QuillConfig::from_yaml_with_warnings(&yaml_content).map(|(c, _)| c)
+}
+
+#[test]
+fn main_refuses_every_shape_a_card_kind_refuses() {
+    let cases = [
+        (
+            "misspelled fields",
+            "main:\n  feilds:\n    title:\n      type: string",
+        ),
+        ("unknown key", "main:\n  title: Memo"),
+        ("list-shaped fields", "main:\n  fields: [title, author]"),
+        ("non-mapping main", "main: [x]"),
+        ("scalar main", "main: 5"),
+        ("empty main", "main:"),
+    ];
+
+    for (label, sections) in cases {
+        let err = config_with_sections(sections)
+            .err()
+            .unwrap_or_else(|| panic!("{label} loaded instead of erroring"));
+        assert!(
+            err.iter()
+                .any(|d| d.code.as_deref() == Some("quill::invalid_card_schema")),
+            "{label}: {:?}",
+            err.iter().map(|d| d.code.as_deref()).collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn a_card_kind_ui_and_body_block_report_their_own_codes() {
+    let ui_err = config_with_sections("card_kinds:\n  note:\n    ui:\n      bogus_key: nope")
+        .expect_err("a malformed card_kinds.<name>.ui is a load error");
+    assert!(
+        ui_err
+            .iter()
+            .any(|d| d.code.as_deref() == Some("quill::invalid_ui")),
+        "{:?}",
+        ui_err.iter().map(|d| d.code.as_deref()).collect::<Vec<_>>()
+    );
+
+    let body_err =
+        config_with_sections("card_kinds:\n  note:\n    body:\n      unsuported: [Table]")
+            .expect_err("a malformed card_kinds.<name>.body is a load error");
+    let hint = body_err
+        .iter()
+        .find(|d| d.code.as_deref() == Some("quill::invalid_body"))
+        .and_then(|d| d.hint.clone())
+        .expect("a malformed card_kinds.<name>.body carries a hint");
+    for key in ["enabled", "example", "unsupported"] {
+        assert!(hint.contains(key), "hint omits {key}: {hint}");
+    }
+}
+
 #[test]
 fn test_field_ui_title_is_valid() {
     let yaml_content = r#"

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -150,6 +150,10 @@ pub struct BodyCardSchema {
     pub unsupported: Vec<BlockConstruct>,
 }
 
+/// The keys [`UiCardSchema`] deserializes, for the hint on a rejected `ui:`
+/// section.
+pub(crate) const UI_CARD_SCHEMA_KEYS: &[&str] = &["title", "groups"];
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 #[non_exhaustive]

--- a/prose/canon/QUILL.md
+++ b/prose/canon/QUILL.md
@@ -103,9 +103,10 @@ Metadata resolution:
 
 - Unknown keys in the `quill:` section error with `quill::unknown_key` (typos like `platefile` are not silently captured).
 - Unknown top-level sections error with `quill::unknown_section` (typos like `card_kind:` are not silently ignored). Root-level `fields:` gets a targeted hint pointing to `main.fields:`.
+- `main:` and each `card_kinds.<name>:` entry parse under one card-schema shape, which accepts `description`, `fields`, `ui`, and `body` only: a section that is not a mapping, an unknown key (`feilds:`), or a `fields:` that is not a mapping errors with `quill::invalid_card_schema` rather than loading as a card with no fields. A `card_kinds:` that is not a mapping errors with `quill::invalid_card_kinds`.
 - Field schemas that fail to parse (e.g. a bare `title:`, missing `type:`) error with `quill::field_parse_error` and an actionable hint where applicable, rather than being dropped from the schema.
 - `object` fields without a `properties` map error with `quill::object_missing_properties`; an empty `properties` map errors with `quill::object_empty_properties`.
-- Malformed `quill.ui` / `main.ui` blocks error with `quill::invalid_ui` rather than being silently discarded.
+- Malformed `quill.ui` / `main.ui` / `card_kinds.<name>.ui` blocks error with `quill::invalid_ui` rather than being silently discarded.
 - Malformed `main.body` / `card_kinds.<name>.body` blocks error with `quill::invalid_body`.
 - A `body.example` set together with `body.enabled: false` warns with `quill::body_example_unused` (the example has no effect).
 


### PR DESCRIPTION
Closes #1488.

## The change

The issue's premise held exactly: every row of its reproduction table loaded `Ok` with zero fields and zero diagnostics.

`main:` and each `card_kinds.<name>:` entry now go through one `CardSchemaDef`, so both accept `description`, `fields`, `ui`, and `body` and nothing else. A section that is not a mapping, an unknown key under it (`feilds:`, `title:`), and a `fields:` that is not a mapping are `quill::invalid_card_schema` in place of a card loading with no fields.

The route is a strict top-level shape check, then the existing `parse_section` helpers for the sub-blocks, rather than letting `CardSchemaDef` deserialize `ui` and `body` itself. Deserializing them there would have collapsed a malformed `main.ui` / `main.body` into the whole-card `quill::invalid_card_schema`, dropping the codes QUILL.md pins and the hints two tests guard. So `ui` and `body` stay raw `serde_json::Value` on the struct and reach `parse_section`, which keeps `quill::invalid_ui` and `quill::invalid_body` for `main` and extends them to a card kind's blocks, which is what QUILL.md already claimed for `card_kinds.<name>.body` but the code did not do. No new diagnostic code, and the shared struct means the accepted key set cannot drift between the two sections.

The mapping check runs ahead of serde, which otherwise reads a 4-element sequence as a struct's fields positionally, so `main: [a, b, c, d]` would have slipped past `deny_unknown_fields`.

## Docs

QUILL.md § Strict Parsing gains the card-schema shape bullet and names `card_kinds.<name>.ui` in the `quill::invalid_ui` bullet. The `quill-yaml-reference.md` claim that a card kind is "shaped exactly like `main:`" is now true in both directions and needed no edit.

## Verification

- `cargo test --workspace`: green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: canon spine OK.
- `cargo clippy -p quillmark-core --all-targets`: 32 warnings, identical to the pre-change baseline.
- Every `Quill.yaml` under `crates/fixtures`, every YAML block in `docs/`, and every inline quill string in the bindings' tests carry only `fields`, `ui`, `body`, or `description` under `main:` (scanned by script); none needed fixing. No binding build ran: the change is Rust-side and Rust tests reach it.

## For review

A bare `main:` (YAML null) is now an error, matching a bare `card_kinds.<name>:`, which already was. Nothing in the repo authored one. If a null `main` should instead mean an absent `main`, that is the one line to change in `parse_card_schema_def`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_