### PR TITLE
fix(core): seed a variant's cells under the world the render floor selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- fix(core): **a seeded variant commits its cells without a discriminant to
+  name their world.** `seed_card` needed the overlay or an `example:` to name a
+  member and dropped the whole field otherwise, so a `$seed` entry was honored
+  for a card's plain fields and silently discarded for its variant-bearing one.
+  The world walked is now the render floor's own selection — overlay ›
+  `example:` › `default:` › blank — and the container commits whenever a cell
+  has something to commit. `value` is written only where the overlay or an
+  `example:` named the member, so a `default:` stays deferred to the floor and
+  the container it leaves without a `value` resolves to the default's world.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -158,6 +158,12 @@ fn seed_field(field: &crate::quill::FieldSchema, overlaid: Option<&QuillValue>) 
 /// before the field set is walked — otherwise the seed commits one world's tag
 /// beside another world's answers.
 ///
+/// The world walked is `overlay › example: › default: › blank`, the render
+/// floor's own selection, so a cell lands under the member the seeded card
+/// renders. Only a member the overlay or an `example:` named is *written*: a
+/// `default:` is read-only here as everywhere, and the container it leaves
+/// without a `value` is the spelling the ladder fills.
+///
 /// Per cell the precedence is the ordinary `overlay › example: › absent`, and
 /// the `!must_fill` marker rides a committed `example` exactly as elsewhere: an
 /// example documents shape, so it is not an answer. An overlay value is exempt —
