### PR TITLE
docs(canon): state what the backend seam, quill-load errors, and the code namespaces actually are

### DIFF
--- a/docs/integration/error-handling.md
+++ b/docs/integration/error-handling.md
@@ -51,7 +51,7 @@ A multi-problem stage (validation, quill config, backend compile) reports **ever
 
 The `code` namespaces are the routing surface:
 
-`parse::*` · `validation::*` · `quill::*` · `edit::*` (mutators) · `typst::*` · `pdfform::*` · `backend::*` · `engine::*`.
+`parse::*` · `validation::*` · `quill::*` · `edit::*` (mutators) · `typst::*` · `pdfform::*` · `pdf::*` (the AcroForm stamping spine both PDF-producing backends share) · `backend::*` · `engine::*`.
 
 Notable codes: `quill::name_mismatch` / `quill::version_mismatch` (a well-formed document paired with the wrong quill; see [Versioning](../quills/versioning.md)); `engine::backend_not_found` (the quill's declared backend is not registered); `parse::input_too_large`, which carries the two byte-sized [§8 caps](../reference/markdown-spec.md#8-limits) — document size and YAML payload size — distinguished only by its `max` arg, while the count caps arrive as `parse::too_many_cards` and `parse::too_many_fields` (args `count`, `max`) and an over-deep payload as `parse::yaml_error_with_location`.
 

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -113,13 +113,13 @@ See [PLATE_DATA.md](PLATE_DATA.md) for the Typst helper package.
 
 ## Backend Implementation
 
-Backends are an in-workspace seam, not an extension point. `Backend` and
-`SessionHandle` are sealed and `#[doc(hidden)]`, outside the crate
-compatibility promise ([COMPATIBILITY.md](COMPATIBILITY.md)), so a new trait
-method lands in a minor release. The seal withholds the promise, not the
-ability: a crate willing to name the hidden module implements both and
-registers through `Quillmark::register_backend`. Nothing it writes against is
-held stable.
+Backends are an in-workspace seam, not an extension point. `Backend` is sealed
+and documented; its seal's module and `SessionHandle` are `#[doc(hidden)]`.
+Both traits sit outside the crate compatibility promise
+([COMPATIBILITY.md](COMPATIBILITY.md)), so a new trait method lands in a minor
+release. The seal withholds the promise, not the ability: a crate willing to
+name the hidden module implements both and registers through
+`Quillmark::register_backend`. Nothing it writes against is held stable.
 
 A quill declares one backend and renders through that one. Rendering a schema
 two ways is therefore two quills, with nothing keeping their field definitions

--- a/prose/canon/COMPATIBILITY.md
+++ b/prose/canon/COMPATIBILITY.md
@@ -24,7 +24,7 @@ own rustdoc:
 
 | Seam | Why it is exempt |
 |---|---|
-| `Backend` + `SessionHandle` | Sealed and `#[doc(hidden)]`; an out-of-workspace backend writes against items this crate does not hold stable. |
+| `Backend` + `SessionHandle` | Sealed, with the seal's module and `SessionHandle` `#[doc(hidden)]`; an out-of-workspace backend writes against items this crate does not hold stable. |
 | `quillmark_typst::emit` | `pub` only so `quillmark-fuzz` can drive the escapers directly. |
 
 Deleting a row promises the seam. Publishing a contract later is additive and

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -22,7 +22,7 @@ severity.
 
 **`Diagnostic`**: severity, optional error `code`, `message`, optional `location` (text anchor: file/line/column), optional `path` (document-model anchor, dotted/bracketed path into the typed `Document`, set by schema validation/coercion), optional `hint`, `source_chain` (omitted from serialization when empty). `location` and `path` are independent and may co-exist.
 
-**`ParseError`**: parsing-stage error enum, `InputTooLarge`, `TooManyFields`, `TooManyCards`, `InvalidStructure`, `EmptyInput`, `MissingQuill`, `InvalidQuillReference`, `YamlErrorWithLocation`; converts to `Diagnostic` via `to_diagnostic()`. The `InvalidQuillReference` case (`parse::invalid_quill_reference`) attaches the canonical `$quill` grammar (`quill_ref_hint()`) as the diagnostic hint. That hint is the single source of truth for the reference grammar: bindings surface it verbatim (e.g. WASM `Document.quillRefHint`) rather than re-stating the rule.
+**`ParseError`**: parsing-stage error enum, `InputTooLarge`, `TooManyFields`, `TooManyCards`, `InvalidStructure`, `EmptyInput`, `MissingQuill`, `InvalidQuillReference`, `BodyImport`, `YamlErrorWithLocation`; converts to `Diagnostic` via `to_diagnostic()`. The `InvalidQuillReference` case (`parse::invalid_quill_reference`) attaches the canonical `$quill` grammar (`quill_ref_hint()`) as the diagnostic hint. That hint is the single source of truth for the reference grammar: bindings surface it verbatim (e.g. WASM `Document.quillRefHint`) rather than re-stating the rule.
 
 **`YamlError`**: the one adapter every `serde-saphyr` error passes through. Sanitizes the message (the engine appends its own Rust API names (`from_multiple`, `DuplicateKeyPolicy`) which `yaml_hints::enrich_yaml_error` strips), derives the hint, and carries the 1-indexed line/column the engine located; `to_diagnostic(code, file)` renders all three. The emit side has no input to point at, so it carries neither position nor hint.
 
@@ -43,8 +43,8 @@ for the one-error-diagnostic case every engine-side refusal takes;
 `into_diagnostics()` consumes). There is no failure taxonomy beyond the
 diagnostics themselves: the machine-routable identity of a failure is each
 diagnostic's namespaced `code` (`parse::*`, `validation::*`, `quill::*`,
