### PR TITLE
fix(typst,pdfform)!: refuse a raster no backend can allocate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- fix(typst,pdfform)!: **a raster nobody can allocate is refused, not
+  attempted.** `RenderOptions.ppi` and the `render_rgba` canvas scale reached
+  tiny-skia and hayro unchecked; both size their buffer from the value and
+  unwrap it, so `ppi: Infinity` or `1e9` panicked the process — in WASM a trap
+  that takes the engine instance with it — while NaN, zero and a negative
+  quietly rasterized a 1×1 image. Every raster path now refuses under
+  `backend::invalid_raster_scale` a scale that is not finite and positive, or
+  that would put a page past `MAX_RASTER_PIXELS` (16384² px: a 1 GiB RGBA
+  buffer, and the area of the WASM painter's per-side clamp, so nothing that
+  clamp admits is refused). US Letter at the default 144 ppi is 138× under it.
+  `SessionHandle::render_rgba` and `LiveSession::render_rgba` return
+  `Result<Option<(u32, u32, Vec<u8>)>, RenderError>` to carry the refusal;
+  `Ok(None)` is still the out-of-range page.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -161,8 +161,7 @@ impl SessionHandle for PdfformSession {
             return self.render_svg();
         }
         if format == OutputFormat::Png {
-            let scale = opts.ppi_or_default() / 72.0;
-            return self.render_png(scale);
+            return self.render_png(quillmark_core::raster_scale(opts.ppi_or_default())?);
         }
 
         // PDF output is always an interactive AcroForm; value-flattening backs
@@ -186,8 +185,16 @@ impl SessionHandle for PdfformSession {
         Some((x1 - x0, y1 - y0))
     }
 
