### PR TITLE
fix(typst): lower every character Typst reads as a newline to a space

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- fix(content): **VT, FF and NEL in document text become a space.** Typst's
+  lexer reads all three as line breaks, like the U+2028/U+2029 separators the
+  ingress already spaced, so one mid-paragraph reopens `at_start` and the
+  characters behind it are read as a block marker — `"intro\u{c}- item"`
+  rendered a bullet — and two in a row split the paragraph. The spaced set is
+  Typst's whole newline set less `\n`, named by
+  `normalize::is_line_separator`, refused by `validate`, and replaced at every
+  text ingress: `from_plaintext`, markdown import, an `Op::Insert` through
+  `apply_text_delta`, and a table cell's text. Markdown-spec §7 states it.
+- fix(typst): **`escape_markup` lowers every character Typst reads as a newline
+  to a space.** A content that reached the emitter without passing the ingress
+  — hand-built, or decoded from storage — could still carry `\r`, VT, FF, NEL,
+  U+2028 or U+2029, and the emitter wrote it through: the text behind it parsed
+  as a heading, list or term marker the document never wrote. One character to
+  one byte, so the per-character span scan stays exact, and the space is trivia
+  to the line-anchor guard, which lands on the marker behind it.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/backends/typst/src/emit.rs
+++ b/crates/backends/typst/src/emit.rs
@@ -46,7 +46,16 @@
 use quillmark_core::error::MAX_NESTING_DEPTH;
 use quillmark_content::island::KnownIslandType;
 use quillmark_content::model::{Container, LineKind, Mark, MarkKind, Content, Normalized, ISLAND_SLOT};
+use quillmark_content::normalize::is_line_separator;
 use std::ops::Range;
+
+/// Does Typst's lexer read `c` as a newline where the emitter writes document
+/// text? Every character of its `is_newline` set but `\n`, which the emitter
+/// writes itself as a line boundary. `Content::validate` rejects all of them, so
+/// one reaches here only from a content the ingress never made.
+fn reads_as_newline(c: char) -> bool {
+    c == '\r' || is_line_separator(c)
+}
 
 /// Neutralizes every markup-special character, so document text cannot inject
 /// markup, references (`@`), or comments (`//`).
@@ -60,6 +69,12 @@ use std::ops::Range;
 /// nothing, so escaping every `-` before a number takes one more than the page
 /// needs. Reading far enough to tell would tie this function to a tokenization
 /// the lexer owns.
+///
+/// Every character Typst reads as a newline but `\n` lowers to a space, the
+/// content ingress's own rule. No escape neutralizes one — a `\` before
+/// whitespace is Typst's linebreak — and each reopens `at_start`, so the text
+/// behind it would parse as a heading, list or term marker. The space it becomes
+/// is trivia to the emitter, which holds the line-anchor guard open behind it.
 ///
 /// `'` and `"` pass through. Smart quotes are an element with a set rule, so a
 /// quill chooses with `#set smartquote(enabled: false)`; escaping them here
@@ -82,6 +97,9 @@ pub fn escape_markup(s: &str) -> String {
                 out.push_str(r"\-")
             }
             '.' if rest.starts_with("..") => out.push_str(r"\."),