-`edit::*`, `typst::*`, `pdfform::*`, `backend::*`, `engine::*`): consumers
-route on codes, not on a type. Multi-problem stages (validation, quill config, backend
+`edit::*`, `typst::*`, `pdfform::*`, `pdf::*`, `backend::*`, `engine::*`):
+consumers route on codes, not on a type. Multi-problem stages (validation, quill config, backend
 compilation) carry several diagnostics so every problem reaches the caller in
 one pass. `Display` follows the count-based message rule shared with both
 bindings: the primary diagnostic's message for a single diagnostic, an
@@ -58,6 +58,11 @@ for a backend session that does not override the incremental-`update` seam
 requested format is outside the backend's `supported_formats`, one code on
 every backend so a caller matches the condition once;
 `engine::backend_not_found`: the quill's declared backend is not registered.
+
+`pdf::*` is the AcroForm stamping spine's own namespace (`pdf::parse`,
+`pdf::write`, `pdf::rotated_page`, `pdf::bad_rect`, …): `quillmark-pdf` carries
+the code on its `PdfError` and the `From` impl forwards it intact into a
+`RenderError`, so a spine refusal routes the same whichever backend drove it.
 
 **`edit::*`: mutator diagnostics.** Document and card mutators fail with the
 `EditError` enum (`crates/core/src/document/edit.rs`), one namespaced code per

--- a/prose/canon/VERSIONING.md
+++ b/prose/canon/VERSIONING.md
@@ -53,11 +53,12 @@ A quill mismatch is distinct from a validation failure (a malformed document): h
 
 Three distinct failure paths, and the parser owns one of them outright:
 
-- **`Quill.yaml` version invalid** → `quill::invalid_version` → surfaces as
-  `RenderError::QuillConfig` at Quill load.
+- **`Quill.yaml` version invalid** → a `quill::invalid_version` diagnostic from
+  Quill load: `Quill::from_tree` returns it in its `Vec<Diagnostic>`,
+  `quill_from_path` in the `RenderError` wrapping that vector.
 - **Document `$quill` reference invalid** (e.g. `my_format@bad`) →
-  `ParseError::InvalidQuillReference`, returned directly by the parser, never as
-  `RenderError::QuillConfig`.
+  `ParseError::InvalidQuillReference` (`parse::invalid_quill_reference`),
+  returned directly by the parser, never through Quill load.
 - **Loaded Quill does not satisfy a well-formed `$quill`** → the two mismatch
   codes above, as a `RenderError` from `render`/`dry_run`.
 


### PR DESCRIPTION
Closes #1522.

## The change

Docs only; four of the issue's five rows are canon corrections, the fifth belongs to another branch.

Row 1: `Backend` is not `#[doc(hidden)]`. Only `mod sealed` (`crates/core/src/backend.rs`) and `SessionHandle` (`crates/core/src/session.rs`) carry the attribute, and `Backend` is root-re-exported from `crates/core/src/lib.rs` and named in the crate-doc headline. The exemption row in COMPATIBILITY.md and the "Backend Implementation" paragraph in ARCHITECTURE.md now say sealed and documented, with the seal's module and `SessionHandle` hidden, both traits outside the compatibility promise. No attribute added: hiding a documented headline seam is the larger break.

Row 2: `RenderError` is a variant-less struct (`crates/core/src/error.rs`), so VERSIONING.md's "Error Handling" bullets name diagnostics: `quill::invalid_version` (`crates/core/src/quill/config.rs`) from Quill load, where `Quill::from_tree` returns a `Vec<Diagnostic>` and `quill_from_path` wraps the same vector in a `RenderError`; and `ParseError::InvalidQuillReference` / `parse::invalid_quill_reference` returned directly by the parser.

Row 3: ERROR.md's `ParseError` list gains `BodyImport`, in the enum's own order. Not on `origin/main` at branch time; PR #1593 makes the same one-word addition, and the two merge cleanly or trivially.

Row 4: the routing-namespace list gains `pdf::*`, with a short paragraph naming it the AcroForm stamping spine's namespace (`pdf::parse`, `pdf::write`, `pdf::rotated_page`, `pdf::bad_rect`). `PdfError` carries the code and `From<PdfError> for RenderError` forwards it intact, so it reaches a consumer through either PDF-producing backend. `pdf::flatten_parse` is deliberately not listed: pdfform's flatten codes move to `pdfform::*` on a separate branch.

## Docs

`docs/integration/error-handling.md` carries the same namespace list for integrators; `pdf::*` added there too. `docs/migrations/` mentions of the seal are era-stamped and already accurate, so untouched.

## Verification

`cargo test --workspace` green. `node scripts/check-canon.mjs`: canon spine OK. No changelog entry: docs only, no observable contract shift.

## For review

Row 5 (QUILL.md's claim that a card kind's malformed `body` errors with `quill::invalid_body`) is left alone: PR #1595 routes card-kind `body`/`ui` through `parse_section`, which makes the sentence true. `config.rs` untouched here.

`RenderError`'s own rustdoc carries an abbreviated namespace sample that already omitted `edit::*` and `pdfform::*` before this issue; left as illustrative, with ERROR.md as the canonical list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_