@@ -176,29 +182,27 @@ fn seed_variant(
     let overlay_member =
         crate::quill::FieldSchema::authored_member(overlay_json).and_then(|v| v.as_str());
 
-    let member = overlay_member
-        .map(str::to_string)
-        .or_else(|| {
-            field
-                .example
-                .as_ref()
-                .and_then(|e| e.as_str())
-                .map(str::to_string)
-        })?;
+    let committed_member =
+        overlay_member.or_else(|| field.example.as_ref().and_then(|e| e.as_str()));
+    let member = committed_member
+        .or_else(|| field.default.as_ref().and_then(|d| d.as_str()))
+        .unwrap_or_default();
 
     let mut map = serde_json::Map::new();
-    map.insert(
-        VARIANT_DISCRIMINANT_KEY.to_string(),
-        serde_json::Value::String(member.clone()),
-    );
     let mut fills: Vec<Vec<crate::value::PathSegment>> = Vec::new();
-    if overlay_member.is_none() && field.must_fill() {
-        fills.push(vec![crate::value::PathSegment::Key(
+    if let Some(committed) = committed_member {
+        map.insert(
             VARIANT_DISCRIMINANT_KEY.to_string(),
-        )]);
+            serde_json::Value::String(committed.to_string()),
+        );
+        if overlay_member.is_none() && field.must_fill() {
+            fills.push(vec![crate::value::PathSegment::Key(
+                VARIANT_DISCRIMINANT_KEY.to_string(),
+            )]);
+        }
     }
 
-    if let Some(fields) = field.variant_fields(&member) {
+    if let Some(fields) = field.variant_fields(member) {
         for (key, schema) in fields {
             // A cell carries any type a card field may, so it seeds through the
             // same descent.
@@ -215,6 +219,10 @@ fn seed_variant(
             }
             map.insert(key.clone(), seeded.value.into_json());
         }
+    }
+
+    if map.is_empty() {
+        return None;
     }
 
     let mut value = seeded_rest(

--- a/crates/core/src/quill/seed/tests.rs
+++ b/crates/core/src/quill/seed/tests.rs
@@ -364,6 +364,59 @@ card_kinds:
     );
 }
 
+/// `value` stays absent — a `default:` is never persisted — and the container
+/// that leaves it out is a valid card.
+#[test]
+fn a_variant_overlay_without_a_discriminant_commits_its_cells_under_the_default_world() {
+    let quill = quill_from_yaml(
+        r#"
+quill: { name: seed_test, version: 1.0.0, backend: typst, description: x }
+main:
+  fields:
+    title: { type: string, default: "" }
+card_kinds:
+  entry:
+    fields:
+      classification:
+        type: enum
+        values: [UNCLASSIFIED, CUI]
+        default: CUI
+        variants:
+          CUI:
+            note: { type: richtext }
+      other: { type: string }
+"#,
+    );
+    let overlay = overlay(json!({ "classification": { "note": "hello" }, "other": "kept" }));
+    let card = quill
+        .seed_card("entry", Some(&overlay))
+        .expect("kind exists");
+
+    let classification = card
+        .payload()
+        .get("classification")
+        .expect("an overlay cell commits without a discriminant to name its world")
+        .as_json()
+        .clone();
+    assert!(
+        classification.get("note").is_some(),
+        "the cell the overlay supplied must reach the card: {classification}"
+    );
+    assert!(
+        classification.get("value").is_none(),
+        "a `default:` discriminant stays deferred to the render floor: {classification}"
+    );
+    assert_eq!(
+        card.payload().get("other").and_then(|v| v.as_str()),
+        Some("kept"),
+        "the sibling field commits as it always did"
+    );
+
+    let doc = Document::from_main_and_cards(quill.seed_main(), vec![card]);
+    let diags = quill.validate(&doc);
+    assert!(diags.is_empty(), "a seeded card is a valid document: {diags:?}");
+}
+
 /// Null ≡ absent in an overlay cell as in any authored one: the field is simply
 /// unanswered, and the seeded card blank-fills it at render.
 #[test]

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -682,6 +682,14 @@ anything. The commit is **sparse** at every depth — only the cells with an
 `example:` is reachable at all. It otherwise would not be: the render floor never
 emits an `example`, and the blueprint is a different document.
 
+A variant container is a namespace whose cells depend on a member, so the seed
+picks one before descending: `overlay › example: › default: › blank`, the same
+selection the render floor makes, so a cell lands in the world the seeded card
+renders. Only a member the overlay or an `example:` named is *written*, the
+`default:` staying deferred as everywhere else. A container therefore commits
+cells while leaving `value` absent, which is the spelling coercion, validation
+and [`resolve()`](#the-resolved-value-view-resolve) already read off the ladder.
+
 **Seed-commits-rest.** A seeded content field commits its codec's resting form
 (a richtext field and the body the canonical content, a plaintext field its
 literal string), so a seeded document is at rest from birth: `conform` of a


### PR DESCRIPTION
Closes #1490.

## The change

`seed_variant` took the member from `overlay › example:` and returned `None` when neither named one, so a `$seed` entry carrying a variant's cells was committed for the card's plain fields and dropped for its variant-bearing one.

The world walked is now the render floor's own selection: overlay › `example:` › `default:` › blank. `value` is written only where the overlay or an `example:` named the member, so the `default:` stays deferred and the "never persist a `default`" invariant holds; the container commits whenever any cell has something to commit, and returns `None` only when nothing does. The `!must_fill` marker still rides a member an `example:` supplied, and rides nothing when no member is written.

A container carrying cells but no `value` is a valid document shape and resolves to the default's world: `conform_variant` treats a null/absent discriminant as "leave the key out so the ladder fills it", `validate_value` blank-fills the member from `default:` before checking the cells, and `resolve_variant_sourced` reads the same ladder. So committing the `default:` as the `value` instead was not needed.

An overlay cell belonging to no world under the selected member is dropped, unchanged: the seeder walks the live world's declared field set, exactly as `seed_parts` walks `schema.fields` and skips an overlay key naming no field.

## Docs

`prose/canon/SCHEMAS.md` § "Document seeding" gains the world-selection rule beside the namespace-descent paragraph it mirrors, and the rustdoc on `seed_variant` says the same.

## Verification

- `cargo test --workspace`: green. The new test `a_variant_overlay_without_a_discriminant_commits_its_cells_under_the_default_world` fails on the pre-change `seed.rs` and passes after: it seeds the issue's reproduction, asserts `classification` commits `note` with `value` absent and `other` commits `"kept"`, and asserts `quill.validate` of a document holding the seeded card is clean.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: canon spine OK.
- `cargo clippy -p quillmark-core`: no warning at `quill/seed.rs` (the tree's pre-existing warnings are elsewhere).
- Bindings not built: the change is core Rust logic the workspace tests reach.

## For review

A seed with no overlay changes too: a variant cell declaring an `example:` in the `default:` world now commits, where it was previously unreachable. That is the documented seeding contract (`example:` is the one source the render floor cannot reproduce, and the commit is sparse at every depth), so it is taken as part of the fix rather than a separate behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_