+            // One char to one byte, which `gen_cluster` reads back as a plain
+            // cluster.
+            c if reads_as_newline(c) => out.push(' '),
             '\\' | '~' | '*' | '_' | '`' | '#' | '[' | ']' | '{' | '}' | '$' | '<' | '>' | '@' => {
                 out.push('\\');
                 out.push(c);
@@ -932,10 +950,11 @@ fn wraps_and_codes(marks: &[Mark], lo: usize, hi: usize) -> (Vec<Wrap>, Vec<(usi
 /// line-anchor one and [`continues_expr`]'s — whose byte sits *outside* the
 /// run's window so `generated == escape_markup(content)` stays exact.
 ///
-/// Under [`Tail::Anchor`] a run opening with spaces or tabs stops at the first
-/// character that is neither: Typst reads them as trivia and holds the anchor
-/// open behind them, while `\` before a space is its linebreak rather than an
-/// escape, so the guard byte has to land on the marker itself.
+/// Under [`Tail::Anchor`] a run opening with trivia — spaces, tabs, and the
+/// [`reads_as_newline`] characters [`escape_markup`] lowers to a space — stops
+/// at the first character that is none of them: Typst reads trivia as holding
+/// the anchor open behind it, while `\` before a space is its linebreak rather
+/// than an escape, so the guard byte has to land on the marker itself.
 fn emit_run(
     out: &mut String,
     pos: usize,
@@ -955,7 +974,7 @@ fn emit_run(
         return (ce, Tail::Expr, (cs..ce, g0..g1, EscapeCtx::StringLit));
     }
     let mut re = next_boundary(pos, hi, chars, wraps, codes);
-    let trivia = |c: char| c == ' ' || c == '\t';
+    let trivia = |c: char| c == ' ' || c == '\t' || reads_as_newline(c);
     if tail == Tail::Anchor && trivia(chars[pos]) {
         re = (pos..re).find(|&p| !trivia(chars[p])).unwrap_or(re);
     }
@@ -1480,6 +1499,7 @@ mod tests {
             "-5 degrees",
             "a-b and a - b",
             "\"double\" and 'single'",
+            "a\u{000B}b\u{000C}c\u{0085}d\u{2028}e\u{2029}f",
         ];
         for s in samples {
             assert_eq!(
@@ -1520,13 +1540,20 @@ mod tests {
         (text, kinds)
     }
 
+    /// What escaped document text may lower to. `SmartQuote` is allowed by
+    /// policy: `'` and `"` stay authored so a quill picks its own typography.
+    const ALLOWED_LEAVES: &[SyntaxKind] = &[
+        SyntaxKind::Text,
+        SyntaxKind::Space,
+        SyntaxKind::Parbreak,
+        SyntaxKind::Escape,
+        SyntaxKind::SmartQuote,
+    ];
+
     /// Escaped text reaches the page as the characters the document holds, read
     /// back through Typst's own parser. The `x` prefix puts the fragment past
     /// `at_start`, whose markers are [`emit_run`]'s guard rather than
     /// [`escape_markup`]'s.
-    ///
-    /// `SmartQuote` is allowed by policy: `'` and `"` stay authored so a quill
-    /// picks its own typography.
     #[test]
     fn escaped_markup_resolves_to_the_authored_text() {
         let samples = [
@@ -1545,18 +1572,42 @@ mod tests {
             "trailing backslash \\",
             "-", "--", "---", "...", "//", "-?", "-1",
         ];
-        let allowed = [
-            SyntaxKind::Text,
-            SyntaxKind::Space,
-            SyntaxKind::Parbreak,
-            SyntaxKind::Escape,
-            SyntaxKind::SmartQuote,
-        ];
         for s in samples {
             let (text, kinds) = resolve(&format!("x{}", escape_markup(s)));
             assert_eq!(text, format!("x{s}"), "escaping {s:?} did not survive Typst");
             for k in kinds {
-                assert!(allowed.contains(&k), "{s:?} lowered to a {k:?} leaf");
+                assert!(ALLOWED_LEAVES.contains(&k), "{s:?} lowered to a {k:?} leaf");
+            }
+        }
+    }
+
+    /// The emitter lowers exactly Typst's own newline set, less the `\n` it
+    /// writes as a line boundary, so a Typst upgrade that widens the set fails
+    /// here rather than in a rendered document.
+    #[test]
+    fn the_lowered_set_is_typsts_newlines_less_lf() {
+        for c in ('\0'..=char::MAX).filter(|c| *c != '\n') {
+            assert_eq!(reads_as_newline(c), typst::syntax::is_newline(c), "{c:?}");
+        }
+    }
+
+    /// A character Typst reads as a newline lowers to a space, so the text
+    /// behind it stays prose instead of opening a heading, list or term marker,
+    /// and a pair of them does not split the paragraph. Such a character reaches
+    /// the emitter only from a content the ingress never made — hand-built, or
+    /// decoded from storage — so the content is built here rather than imported.
+    #[test]
+    fn a_stray_newline_lowers_to_a_space_and_opens_no_block() {
+        use quillmark_content::model::Line;
+        for c in ('\0'..=char::MAX).filter(|c| *c != '\n' && reads_as_newline(*c)) {
+            let text = format!("{c}- item{c}{c}tail{c}= not a heading");
+            let rt = Content::new(text, vec![Line::new(LineKind::Para)]).into_normalized();
+            assert!(rt.validate().is_err(), "{c:?} passes the content invariants");
+
+            let markup = emit_content(&rt).unwrap().markup;
+            assert_eq!(markup, " \\- item  tail = not a heading\n\n", "for {c:?}");
+            for k in resolve(&markup).1 {
+                assert!(ALLOWED_LEAVES.contains(&k), "{c:?} lowered to a {k:?} leaf");
             }
         }
     }
@@ -1713,6 +1764,7 @@ mod tests {
             (EscapeCtx::Markup, "3--5"),
             (EscapeCtx::Markup, "wait..."),
             (EscapeCtx::Markup, "-5 and -?x"),
+            (EscapeCtx::Markup, "a\u{0085}b\u{2028}c"),
             (EscapeCtx::StringLit, "fn add(a, b)"),
             (EscapeCtx::StringLit, "a\"b\\c"),
             (EscapeCtx::StringLit, "tab\there"),

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -349,8 +349,8 @@ export interface CardAddr {
  * position through it with `mapPos`.
  *
  * Applying one admits an `insert` string rather than storing it verbatim: `\r`
- * and the Unicode bidi controls drop, and a U+2028 or U+2029 line separator
- * becomes a space. Nothing reports the substitution.
+ * and the Unicode bidi controls drop, and a line separator — VT, FF, NEL,
+ * U+2028, U+2029 — becomes a space. Nothing reports the substitution.
  */
 export interface Delta {
     ops: ({ retain: number } | { insert: string } | { delete: number })[];

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -1,7 +1,7 @@
 //! Markdown import (cold): `normalize → pulldown → content`.
 //!
 //! Input is normalized by [`crate::normalize::normalize_markdown`] (CRLF→LF,
-//! bidi controls dropped, U+2028/U+2029 spaced, HTML comment-fence repair) so
+//! bidi controls dropped, line separators spaced, HTML comment-fence repair) so
 //! the content invariants hold by construction, then parsed with
 //! `pulldown_cmark` (CommonMark + strikethrough + pipe tables) and walked into
 //! a [`Content`]. This is the one place the `<u>` allowlist runs.
@@ -78,7 +78,8 @@ pub fn from_markdown(markdown: &str) -> Result<Normalized, ImportError> {
 /// [`from_markdown`]. Every character is content, never syntax: `*hi*` is four
 /// literal chars, not emphasis. With [`crate::export::to_plaintext`] it pins the
 /// fixed point `to_plaintext(from_plaintext(s)) == s` for any `s` free of `\r`,
-/// bidi controls, U+2028/U+2029 line separators, and [`ISLAND_SLOT`].
+/// bidi controls, line separators (VT, FF, NEL, U+2028, U+2029), and
+/// [`ISLAND_SLOT`].
 ///
 /// Line structure is **derived, not stored**: a lone `\n` between two non-empty
 /// segments is a within-paragraph break ([`Line::continues`] `true`); a blank
@@ -947,17 +948,17 @@ mod tests {
 
     #[test]
     fn line_separators_are_spaced_at_every_text_ingress() {
-        for sep in ['\u{2028}', '\u{2029}'] {
+        for sep in ['\u{000B}', '\u{000C}', '\u{0085}', '\u{2028}', '\u{2029}'] {
             let src = format!("intro{sep}- item");
             assert_eq!(imp_plain(&src).text, "intro - item", "plaintext {sep:?}");
             assert_eq!(imp(&src).text, "intro - item", "markdown {sep:?}");
-        }
 
-        let held = Content::new("intro\u{2028}- item".into(), vec![Line::new(LineKind::Para)]);
-        assert_eq!(
-            held.validate(),
-            Err(crate::model::Invariant::LineSeparator('\u{2028}'))
-        );
+            let held = Content::new(src, vec![Line::new(LineKind::Para)]);
+            assert_eq!(
+                held.validate(),
+                Err(crate::model::Invariant::LineSeparator(sep))
+            );
+        }
     }
 
     #[test]

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -25,9 +25,9 @@ pub const ISLAND_SLOT: char = '\u{FFFC}';
 ///
 /// Invariants (established once by import normalization, checked by
 /// [`Content::validate`]): the text holds no `\r`, no bidi controls, and no
-/// U+2028/U+2029 line separators; the count of [`ISLAND_SLOT`] equals
-/// `islands.len()`; `lines.len()` equals the number of `\n`-separated segments;
-/// marks are normalized (sorted, unioned).
+/// line separator (every character Typst reads as a newline but `\n`); the count
+/// of [`ISLAND_SLOT`] equals `islands.len()`; `lines.len()` equals the number of
+/// `\n`-separated segments; marks are normalized (sorted, unioned).
 #[derive(Debug, Clone, PartialEq)]
 #[non_exhaustive]
 pub struct Content {
@@ -796,8 +796,8 @@ pub enum Invariant {
     CarriageReturn,
     /// A bidi formatting control in the text.
     BidiControl(char),
-    /// A U+2028/U+2029 line separator in the text, which a downstream lexer
-    /// reads as a line break.
+    /// A line separator in the text — VT, FF, NEL, U+2028 or U+2029 — which a
+    /// downstream lexer reads as a line break.
     LineSeparator(char),
     /// `island_slot_count != islands.len()`.
     IslandSlotMismatch { slots: usize, islands: usize },

--- a/crates/content/src/normalize.rs
+++ b/crates/content/src/normalize.rs
@@ -22,12 +22,20 @@ pub(crate) fn is_bidi_char(c: char) -> bool {
     )
 }
 
-/// U+2028 LINE SEPARATOR and U+2029 PARAGRAPH SEPARATOR, which Typst's lexer
-/// reads as line breaks: one mid-paragraph reopens `at_start`, so what follows
-/// it is read as a block marker the author never wrote.
+/// Every character Typst's lexer reads as a line break (`is_newline`) besides
+/// `\n` and `\r`: one mid-paragraph reopens `at_start`, so what follows it is
+/// read as a block marker the author never wrote, and two in a row are a
+/// paragraph break.
 #[inline]
-pub(crate) fn is_line_separator(c: char) -> bool {
-    matches!(c, '\u{2028}' | '\u{2029}')
+pub fn is_line_separator(c: char) -> bool {
+    matches!(
+        c,
+        '\u{000B}' // LINE TABULATION (VT)
+        | '\u{000C}' // FORM FEED (FF)
+        | '\u{0085}' // NEXT LINE (NEL)
+        | '\u{2028}' // LINE SEPARATOR
+        | '\u{2029}' // PARAGRAPH SEPARATOR
+    )
 }
 
 /// What the content admits `c` as, `None` dropping it. A `\r` is dropped
@@ -134,7 +142,7 @@ fn fix_html_comment_fences(s: &str) -> String {
 }
 
 /// Applies all markdown normalizations in order: CRLF → LF, bidi controls
-/// dropped and U+2028/U+2029 spaced, HTML comment fence repair.
+/// dropped and line separators spaced, HTML comment fence repair.
 pub fn normalize_markdown(markdown: &str) -> String {
     let cleaned = normalize_line_endings(markdown);
     let cleaned = admit_chars(&cleaned);
@@ -175,6 +183,10 @@ mod tests {
             ("**bold** text", "**bold** text"),
             ("intro\u{2028}- item", "intro - item"),
             ("intro\u{2029}= Heading", "intro = Heading"),
+            ("intro\u{000B}- item", "intro - item"),
+            ("intro\u{000C}- item", "intro - item"),
+            ("intro\u{0085}= Heading", "intro = Heading"),
+            ("- one\u{000C}\u{000C}two", "- one  two"),
             ("he\u{202D}llo", "hello"),
             ("**asdf** or \u{202D}**(1234**", "**asdf** or **(1234**"),
             ("a\u{200E}b\u{200F}c", "abc"),

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -410,8 +410,8 @@ impl Content {
     /// *inserts* a raw slot is rejected ([`ApplyError::IslandSlotInInsert`]).
     ///
     /// Inserted text is sanitized first, mirroring what `import` applies at the
-    /// string boundary: `\r` and Unicode bidi controls are stripped, and a
-    /// U+2028/U+2029 line separator becomes a space — the chars
+    /// string boundary: `\r` and Unicode bidi controls are stripped, and a line
+    /// separator (VT, FF, NEL, U+2028, U+2029) becomes a space — the chars
     /// [`Content::validate`] forbids.
     pub fn apply_text_delta(&mut self, delta: &Delta) -> Result<(), ApplyError> {
         self.apply_text_delta_inner(delta)?;
@@ -1810,14 +1810,16 @@ mod tests {
     fn insert_line_separator_is_spaced() {
         // A space keeps the words apart without minting the line break Typst
         // would read, and which would make `- item` a bullet.
-        let mut rt = from_markdown("ab").unwrap();
-        let d = Delta {
-            ops: vec![Op::Retain(2), Op::Insert("\u{2028}- item".into())],
-        };
-        rt.apply_text_delta(&d).unwrap();
-        assert_eq!(rt.text, "ab - item");
-        assert_eq!(rt.lines.len(), 1);
-        assert_eq!(rt.validate(), Ok(()));
+        for sep in ['\u{000B}', '\u{000C}', '\u{0085}', '\u{2028}', '\u{2029}'] {
+            let mut rt = from_markdown("ab").unwrap();
+            let d = Delta {
+                ops: vec![Op::Retain(2), Op::Insert(format!("{sep}- item"))],
+            };
+            rt.apply_text_delta(&d).unwrap();
+            assert_eq!(rt.text, "ab - item", "for {sep:?}");
+            assert_eq!(rt.lines.len(), 1);
+            assert_eq!(rt.validate(), Ok(()));
+        }
     }
 
     #[test]

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -813,9 +813,11 @@ fn pad_row(v: &mut Value, cols: usize) {
     }
 }
 
-/// Every char a downstream lexer reads as a line break, the U+2028/U+2029
-/// separators included. A cell is one line.
-const CELL_BREAKS: &[char] = &['\n', '\r', '\u{2028}', '\u{2029}'];
+/// Every char a downstream lexer reads as a line break, the separators
+/// [`crate::normalize::is_line_separator`] names included. A cell is one line.
+fn is_cell_break(c: char) -> bool {
+    c == '\n' || c == '\r' || crate::normalize::is_line_separator(c)
+}
 
 /// De-newline a cell's text (each line break → a space, 1:1 so mark offsets
 /// hold) and re-normalize its marks. Writes back into the cell's **own** object
@@ -823,8 +825,8 @@ const CELL_BREAKS: &[char] = &['\n', '\r', '\u{2028}', '\u{2029}'];
 /// survives.
 fn canon_cell(cell: &mut Value) {
     let (text, marks) = parse_cell(cell);
-    let text = if text.contains(CELL_BREAKS) {
-        text.replace(CELL_BREAKS, " ")
+    let text = if text.contains(is_cell_break) {
+        text.replace(is_cell_break, " ")
     } else {
         text
     };
@@ -875,7 +877,7 @@ pub(crate) fn table_shape_error(props: &Value) -> Option<Invariant> {
     }
     for (i, cell) in table_cell_values(props).enumerate() {
         let text = cell.get("text").and_then(Value::as_str).unwrap_or_default();
-        if text.contains(CELL_BREAKS) {
+        if text.contains(is_cell_break) {
             return Some(Invariant::TableCellNewline { cell: i });
         }
     }

--- a/crates/fuzz/src/convert_fuzz.rs
+++ b/crates/fuzz/src/convert_fuzz.rs
@@ -30,11 +30,11 @@ const ALLOWED_LEAVES: &[SyntaxKind] = &[
 
 /// A `--`, a `...`, or a separator ahead of a block marker never lands by
 /// chance in a draw over all of Unicode. The second alphabet is what does land
-/// one: Typst's special characters, the U+2028/U+2029 separators it reads as
-/// line breaks, and the markers and space that open a block behind one.
+/// one: Typst's special characters, every separator it reads as a line break,
+/// and the markers and space that open a block behind one.
 fn escaper_input() -> impl Strategy<Value = String> {
     prop_oneof![
-        r#"[-.?/~*_#+=\[\]{}$<>@'"0-9a-c \\`\x{2028}\x{2029}]{0,40}"#,
+        r#"[-.?/~*_#+=\[\]{}$<>@'"0-9a-c \\`\x{0B}\x{0C}\x{85}\x{2028}\x{2029}]{0,40}"#,
         "\\PC*",
     ]
 }
@@ -96,10 +96,9 @@ proptest! {
     #[test]
     fn fuzz_escape_markup_survives_the_typst_parser(s in escaper_input()) {
         // The escaper answers for the text a content holds, so the draw enters
-        // through the content ingress, which spaces the U+2028/U+2029
-        // separators: Typst reads one as a line break that reopens `at_start`,
-        // and no escape neutralizes it (a `\` before whitespace is its own
-        // linebreak).
+        // through the content ingress, which spaces every separator: Typst
+        // reads one as a line break that reopens `at_start`, and no escape
+        // neutralizes it (a `\` before whitespace is its own linebreak).
         let s = to_plaintext(&from_plaintext(&s));
         // Past `at_start`, whose markers are the emitter's guard, not the escaper's.
         let (text, kinds) = resolve(&format!("x{}", escape_markup(&s)));

--- a/prose/canon/CONVERT.md
+++ b/prose/canon/CONVERT.md
@@ -51,6 +51,15 @@ Two escapers guard the two Typst contexts; both live in `emit`:
   shorthand leaves behind is too short to re-form it. Applied to plain text runs
   and to a table cell's text.
 
+  **Stray newlines lower to a space.** Every character Typst's lexer reads as a
+  newline besides `\n` — `\r`, VT, FF, NEL, U+2028, U+2029 — becomes a space.
+  The content ingress drops or spaces all six, so one reaches the emitter only
+  from a content built or decoded some other way. No escape neutralizes one: a
+  `\` before whitespace is Typst's linebreak. One reopens `at_start`, so the
+  text behind it parses as a heading, list or term marker; two in a row split
+  the paragraph. One character to one byte, so the per-character span scan
+  stays exact, and the space is trivia the line-anchor guard holds open behind.
+
   **Smart quotes are the quill's.** `'` and `"` pass through, so Typst's
   language-aware substitution applies and a quill chooses with
   `#set smartquote(enabled: false)`. Escaping them here would settle that for

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -428,11 +428,13 @@ Before CommonMark parsing, each body region is normalized:
 2. **Bidi control stripping.** Remove U+061C, U+200E, U+200F,
    U+202A–U+202E, U+2066–U+2069. These invisible characters can
    desynchronize delimiter runs when copy-pasted from bidi-aware sources.
-3. **Line-separator spacing.** Replace U+2028 (LINE SEPARATOR) and U+2029
-   (PARAGRAPH SEPARATOR) with a single U+0020 space. CommonMark reads
-   neither as a line ending, but a backend lexer may, in which case the
-   text after one is read as a block marker the author never wrote. Both
-   are Unicode whitespace, so a space keeps the words they part apart.
+3. **Line-separator spacing.** Replace U+000B (LINE TABULATION), U+000C
+   (FORM FEED), U+0085 (NEXT LINE), U+2028 (LINE SEPARATOR) and U+2029
+   (PARAGRAPH SEPARATOR) with a single U+0020 space. CommonMark reads none
+   of them as a line ending, but a backend lexer may, in which case the
+   text after one is read as a block marker the author never wrote and two
+   in a row split the paragraph. All five are Unicode whitespace, so a
+   space keeps the words they part apart.
 4. **HTML comment fence repair.** If `-->` is followed by non-whitespace
    text on the same line, insert a newline after `-->` so the trailing
    text reaches the paragraph parser instead of being consumed by the


### PR DESCRIPTION
Closes #1519.

## The change

Verified the issue's premise first: `from_markdown("intro\u{c}- item")` emitted `"intro\u{c}- item\n\n"`, which `typst::syntax::parse` read as `[Text, Space, ListItem, Parbreak]`; identical for VT and NEL, and `from_plaintext("intro\u{c}= heading")` validated `Ok`.

Both halves the issue proposes, plus two the code showed were needed:

- **Ingress.** `normalize::is_line_separator` now names Typst's whole `is_newline` set less `\n` and `\r`: VT, FF, NEL, U+2028, U+2029. It drives `admit_char` (so markdown import, `from_plaintext`, and `apply_text_delta`'s insert sanitizer all space them), the `Invariant::LineSeparator` check, and `serial`'s table-cell de-newlining, which promised "every char a downstream lexer reads as a line break" and under-delivered. The predicate is now `pub` so the emitter shares it rather than minting a parallel list.
- **Emitter.** `escape_markup` maps that set *plus `\r`* to a space. `\r` sits in exactly the same position (a validate-rejected character a hand-built or decoded content can still hold), so leaving it out would be an inconsistency.
- **Not in the issue, but required:** mapping to a space alone reintroduces the bug at a line anchor. A content opening `"\u{c}- item"` would emit `" - item"`, and Typst reads the leading space as trivia holding `at_start` open, so `- ` is still a list marker. `emit_run`'s trivia set (previously space and tab) now includes these characters, so the run splits and the `\` guard lands on the marker.

## Docs

`prose/references/markdown-spec.md` §7.3 (the normative ingress rule) states the widened set; `prose/canon/CONVERT.md` gains the emitter's rule under `escape_markup`. Doc comments on `Content`, `Invariant::LineSeparator`, `from_plaintext`'s fixed point, `apply_text_delta`, and the WASM `Delta` TS declaration follow.

## Verification

- `cargo test --workspace`: green. New: `the_lowered_set_is_typsts_newlines_less_lf` (scans all of Unicode against `typst::syntax::is_newline`, so a Typst upgrade that widens the set fails here), `a_stray_newline_lowers_to_a_space_and_opens_no_block` (hand-built content, asserts the markup and that no leaf is a block marker). Extended: the `escape_tripwire_markup` and `run_offset_inversion_is_cluster_exact` samples (the `gen_cluster` 1-char/1-byte invariant), the normalize table, `line_separators_are_spaced_at_every_text_ingress`, `insert_line_separator_is_spaced`, and `convert_fuzz.rs::escaper_input`.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: OK.
- `cargo clippy` on the three changed crates: 38 warnings, same count as `origin/main`.
- No binding build: the only binding change is a TypeScript doc comment, which the workspace build already compiles.

## For review

The edit lane is covered: `apply_text_delta` sanitizes inserts through the same `admit_char`, tested for all five characters. A content can still hold one after `Card::overwrite_body`, which takes the `Normalized` token without validating; `normalize` repairs none of these (matching the existing `\r`/bidi/U+2028 shape), so the emitter's mapping is that lane's guard, which is what the new emitter test models.

No `!` marker: `validate` now refuses text it accepted, but this follows the precedent of the U+2028/U+2029 entry, logged as a plain `fix(content)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_