### PR TITLE
fix(core): warn when a `!must_fill` marker sits inside a `$` metadata value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- fix(core): **a `!must_fill` marker nested inside `$seed` or `$ext` warns
+  instead of vanishing.** A `$` metadata value is a plain tree with no fill
+  carrier, so a marker under one reached neither storage nor emit and the cell
+  it marked read back as `null`. Parse now emits a
+  `parse::fill_marker_unsupported_position` warning naming the cell
+  (`$seed.note.from`), the family every other unpreservable marker position
+  already draws. The value under the marker is kept, as it was; a marker on the
+  `$` key itself remains a parse error.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -7,7 +7,7 @@
 
 use crate::error::ParseError;
 use crate::value::QuillValue;
-use crate::Diagnostic;
+use crate::{Diagnostic, Severity};
 
 use super::fences::{find_metadata_blocks, RootFault};
 use super::meta::{extract_meta_items, meta_key};
@@ -190,7 +190,7 @@ pub(super) fn build_block(
         });
     }
 
-    let pre = prescan_fence_content(raw_content);
+    let mut pre = prescan_fence_content(raw_content);
 
     if let Some(err) = pre.fill_target_errors.first() {
         return Err(ParseError::InvalidStructure(err.clone()));
@@ -209,6 +209,9 @@ pub(super) fn build_block(
             }
         }
     }
+
+    pre.warnings
+        .extend(meta_rooted_fill_warnings(&pre.nested_fills));
 
     let content = pre.cleaned_yaml.trim().to_string();
     let (meta_items, yaml_value) = if content.is_empty() {
@@ -564,6 +567,30 @@ fn apply_nested_fills(
         );
     }
     Ok(())
+}
+
+/// One warning per nested `!must_fill` path rooted at a `$` metadata key. A
+/// `PayloadItem::Meta` value is a plain tree with no fill carrier, so the marker
+/// reaches neither storage nor emit; the value under it survives, as in every
+/// other unpreservable marker position.
+fn meta_rooted_fill_warnings(nested_fills: &[Vec<CommentPathSegment>]) -> Vec<Diagnostic> {
+    nested_fills
+        .iter()
+        .filter(|path| {
+            matches!(path.first(), Some(CommentPathSegment::Key(k)) if k.starts_with('$'))
+        })
+        .map(|path| {
+            Diagnostic::new(
+                Severity::Warning,
+                format!(
+                    "a `!must_fill` marker at `{}` is inside `$` system metadata and is \
+                     not preserved; system-metadata values carry no placeholder markers",
+                    render_path(path)
+                ),
+            )
+            .with_code("parse::fill_marker_unsupported_position".to_string())
+        })
+        .collect()
 }
 
 /// Render a structural path as a dotted/bracketed string for diagnostics,

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -132,6 +132,41 @@ fn unsupported_fill_position_warns_not_silently_dropped() {
     );
 }
 
+/// A `$seed` / `$ext` value carries no fill markers, so a marker nested inside
+/// one is dropped like any other unpreservable position: the warning names the
+/// cell that lost it.
+#[test]
+fn fill_marker_inside_meta_value_warns_with_its_path() {
+    let cases = [
+        (
+            "~~~card-yaml\n$quill: q\n$kind: main\n$seed:\n  note:\n    from: !must_fill\n    to: !must_fill X\n~~~\n",
+            ["$seed.note.from", "$seed.note.to"],
+        ),
+        (
+            "~~~card-yaml\n$quill: q\n$kind: main\n$ext:\n  ns:\n    from: !must_fill\n    to: !must_fill X\n~~~\n",
+            ["$ext.ns.from", "$ext.ns.to"],
+        ),
+    ];
+
+    for (src, paths) in cases {
+        let out = Document::parse(src).unwrap();
+        let named: Vec<&str> = out
+            .warnings
+            .iter()
+            .filter(|w| w.code.as_deref() == Some("parse::fill_marker_unsupported_position"))
+            .map(|w| w.message.as_str())
+            .collect();
+        for path in paths {
+            assert!(
+                named.iter().any(|m| m.contains(path)),
+                "a marker at `{}` must warn\nGot: {:?}",
+                path,
+                named
+            );
+        }
+    }
+}
+
 /// The prescan splits on `\n`, so CRLF input reaches it with a trailing `\r` on
 /// every line. Line endings carry no meaning of their own: the parse must land
 /// where the LF twin lands.

--- a/docs/authoring/card-yaml.md
+++ b/docs/authoring/card-yaml.md
@@ -190,11 +190,12 @@ It is rejected on mappings (tag the leaves, not the container). `!must_fill`
 is the only placeholder tag; every other custom YAML tag (`!include`, `!env`,
 `!fill`) is dropped with a warning and the value kept.
 
