### PR TITLE
fix(core)!: validate refuses every value the render floor refuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- fix(core)!: **`Quill::validate` refuses every value the render floor
+  refuses.** Validation judged a floor refusal by the authored value's own
+  shape, and two shapes read well-typed there: a content object that is not
+  canonical content on a `richtext` or `plaintext` field (`{prose: older}`),
+  and an integer past `i64` on an `integer` field (`18446744073709551615`).
+  Both audited clean while `compile_data` and `dry_run` refused them, so the
+  `validate`/`dry_run` pairing an editor runs on gave two verdicts. A leaf the
+  floor cannot conform is now a `validation::type_mismatch` at the field's
+  path, unless a shape check already names the refusal
+  (`validation::not_inline`, `validation::not_plain`,
+  `validation::format_violation`); a container's refusal stays the element's or
+  property's, at its own path. A numeric literal past `i64` reports `actual:
+  number`, the type that does carry it, so the mismatch hint stays true, and
+  such a literal in a `default:` or `example:` is a load error.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/core/src/quill/compose.rs
+++ b/crates/core/src/quill/compose.rs
@@ -219,11 +219,14 @@ impl Quill {
     /// warnings (`validation::must_fill`, `validation::out_of_variant`,
     /// `validation::example_unchanged`); the rest are blockers.
     ///
-    /// **A blocker here means the document does not render.** Values are judged
-    /// in the form the render floor builds from them (`conform_value` at
-    /// `Leniency::Render`), so a bare scalar for an `array`, `"3"` for an
-    /// `integer`, and a length-1 array for a `string` are valid. The leniencies
-    /// are listed under `prose/canon/SCHEMAS.md` §"Type coercion".
+    /// **A blocker here means the document does not render, and a value the
+    /// render floor refuses is a blocker here.** Values are judged in the form
+    /// the floor builds from them (`conform_value` at `Leniency::Render`), so a
+    /// bare scalar for an `array`, `"3"` for an `integer`, and a length-1 array
+    /// for a `string` are valid, while a value the floor cannot conform is a
+    /// `validation::type_mismatch` even where its authored shape reads
+    /// well-typed. The leniencies are listed under `prose/canon/SCHEMAS.md`
+    /// §"Type coercion".
     ///
     /// `validation::must_fill` has **two triggers**, covering disjoint failures
     /// under one code: a `!must_fill` marker the document carries

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -1391,12 +1391,12 @@ impl QuillConfig {
                     source_token,
                     ..
                 } => {
-                    // validation.rs uses "number" for all non-integer JSON numbers;
-                    // display as "float" so messages match the YAML author's mental model.
-                    let display_actual = if actual == "number" {
-                        "float"
-                    } else {
-                        actual.as_str()
+                    // validation.rs says "number" for every JSON number outside
+                    // `i64`: the fractional literal, which the YAML author calls
+                    // a float, and the integer past the range, which is not one.
+                    let display_actual = match actual.as_str() {
+                        "number" if source_token.contains(['.', 'e', 'E']) => "float",
+                        other => other,
                     };
                     // Show the offending value's content. A top-level mismatch
                     // renders the original literal (so arrays/objects show their

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -319,8 +319,11 @@ fn yaml_scalar_type(value: &serde_json::Value) -> &'static str {
     match value {
         serde_json::Value::Null => "null",
         serde_json::Value::Bool(_) => "boolean",
+        // An `integer` is the engine's `i64`. A numeric literal past that range
+        // is a `number`, the type that does carry it, which keeps the mismatch
+        // hint ("change the schema's `type:` to `{actual}`") true.
         serde_json::Value::Number(n) => {
-            if n.is_i64() || n.is_u64() {
+            if n.is_i64() {
                 "integer"
             } else {
                 "number"
@@ -430,10 +433,12 @@ enum ValueContext {
 ///
 /// A document value is judged in the form the render floor builds from it, not
 /// as authored: `conform_value` at `Leniency::Render` runs first. Validity is
-/// therefore renderability — `Quill::validate` cannot refuse a document
-/// `compile_data` accepts. A value the floor refuses is judged as authored,
-/// where the type check reports it. Conforming runs per node rather than per
-/// field, so one refused element does not mistype its siblings.
+/// therefore renderability, in both directions — `Quill::validate` neither
+/// refuses a document `compile_data` accepts nor passes one it refuses. A leaf
+/// the floor refuses is judged as authored, so the type check names the value
+/// the author wrote, and is refused even where that check finds the authored
+/// shape well-typed. Conforming runs per node rather than per field, so one
+/// refused element does not mistype its siblings.
 ///
 /// Schema literals are judged as written: an `example:`/`default:` is the
 /// blueprint's own text, and coercing it would let the blueprint emit a
@@ -460,15 +465,20 @@ fn validate_value(
     }
 
     let conformed = match ctx {
-        ValueContext::Document => super::QuillConfig::conform_value(
+        ValueContext::Document => Some(super::QuillConfig::conform_value(
             value,
             field,
             &path.to_string(),
             super::config::Leniency::Render,
-        )
-        .ok(),
+        )),
         ValueContext::SchemaLiteral => None,
     };
+    // A container's refusal belongs to the element or property that caused it,
+    // which the recursion below reaches at its own path; a leaf's refusal is
+    // this path's.
+    let floor_refused = matches!(conformed, Some(Err(_)))
+        && !matches!(field.r#type, FieldType::Array | FieldType::Object);
+    let conformed = conformed.and_then(Result::ok);
     let value = conformed.as_ref().unwrap_or(value);
 
     let mut errors = Vec::new();
@@ -484,10 +494,7 @@ fn validate_value(
         FieldType::RichText { .. } | FieldType::PlainText { .. } => {
             value.as_json().is_object() || value.as_str().is_some()
         }
-        FieldType::Integer => {
-            let json = value.as_json();
-            json.is_i64() || json.is_u64()
-        }
+        FieldType::Integer => value.as_json().is_i64(),
         FieldType::Number => value.as_json().is_number(),
         FieldType::Boolean => value.as_bool().is_some(),
         FieldType::Date | FieldType::DateTime => {
@@ -567,9 +574,9 @@ fn validate_value(
     // already raises TypeMismatch below, and a null/absent field blank-fills to
     // the empty content, which is both inline and plain). Mirror the
     // coercion-layer checks so a content that bypassed coercion (e.g. a direct
-    // `validate_document`) is still caught. A decode failure is not this layer's
-    // error to report: swallow it and flag only a well-formed but mis-shaped
-    // content.
+    // `validate_document`) is still caught. A decode failure names no shape:
+    // for a document it is the floor's refusal, reported below; for a schema
+    // literal it is the load-time content import's.
     if type_valid {
         match field.r#type {
             FieldType::RichText { inline: true } => {
@@ -588,8 +595,7 @@ fn validate_value(
                 // Plaintext strings are literal, not markdown, so a schema
                 // literal decodes through the literal codec; a Document value is
                 // a canonical content object. The plain constraint is primary;
-                // the single-line constraint applies only when `inline`. A decode
-                // error is another layer's to report (swallowed via `.ok()`).
+                // the single-line constraint applies only when `inline`.
                 if let Some(rt) = crate::document::Codec::Plaintext
                     .decode_value(value.as_json())
                     .and_then(Result::ok)
@@ -614,7 +620,13 @@ fn validate_value(
     let format_error_already_reported =
         matches!(field.r#type, FieldType::Date | FieldType::DateTime) && value.as_str().is_some();
 
-    if !type_valid && !format_error_already_reported {
+    // The floor refused a leaf the checks above find well-typed — a content
+    // object that is not canonical content, an integer past `i64` — and no
+    // shape check named the refusal. The mismatch is the refusal: the render
+    // door and this surface give one verdict.
+    let unnamed_refusal = floor_refused && errors.is_empty();
+
+    if (!type_valid || unnamed_refusal) && !format_error_already_reported {
         errors.push(ValidationError::TypeMismatch {
             path: path.to_string(),
             expected: field.r#type.as_str().to_string(),

--- a/crates/quillmark/tests/validate_test.rs
+++ b/crates/quillmark/tests/validate_test.rs
@@ -216,6 +216,37 @@ fn validate_refuses_what_the_render_floor_refuses() {
 }
 
 #[test]
+fn validate_refuses_a_well_shaped_value_the_floor_cannot_conform() {
+    let quill = quill_from_yaml(LENIENT);
+    // A content field rests in an object and an `integer` in an integer
+    // literal, so only the floor's conformance separates these from valid
+    // values.
+    for (field, authored) in [
+        ("prose", "prose:\n  prose: older\n"),
+        ("literal", "literal:\n  prose: older\n"),
+        ("count", "count: 18446744073709551615\n"),
+    ] {
+        let doc = lenient_doc(authored);
+        let diags = quill.validate(&doc);
+        assert!(
+            diags
+                .iter()
+                .any(|d| d.code.as_deref() == Some("validation::type_mismatch")
+                    && d.path.as_deref() == Some(&format!("main.{field}")[..])),
+            "`{authored}` should be a type_mismatch at `main.{field}`; got: {:?}",
+            diags
+                .iter()
+                .map(|d| (&d.code, &d.path))
+                .collect::<Vec<_>>()
+        );
+        assert!(
+            quill.dry_run(&doc).is_err(),
+            "`{authored}` does not render either"
+        );
+    }
+}
+
+#[test]
 fn validate_reports_a_refused_element_without_mistyping_its_siblings() {
     let quill = quill_from_yaml(
         r#"

--- a/docs/quills/quill-yaml-reference.md
+++ b/docs/quills/quill-yaml-reference.md
@@ -142,7 +142,7 @@ discharges it.
 | `enum`     | A closed set of string values; requires a `values:` list. Also accepts its [blank](#the-blank-values-is-for-choices-not-for-the-absence-of-one) (`""`), which is not a declared member. Projects to JSON-Schema `{type: string, enum: ["", …]}` |
 | `plaintext`| Navigable, **unformatted** prose over the canonical content: the same nav/regions as `richtext`, but a literal codec (delimiters stay literal, no markup). Add `inline: true` for the single-line variant |
 | `number`   | Numeric scalar (integers and decimals) |
-| `integer`  | Integer-only numeric scalar |
+| `integer`  | Integer-only numeric scalar, sized as an `i64`; a literal past that range takes `number` |
 | `boolean`  | `true` or `false` |
 | `array`    | Ordered list; requires an `items:` element schema |
 | `date`     | A strict calendar date `YYYY-MM-DD`; rejects any time component |

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -209,7 +209,8 @@ Scalar → content is the lossy direction: the stored string enters the codec's 
 **Coercion is the type predicate; validation reads its result.** `validate_value`
 conforms each document value through `conform_value` at `Leniency::Render`
 before judging it, so a type has one predicate. **A fatal `validation::*`
-diagnostic means the document does not render.**
+diagnostic means the document does not render.** The pairing holds in both
+directions: a value the floor refuses carries one.
 
 The value a document rests at is a separate question from the value the floor
 builds. `letterhead_caption: HEADQUARTERS` rests as the authored scalar and is
@@ -219,8 +220,12 @@ resting form is `Quill::conform`'s job, not validation's.
 
 Conforming runs per node, so an element the floor refuses does not mistype its
 siblings: `counts: [true, "abc"]` under `integer` items is one mismatch, at
-`counts[1]`. A value the floor refuses outright is judged as authored, where the
-type check reports it.
+`counts[1]`. A leaf the floor refuses is judged as authored, so the type check
+names the value the author wrote, and is a `type_mismatch` even where the
+authored shape reads well-typed — a content object that is not canonical
+content, an integer past `i64` — unless a shape check already names the refusal
+(`not_inline`, `not_plain`, `format_violation`). A container's refusal is the
+element's or property's, reported at that path.
 
 Validation adds the arbitration coercion cannot carry — the enum domain, the
 datetime grammar, indexed element paths, the inline/plain content shapes — over
@@ -237,7 +242,7 @@ Coercion rules per type:
 |---|---|
 | `array` | array wrapping plus element-wise coercion against the `items` schema; a bad element fails at its indexed path, e.g. `counts[1]` |
 | `boolean` | from string, int, or float |
-| `number` / `integer` | from string, or from boolean (`true→1`, `false→0`) |
+| `number` / `integer` | from string, or from boolean (`true→1`, `false→0`). An `integer` is an `i64`; a literal past that range is refused, and only `number` carries it |
 | `string` | unwraps a length-1 string array into the bare string; identity otherwise |
 | `richtext` | commits the canonical content form (the model): an authored markdown string imports via `quillmark-content::import`, an editor-supplied content object revalidates and re-canonicalizes. The length-1-array-unwrap and bare-scalar-stringify leniencies feed the import |
 | `date` / `datetime` | per-type strict-grammar validation, stored verbatim: a `date` rejects any time component, a `datetime` rejects offsets/space/fractional/bare-date. Neither truncates |


### PR DESCRIPTION
Closes #1485.

## The change

`validate_value` conformed each document value through `conform_value` at `Leniency::Render` and, on `Err`, judged the raw value by the read-side type check alone. Two shapes read well-typed there, so the refusal vanished: a content object that is not canonical content on a `richtext`/`plaintext` field (the shape pass swallowed its decode failure via `.and_then(Result::ok)`, and never ran at all for a non-inline `richtext`), and a `u64` past `i64::MAX` on an `integer` (`is_u64()` accepted what coercion rejects). Both audited clean while `compile_data` and `dry_run` refused them.

The fix takes the issue's general principle rather than only patching the shape pass, since that pass does not run for every content field: a leaf the floor cannot conform is now a `validation::type_mismatch` at its path, unless a shape check already named the refusal (`not_inline`, `not_plain`, `format_violation`). A container's refusal stays the element's or property's, reported at its own path by the per-node recursion, so nothing double-reports. The `integer` predicate drops to `is_i64()`, coercion's own.

`yaml_scalar_type` now calls a numeric literal past `i64` a `number`, not an `integer`. Without that, the new diagnostic reads "got integer `18446744073709551615`, schema declares `integer`" and hints "change the schema's `type:` to `integer`". `number` is the type that does carry the value, so the message and the hint are both true. The load-time literal message maps `number` to "float" only for a fractional token, since an out-of-range integer is not a float.

No new diagnostic code: canon (ERROR.md § warning flow, § coverage) already says a floor refusal surfaces as `validation::type_mismatch`, and `validation::coercion_failed` stays the render door's.

## Docs

- SCHEMAS.md § "Type coercion": the pairing holds in both directions; what a leaf refusal reports and where a container's goes; `integer` is an `i64`.
- `Quill::validate` rustdoc: a value the floor refuses is a blocker here.
- `docs/quills/quill-yaml-reference.md`: the `integer` row names the `i64` size.

## Verification

- `cargo test --workspace`: green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: canon spine OK.
- `cargo clippy -p quillmark-core`: 32 warnings, the same 32 as on `main`.
- New test `validate_refuses_a_well_shaped_value_the_floor_cannot_conform` pairs `validate` and `dry_run` over all three inputs. Bindings unchanged, so neither was built.

## For review

- Dropping `is_u64()` also tightens schema literals: a `default:`/`example:` past `i64` is now a load error (`quill::default_type_mismatch`). It could never render, so refusing it at load is the consistent verdict, but it is the one input class that changes outside document validation.
- A `{prose: older}` object still draws its `conform::field_decode` warning from `Quill::conform` at parse; that rides `Parsed.warnings`, a different surface from `Quill::validate`, so the two do not duplicate in one list.
- `docs/migrations/0.112-to-0.113.md` exists and is titled "Four changes"; no fifth section was added, matching the other unreleased `!` entry (MAX_YAML_DEPTH), which also left the guide to the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_