-    fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> {
-        let p = self.flat.pages().get(page)?;
+    fn render_rgba(
+        &self,
+        page: usize,
+        scale: f32,
+    ) -> Result<Option<(u32, u32, Vec<u8>)>, RenderError> {
+        let Some(p) = self.flat.pages().get(page) else {
+            return Ok(None);
+        };
+        let (width_pt, height_pt) = p.render_dimensions();
+        quillmark_core::check_raster(scale, width_pt, height_pt)?;
         let cache = RenderCache::new();
         let interp = standard_font_settings();
         let render_settings = scaled_render_settings(scale);
@@ -199,7 +206,7 @@ impl SessionHandle for PdfformSession {
             .into_iter()
             .flat_map(|px| [px.r, px.g, px.b, px.a])
             .collect();
-        Some((w, h, bytes))
+        Ok(Some((w, h, bytes)))
     }
 
     fn regions(&self) -> Vec<RenderedRegion> {
@@ -256,6 +263,8 @@ impl PdfformSession {
 
         let mut artifacts = Vec::with_capacity(self.flat.pages().len());
         for page in self.flat.pages().iter() {
+            let (width_pt, height_pt) = page.render_dimensions();
+            quillmark_core::check_raster(scale, width_pt, height_pt)?;
             let cache = RenderCache::new();
             let pixmap = hayro_render(page, &cache, &interp, &render_settings);
             let png = pixmap.into_png().map_err(|e| {

--- a/crates/backends/pdfform/tests/canvas_conformance.rs
+++ b/crates/backends/pdfform/tests/canvas_conformance.rs
@@ -20,14 +20,17 @@ agree: true\n\
 favorite_color: green\n\
 ~~~\n";
 
-#[test]
-fn pdfform_canvas_raster_is_complete() {
+fn open() -> quillmark_core::LiveSession {
     let quill = quillmark::quill_from_path(quillmark_fixtures::quills_path("sample_form"))
         .expect("load sample_form quill");
     let engine = Quillmark::new();
     let doc = Document::parse(FILLED).expect("parse markdown").document;
+    engine.open(&quill, &doc).expect("open session")
+}
 
-    let session = engine.open(&quill, &doc).expect("open session");
+#[test]
+fn pdfform_canvas_raster_is_complete() {
+    let session = open();
 
     assert!(
         session.page_size_pt(0).is_some(),
@@ -38,6 +41,7 @@ fn pdfform_canvas_raster_is_complete() {
     let (width_pt, height_pt) = session.page_size_pt(0).expect("page 0 size");
     let (px_w, px_h, rgba) = session
         .render_rgba(0, scale)
+        .expect("page 0 rasterizes at 2x")
         .expect("pdfform session must rasterize page 0");
 
     let expect_w = (width_pt * scale).round() as i64;
@@ -97,5 +101,28 @@ fn pdfform_canvas_raster_is_complete() {
     assert!(
         ink > 0,
         "field region box must contain non-white opaque pixels"
+    );
+}
+
+#[test]
+fn a_canvas_scale_that_cannot_be_rasterized_is_refused_rather_than_painted() {
+    let session = open();
+    for scale in [f32::INFINITY, f32::NAN, 0.0, -2.0, 1e6] {
+        let err = session
+            .render_rgba(0, scale)
+            .err()
+            .unwrap_or_else(|| panic!("{scale}x is not rasterizable"));
+        assert_eq!(
+            err.diagnostics()[0].code.as_deref(),
+            Some("backend::invalid_raster_scale")
+        );
+    }
+
+    assert!(
+        session
+            .render_rgba(99, 2.0)
+            .expect("a page out of range is not a refused scale")
+            .is_none(),
+        "an out-of-range page still answers None"
     );
 }

--- a/crates/backends/pdfform/tests/render_formats.rs
+++ b/crates/backends/pdfform/tests/render_formats.rs
@@ -2,6 +2,7 @@
 //! content — so they render without viewer appearance synthesis.
 
 use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
+use quillmark_core::{RenderError, RenderResult};
 
 const FILLED: &str = "~~~\n\
 $quill: sample_form\n\
@@ -13,15 +14,18 @@ agree: true\n\
 favorite_color: green\n\
 ~~~\n";
 
-fn render(format: OutputFormat, ppi: Option<f32>) -> Vec<quillmark_core::Artifact> {
+fn try_render(format: OutputFormat, ppi: Option<f32>) -> Result<RenderResult, RenderError> {
     let quill = quillmark::quill_from_path(quillmark_fixtures::quills_path("sample_form"))
         .expect("load sample_form quill");
     let engine = Quillmark::new();
     let doc = Document::parse(FILLED).expect("parse markdown").document;
     let mut opts = RenderOptions::default().with_output_format(format);
     opts.ppi = ppi;
-    engine
-        .render(&quill, &doc, &opts)
+    engine.render(&quill, &doc, &opts)
+}
+
+fn render(format: OutputFormat, ppi: Option<f32>) -> Vec<quillmark_core::Artifact> {
+    try_render(format, ppi)
         .unwrap_or_else(|e| panic!("render {format:?}: {e:?}"))
         .artifacts
 }
@@ -51,3 +55,17 @@ fn renders_png_per_page() {
     }
 }
 
+/// The rasterizer takes the pixel dimensions unchecked and aborts on the buffer
+/// it cannot allocate, so the refusal is the backend's to make.
+#[test]
+fn a_ppi_that_cannot_be_rasterized_is_refused_rather_than_rendered() {
+    for ppi in [f32::INFINITY, f32::NAN, 0.0, -144.0, 1e9] {
+        let err = try_render(OutputFormat::Png, Some(ppi))
+            .err()
+            .unwrap_or_else(|| panic!("{ppi} ppi is not rasterizable"));
+        assert_eq!(
+            err.diagnostics()[0].code.as_deref(),
+            Some("backend::invalid_raster_scale")
+        );
+    }
+}

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -90,11 +90,14 @@ pub(crate) fn render_document_pages(
             Ok(RenderResult::new(artifacts, OutputFormat::Svg))
         }
         OutputFormat::Png => {
-            let scale = ppi / 72.0;
+            let scale = quillmark_core::raster_scale(ppi)?;
             let opts = render_options(scale);
             let mut artifacts = Vec::with_capacity(selected_indices.len());
             for idx in selected_indices {
-                let pixmap = typst_render::render(&document.pages()[idx], &opts);
+                let page = &document.pages()[idx];
+                let size = page.frame.size();
+                quillmark_core::check_raster(scale, size.x.to_pt() as f32, size.y.to_pt() as f32)?;
+                let pixmap = typst_render::render(page, &opts);
                 let png_data = pixmap.encode_png().map_err(|e| {
                     RenderError::coded("typst::png_encoding", format!("PNG encoding failed: {e}"))
                 })?;

--- a/crates/backends/typst/src/lib.rs
+++ b/crates/backends/typst/src/lib.rs
@@ -295,8 +295,16 @@ impl SessionHandle for TypstSession {
 
     /// Non-premultiplied RGBA8 at `scale`× the natural 72 ppi, returned as
     /// `(width_px, height_px, rgba)` with `w * h * 4` row-major bytes.
-    fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> {
-        let p = self.live.document.pages().get(page)?;
+    fn render_rgba(
+        &self,
+        page: usize,
+        scale: f32,
+    ) -> Result<Option<(u32, u32, Vec<u8>)>, RenderError> {
+        let Some(p) = self.live.document.pages().get(page) else {
+            return Ok(None);
+        };
+        let size = p.frame.size();
+        quillmark_core::check_raster(scale, size.x.to_pt() as f32, size.y.to_pt() as f32)?;
         let pixmap = typst_render::render(p, &compile::render_options(scale));
         let width = pixmap.width();
         let height = pixmap.height();
@@ -308,7 +316,7 @@ impl SessionHandle for TypstSession {
             rgba.push(c.blue());
             rgba.push(c.alpha());
         }
-        Some((width, height, rgba))
+        Ok(Some((width, height, rgba)))
     }
 
     /// Widgets first (one fixed-size box each), then span-tracked content in

--- a/crates/backends/typst/tests/raster_scale.rs
+++ b/crates/backends/typst/tests/raster_scale.rs
@@ -1,0 +1,89 @@
+//! A raster the backend cannot allocate is refused before it is asked for:
+//! `typst_render` takes the pixel dimensions unchecked and unwraps the buffer.
+
+use quillmark_core::{Backend, LiveSession, OutputFormat, RenderError, RenderOptions};
+use quillmark_typst::TypstBackend;
+
+mod common;
+use common::quill_with_plate as quill;
+
+const YAML: &str = r#"
+quill:
+  name: raster_scale
+  version: 0.1.0
+  backend: typst
+  description: one small page to rasterize
+typst:
+  plate_file: plate.typ
+main:
+  fields: {}
+"#;
+
+const PLATE: &str = "#set page(width: 200pt, height: 120pt, margin: 12pt)\nink\n";
+
+/// Every value a caller can hand either knob and get no raster from: not
+/// finite, not positive, or past the pixel ceiling.
+const UNRASTERIZABLE_PPI: [f32; 5] = [f32::INFINITY, f32::NAN, 0.0, -144.0, 1e9];
+
+fn open() -> LiveSession {
+    TypstBackend
+        .open(&quill(YAML, PLATE), &serde_json::json!({}))
+        .expect("open")
+}
+
+fn code(err: RenderError) -> String {
+    err.diagnostics()[0]
+        .code
+        .clone()
+        .expect("a refusal carries its code")
+}
+
+#[test]
+fn a_ppi_that_cannot_be_rasterized_is_refused_rather_than_rendered() {
+    let session = open();
+    for ppi in UNRASTERIZABLE_PPI {
+        let opts = RenderOptions::default()
+            .with_output_format(OutputFormat::Png)
+            .with_ppi(ppi);
+        assert_eq!(
+            code(session
+                .render(&opts)
+                .err()
+                .unwrap_or_else(|| panic!("{ppi} ppi is not rasterizable"))),
+            "backend::invalid_raster_scale"
+        );
+    }
+
+    let opts = RenderOptions::default()
+        .with_output_format(OutputFormat::Png)
+        .with_ppi(144.0);
+    assert!(!session.render(&opts).expect("144 ppi renders").artifacts[0]
+        .bytes
+        .is_empty());
+}
+
+#[test]
+fn a_canvas_scale_that_cannot_be_rasterized_is_refused_rather_than_painted() {
+    let session = open();
+    for scale in UNRASTERIZABLE_PPI.map(|ppi| ppi / 72.0) {
+        assert_eq!(
+            code(session
+                .render_rgba(0, scale)
+                .err()
+                .unwrap_or_else(|| panic!("{scale}x is not rasterizable"))),
+            "backend::invalid_raster_scale"
+        );
+    }
+
+    assert!(session
+        .render_rgba(0, 2.0)
+        .expect("2x rasterizes")
+        .is_some());
+    assert!(
+        session
+            .render_rgba(99, 2.0)
+            .expect("a page out of range is not a refused scale")
+            .is_none(),
+        "an out-of-range page still answers None"
+    );
+}

--- a/crates/backends/typst/tests/widget_geometry.rs
+++ b/crates/backends/typst/tests/widget_geometry.rs
@@ -57,8 +57,14 @@ fn open() -> LiveSession {
 /// The bounding box, in Typst top-left-origin points, of the pixels that differ
 /// between `page` and `twin`.
 fn diff_bbox(session: &LiveSession, page: usize, twin: usize) -> [f32; 4] {
-    let (w, h, a) = session.render_rgba(page, SCALE).expect("render page");
-    let (tw, th, b) = session.render_rgba(twin, SCALE).expect("render twin");
+    let (w, h, a) = session
+        .render_rgba(page, SCALE)
+        .expect("SCALE rasterizes")
+        .expect("render page");
+    let (tw, th, b) = session
+        .render_rgba(twin, SCALE)
+        .expect("SCALE rasterizes")
+        .expect("render twin");
     assert_eq!((w, h), (tw, th), "the twin pages render at the same size");
 
     let (mut x0, mut y0, mut x1, mut y1) = (u32::MAX, u32::MAX, 0u32, 0u32);

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -33,8 +33,11 @@ impl PyQuillmark {
 
     /// Render `doc` against `quill` in one shot, resolving `quill`'s backend on
     /// this engine. The default `output_format` falls back to the backend's
-    /// first supported format. Raises `QuillmarkError` (`engine::backend_not_found`)
-    /// when the backend is not registered.
+    /// first supported format. `ppi` (raster formats only, default 144) must be
+    /// finite, above 0, and small enough to keep every rendered page under
+    /// 268435456 pixels. Raises `QuillmarkError` (`engine::backend_not_found`)
+    /// when the backend is not registered, or `backend::invalid_raster_scale`
+    /// for a `ppi` outside that range.
     #[pyo3(signature = (quill, doc, format=None, ppi=None, pages=None, producer=None, regions=false))]
     #[allow(clippy::too_many_arguments)] // kwargs mirror RenderOptions 1:1; the signature IS the Python API
     fn render(

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -337,6 +337,12 @@ export interface Artifact {
 /** Options for one render. */
 export interface RenderOptions {
 	format?: OutputFormat;
+	/**
+	 * Pixels per inch for raster formats (PNG); ignored by PDF and SVG.
+	 * Defaults to 144. Must be finite, above 0, and small enough to keep every
+	 * rendered page under 268435456 pixels — anything else throws
+	 * `backend::invalid_raster_scale`.
+	 */
 	ppi?: number;
 	pages?: number[];
 	producer?: string;

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -2953,7 +2953,9 @@ impl LiveSession {
     /// this call.
     ///
     /// Throws if the backend has no canvas painter, `page` is out of range, `ctx`
-    /// is the wrong type, or either scale is non-finite or `<= 0`.
+    /// is the wrong type, either scale is non-finite or `<= 0`, or the page
+    /// cannot be rasterized at the resulting scale
+    /// (`backend::invalid_raster_scale`).
     #[wasm_bindgen(js_name = paint, unchecked_return_type = "PaintResult")]
     pub fn paint(
         &self,
@@ -3026,6 +3028,7 @@ impl LiveSession {
         let (pixel_w, pixel_h, mut rgba) = self
             .inner
             .render_rgba(page, render_scale as f32)
+            .map_err(|e| WasmError::from(e).to_js_value())?
             .ok_or_else(|| {
                 WasmError::from(format!(
                     "paint: backend '{}' reported a canvas painter but produced no raster \

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -51,6 +51,65 @@ pub fn unsupported_format(format: OutputFormat, backend: &str, supported: &[Outp
     )
 }
 
+/// The pixel ceiling on one rasterized page, shared by every raster path so a
+/// caller meets one number.
+///
+/// RGBA is 4 bytes a pixel, so one page's buffer stops at 1 GiB: a quarter of
+/// wasm32's whole address space, and far under the size at which the
+/// rasterizers' own 32-bit dimension arithmetic wraps. It is also the area of
+/// the WASM painter's 16384-px-per-side backing-store clamp
+/// ([PREVIEW.md](https://github.com/borb-sh/quillmark/blob/main/prose/canon/PREVIEW.md)),
+/// so every raster that clamp admits still renders. US Letter at
+/// [`RenderOptions::DEFAULT_PPI`](crate::RenderOptions::DEFAULT_PPI) is 1.9 Mpx,
+/// 138× under it.
+pub const MAX_RASTER_PIXELS: u64 = 16_384 * 16_384;
+
+fn invalid_raster_scale(message: String, hint: &str) -> RenderError {
+    RenderError::from_diag(
+        crate::Diagnostic::new(crate::Severity::Error, message)
+            .with_code("backend::invalid_raster_scale".to_string())
+            .with_hint(hint.to_string()),
+    )
+}
+
+/// Device pixels per point for a raster render at `ppi`, under
+/// `backend::invalid_raster_scale` unless `ppi` is finite and positive.
+pub fn raster_scale(ppi: f32) -> Result<f32, RenderError> {
+    if !ppi.is_finite() || ppi <= 0.0 {
+        return Err(invalid_raster_scale(
+            format!("ppi {ppi} is not a finite positive number"),
+            "Pass a ppi above 0, or none at all for the default 144.",
+        ));
+    }
+    Ok(ppi / 72.0)
+}
+
+/// The refusal every raster backend owes a page it cannot rasterize, checked
+/// before the rasterizer allocates: under `backend::invalid_raster_scale` unless
+/// `scale` (device pixels per point, as [`raster_scale`] returns) is finite and
+/// positive and the `width_pt` × `height_pt` page fits [`MAX_RASTER_PIXELS`].
+pub fn check_raster(scale: f32, width_pt: f32, height_pt: f32) -> Result<(), RenderError> {
+    if !scale.is_finite() || scale <= 0.0 {
+        return Err(invalid_raster_scale(
+            format!("raster scale {scale} is not a finite positive number of device pixels per point"),
+            "Pass a scale above 0.",
+        ));
+    }
+    // `max` takes the non-NaN side, flooring a degenerate page size at the one
+    // pixel the rasterizers floor it at.
+    let px = |pt: f32| (f64::from(scale) * f64::from(pt)).round().max(1.0);
+    let (w, h) = (px(width_pt), px(height_pt));
+    if w * h > MAX_RASTER_PIXELS as f64 {
+        return Err(invalid_raster_scale(
+            format!(
+                "a {width_pt}x{height_pt} pt page at {scale} device pixels per point is {w}x{h} px, past the {MAX_RASTER_PIXELS} px ceiling"
+            ),
+            "Rasterize fewer pixels: lower the ppi (the default is 144) or the canvas scale.",
+        ));
+    }
+    Ok(())
+}
+
 /// Pre-session hint for whether a backend with these `formats` can paint pages
 /// to a canvas, used before a session exists (e.g. a GUI deciding whether to
 /// mount a canvas preview without first paying to open one).
@@ -71,6 +130,50 @@ pub fn formats_support_canvas(formats: &[OutputFormat]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// US Letter, the shape every raster check below is measured against.
+    const LETTER_PT: (f32, f32) = (612.0, 792.0);
+
+    fn code(err: RenderError) -> String {
+        err.diagnostics()[0]
+            .code
+            .clone()
+            .expect("a refusal carries its code")
+    }
+
+    #[test]
+    fn raster_scale_refuses_a_ppi_that_is_not_finite_and_positive() {
+        for ppi in [f32::INFINITY, f32::NEG_INFINITY, f32::NAN, 0.0, -144.0] {
+            let err = raster_scale(ppi)
+                .err()
+                .unwrap_or_else(|| panic!("{ppi} is not a usable ppi"));
+            assert_eq!(code(err), "backend::invalid_raster_scale");
+        }
+        assert_eq!(raster_scale(144.0).expect("144 ppi is usable"), 2.0);
+    }
+
+    #[test]
+    fn check_raster_refuses_a_page_past_the_pixel_ceiling() {
+        let (w, h) = LETTER_PT;
+        let ceiling = (MAX_RASTER_PIXELS as f64 / f64::from(w * h)).sqrt() as f32;
+        assert!(check_raster(ceiling, w, h).is_ok());
+        assert_eq!(
+            code(check_raster(ceiling * 2.0, w, h).expect_err("twice the ceiling scale")),
+            "backend::invalid_raster_scale"
+        );
+        assert_eq!(
+            code(check_raster(f32::INFINITY, w, h).expect_err("an infinite scale")),
+            "backend::invalid_raster_scale"
+        );
+    }
+
+    #[test]
+    fn the_default_ppi_leaves_a_letter_page_far_under_the_ceiling() {
+        let (w, h) = LETTER_PT;
+        let scale = raster_scale(crate::RenderOptions::DEFAULT_PPI).expect("the default ppi");
+        check_raster(scale, w, h).expect("the default render is not near the ceiling");
+        assert!(f64::from(w * scale) * f64::from(h * scale) * 100.0 < MAX_RASTER_PIXELS as f64);
+    }
 
     #[test]
     fn formats_support_canvas_keys_off_visual_formats() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -34,7 +34,10 @@ pub mod reader;
 pub use reader::{CardReader, TypedReader};
 
 pub mod backend;
-pub use backend::{formats_support_canvas, unsupported_format, Backend};
+pub use backend::{
+    check_raster, formats_support_canvas, raster_scale, unsupported_format, Backend,
+    MAX_RASTER_PIXELS,
+};
 
 pub mod error;
 pub use error::{

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -55,8 +55,8 @@ pub trait SessionHandle: Send + Sync + 'static {
 
     /// Render `page` to a non-premultiplied RGBA8 buffer at `scale`× the natural
     /// 72-ppi size, returning `(width_px, height_px, rgba)` (row-major, `w*h*4`
-    /// bytes), or `None` if `page` is out of range or the backend has no canvas
-    /// painter. The other half of the seam paired with
+    /// bytes), or `Ok(None)` if `page` is out of range or the backend has no
+    /// canvas painter. The other half of the seam paired with
     /// [`page_size_pt`](Self::page_size_pt).
     ///
     /// A backend that returns `Some` here guarantees a **complete** raster:
@@ -64,12 +64,19 @@ pub trait SessionHandle: Send + Sync + 'static {
     /// caller composites nothing. [`regions`](Self::regions) is for overlay and
     /// cross-navigation UIs, never required to complete the raster.
     ///
+    /// A scale the page cannot be rasterized at is the `Err`: run it through
+    /// [`check_raster`](crate::check_raster), which every raster path shares.
+    ///
     /// A backend with no painter overrides neither this nor
     /// [`page_size_pt`](Self::page_size_pt), and
     /// [`LiveSession::supports_canvas`] derives the capability from that half
     /// of the seam rather than a separate flag.
-    fn render_rgba(&self, _page: usize, _scale: f32) -> Option<(u32, u32, Vec<u8>)> {
-        None
+    fn render_rgba(
+        &self,
+        _page: usize,
+        _scale: f32,
+    ) -> Result<Option<(u32, u32, Vec<u8>)>, RenderError> {
+        Ok(None)
     }
 
     /// Schema-field geometry for the compiled session: [`RenderedRegion`]s
@@ -208,11 +215,20 @@ impl LiveSession {
         self.inner.page_size_pt(page)
     }
 
-    /// Rasterize `page` to non-premultiplied RGBA8 at `scale`× 72 ppi, or `None`
-    /// if `page` is out of range or the backend has no canvas painter. A `Some`
-    /// result is a **complete** raster: all content visible, no caller-side
-    /// compositing.
-    pub fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> {
+    /// Rasterize `page` to non-premultiplied RGBA8 at `scale`× 72 ppi, or
+    /// `Ok(None)` if `page` is out of range or the backend has no canvas
+    /// painter. A `Some` result is a **complete** raster: all content visible,
+    /// no caller-side compositing.
+    ///
+    /// `scale` is device pixels per point, and must be finite, positive, and
+    /// small enough to keep the page under
+    /// [`MAX_RASTER_PIXELS`](crate::MAX_RASTER_PIXELS); anything else is a
+    /// `backend::invalid_raster_scale` refusal.
+    pub fn render_rgba(
+        &self,
+        page: usize,
+        scale: f32,
+    ) -> Result<Option<(u32, u32, Vec<u8>)>, RenderError> {
         self.inner.render_rgba(page, scale)
     }
 

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -159,6 +159,11 @@ pub struct RenderOptions {
     /// Ignored for vector/document formats (PDF, SVG).
     /// `None` resolves to [`RenderOptions::DEFAULT_PPI`] through
     /// [`ppi_or_default`](RenderOptions::ppi_or_default).
+    ///
+    /// Must be finite and positive, and small enough to keep every rendered
+    /// page under [`MAX_RASTER_PIXELS`](crate::MAX_RASTER_PIXELS); a raster
+    /// backend refuses anything else with a `backend::invalid_raster_scale`
+    /// [`RenderError`](crate::RenderError).
     pub ppi: Option<f32>,
     /// Optional 0-based page indices to render (e.g., `vec![0, 2]` for
     /// the first and third pages). `None` renders all pages. Any index

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -57,6 +57,10 @@ for a backend session that does not override the incremental-`update` seam
 (both built-in backends override it); `backend::format_not_supported`: the
 requested format is outside the backend's `supported_formats`, one code on
 every backend so a caller matches the condition once;
+`backend::invalid_raster_scale`: a `RenderOptions.ppi` or a `render_rgba` scale
+that is not finite and positive, or that would rasterize a page past
+`MAX_RASTER_PIXELS` — ppi and canvas scale are the same quantity in two units,
+so they share the code and the message names which one was passed;
 `engine::backend_not_found`: the quill's declared backend is not registered.
 
 **`edit::*`: mutator diagnostics.** Document and card mutators fail with the

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -46,7 +46,8 @@ pub trait SessionHandle: Send + Sync + 'static {
 
     // Canvas seam: default None = "no painter".
     fn page_size_pt(&self, page: usize) -> Option<(f32, f32)> { None }
-    fn render_rgba(&self, page: usize, scale: f32) -> Option<(u32, u32, Vec<u8>)> { None }
+    fn render_rgba(&self, page: usize, scale: f32)
+        -> Result<Option<(u32, u32, Vec<u8>)>, RenderError> { Ok(None) }
 
     // Warnings seam: the current compile's non-fatal diagnostics; default empty.
     fn warnings(&self) -> &[Diagnostic] { &[] }
@@ -130,6 +131,13 @@ compositing of its own. Backends satisfy it differently:
   streams at session-open (and again at each `update`), then rasterizes that
   flat PDF via hayro, so field values appear in the raster on their own, with
   no regions-compositing by the caller.
+
+`Ok(None)` is the out-of-range page and the painterless backend; the `Err` is a
+`scale` no page can be rasterized at. Neither rasterizer bounds the buffer it
+sizes from `scale × page size`, so a scale that is not finite and positive, or
+that puts the page past `MAX_RASTER_PIXELS` (16384², the area of the per-side
+clamp below), is refused under `backend::invalid_raster_scale` before either is
+asked. `RenderOptions.ppi` meets the same ceiling on the byte-artifact path.
 
 ### Painter owns the canvas
 


### PR DESCRIPTION
Closes #1520.

## The change

The premise holds on both backends: `render(Png, ppi = f32::INFINITY)` aborts through `vello_common::pixmap::Pixmap::new` on pdfform as it does through tiny-skia on typst, and NaN/zero/negative rasterize a 1×1 image.

`quillmark_core::raster_scale(ppi)` and `check_raster(scale, width_pt, height_pt)` are one backend-neutral guard beside `unsupported_format`, run before either rasterizer sizes a buffer. A scale that is not finite and positive, or that puts a page past `MAX_RASTER_PIXELS`, is a `backend::invalid_raster_scale` `RenderError`: one code, since ppi and canvas scale are the same quantity in two units and the message names which was passed. NaN, zero and negative are refused, not clamped.

The ceiling is 16384² px: a 1 GiB RGBA buffer, and exactly the area of the WASM painter's existing per-side backing-store clamp, so nothing that clamp admits is refused. Every fixture quill is US Letter, 1.9 Mpx at the default 144 ppi, 138× under.

Call sites: typst `compile.rs` (PNG, per selected page) and `lib.rs`; pdfform `render_png` (per page, sized from hayro's own `render_dimensions`) and `render_rgba`.

The canvas seam had no way to carry a refusal, so `SessionHandle::render_rgba` and `LiveSession::render_rgba` now return `Result<Option<(u32, u32, Vec<u8>)>, RenderError>`. `Ok(None)` is still the out-of-range page; keeping the refusal inside `None` would have made WASM `paint`'s "backend reported a painter but produced no raster" message lie. `paint` maps the `Err` through, and it is reachable there for a zero-dimension page, which bypasses the per-side clamp.

## Docs

`ERROR.md` notable codes (no args, so no table row); `PREVIEW.md` seam signature plus the `Ok(None)`-vs-`Err` rule; `RenderOptions::ppi`, `LiveSession::render_rgba`, `runtime.d.ts` `ppi`, and the Python `render` docstring all state the accepted range.

## Verification

- `cargo test --workspace` green, including new tests on both backends: `ppi ∈ {∞, NaN, 0, −144, 1e9}` and `render_rgba(0, ·)` at the same scales return the code and do not panic.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace` clean; `node scripts/check-canon.mjs` OK; clippy adds no warnings in the touched files.
- WASM: `./scripts/build-wasm.sh --ci`, `npx vitest run` (264 passed), `npm run typecheck` clean. `npm install` needed `--legacy-peer-deps` here (an arborist crash unrelated to the change).
- Python not built: the only change there is a docstring, covered by the workspace build.

## For review

The `!` is for the refusal of ppi values that used to render 1×1 and for the seam's return type. No section was added to `docs/migrations/0.112-to-0.113.md`: the other `!` entry under Unreleased has none either, so the guide looks assembled at release; fold this break in there if that is wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_