-Use **block style** for placeholders. A marker written inside a flow
-collection (`addr: {street: !must_fill}`), on a bare sequence element
-(`- !must_fill`), or under a YAML anchor/merge key is **not** preserved: the
-flow and bare-element cases emit a `parse::fill_marker_unsupported_position`
-warning so the loss is never silent.
+Use **block style** for placeholders, on a data field. A marker written inside
+a flow collection (`addr: {street: !must_fill}`), on a bare sequence element
+(`- !must_fill`), nested inside a `$` metadata value (`$seed`, `$ext`), or
+under a YAML anchor/merge key is **not** preserved. Every case but the anchor
+one emits a `parse::fill_marker_unsupported_position` warning so the loss is
+never silent.
 
 ## Card Blocks
 

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -256,11 +256,12 @@ data payload.
   `!must_fill` may be applied to scalars (string, integer, float, bool, null)
   and sequences; it is rejected on a mapping (tag the leaves, not the
   container). `!must_fill` may not be applied to a `$` metadata key. The marker
-  is preserved only in **block style**: `key: !must_fill` at any depth. A
-  marker written inside a **flow collection** (`{…}` / `[…]`) or on a **bare
-  sequence element** (`- !must_fill`) cannot be round-tripped and is reported
-  with a `parse::fill_marker_unsupported_position` warning (the value is kept,
-  the marker is not); markers under YAML **anchors/merge keys** are likewise
+  is preserved only in **block style** under a data field: `key: !must_fill` at
+  any depth. A marker written inside a **flow collection** (`{…}` / `[…]`), on a
+  **bare sequence element** (`- !must_fill`), or nested inside a **`$` metadata
+  value** (`$seed`, `$ext`) cannot be round-tripped and is reported with a
+  `parse::fill_marker_unsupported_position` warning (the value is kept, the
+  marker is not); markers under YAML **anchors/merge keys** are likewise
   not preserved. `!must_fill` is the only fill tag: every other custom tag,
   `!include`, `!env`, and the former `!fill` spelling: is dropped with a
   `parse::unsupported_yaml_tag` warning; the scalar value is kept but the tag


### PR DESCRIPTION
Closes #1483.

## The change

Premise verified against current code: `$seed:\n  note:\n    from: !must_fill` parsed with zero warnings, `seed()` read `{"note":{"from":null,"to":"X"}}`, and the marker was gone from `to_markdown()`. Prescan records the path; `build_payload` skips `$` keys before `apply_nested_fills` runs, so the path was dropped on the floor.

`build_block` now walks `pre.nested_fills` and emits one `parse::fill_marker_unsupported_position` warning per path rooted at a `$` key, naming the cell (`$seed.note.from`). The value under the marker is kept, exactly as in the flow-collection and bare-sequence-element cases.

**Severity: a warning, not the hard error.** The spec's hard error is for a marker *on* a `$` key, a category refusal, since a system key has no placeholder semantics. A marker one level in is user data whose marker the storage model cannot carry, which is precisely the unpreservable-position family; that family warns, keeps the value, and already owns this code. Reusing it costs no new code, no new `ParseError` variant, and no ERROR.md args row (the code is a prescan warning and carries no args). Making it an error would instead need a new variant to carry the code, and would refuse documents that parse clean today.

The "longer term" half of the issue (a fill carrier on `PayloadItem::Meta`) is deliberately not attempted.

## Docs

`prose/references/markdown-spec.md` §3.4 and `docs/authoring/card-yaml.md` each list the positions this code covers; both now name a marker nested inside a `$` metadata value alongside flow collections and bare sequence elements, and the block-style rule now says "under a data field". ERROR.md needed no change: it carries no row for this code (its args table covers `ParseError` variants and the arg-bearing warning families, and this code carries no args).

## Verification

- `cargo test --workspace`: green, 0 failures.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: canon spine OK.
- `cargo clippy -p quillmark-core --all-targets`: no new warnings (the three `assemble.rs` collapsible-`if` warnings are pre-existing on untouched code).
- No binding build: the change is core Rust reached by Rust tests.

## For review

The new test asserts the code plus the cell path inside the message, since the warning carries neither `args` nor `Diagnostic.path`. Setting `path` was considered (ERROR.md sanctions `$seed.<kind>.<field>` as a config-space anchor riding the `DocPath` serializer), but `$ext` lives on composable cards too, and a bare `$ext.foo` anchor is ambiguous across cards, so the path stays in the message where the flow/bare-element sibling also carries no anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_