### PR TITLE
fix(pdfform)!: the spine owns the rect guard and the objects flatten writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(pdfform)!: **flatten's own parse failure is `pdfform::flatten_parse`.** A
+  page dict or `/Contents` the content-stream flattener cannot read raised
+  `pdf::flatten_parse`, naming the stamp spine for a failure of the backend's
+  own code; it carries the `pdfform::*` namespace every other pdfform code
+  uses. `pdf::bad_rect` stays the spine's and is minted in one place,
+  `FieldSpec::assert_finite_rect`, which the stamp and flatten paths both call.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/backends/pdfform/src/flatten.rs
+++ b/crates/backends/pdfform/src/flatten.rs
@@ -15,18 +15,18 @@
 use quillmark_pdf::{
     reader::{
         extract_outer_dict, find_dict_value, parse_indirect_ref, splice_dict_value, ObjectIndex,
-        Page, UpdatedObject,
+        Page,
     },
     writer::{
-        alloc_id, append_refs_to_array_key, dict_object, pdf_escape, winansi_encode, OnNonArray,
+        alloc_id, append_refs_to_array_key, content_stream_object, dict_object, pdf_escape,
+        type1_font_object, winansi_encode, OnNonArray,
     },
     FieldSpec, FieldType, PdfError, PdfUpdate, CHECKBOX_ON_STATE,
 };
 
 use crate::typography;
 
-const CODE_PARSE: &str = "pdf::flatten_parse";
-const CODE_BAD_RECT: &str = "pdf::bad_rect";
+const CODE_PARSE: &str = "pdfform::flatten_parse";
 
 const STATE_RESET: &[u8] = b"0 g 0 Tr 0 Tc 0 Tw 100 Tz 0 Ts\n";
 
@@ -40,18 +40,8 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
         return Ok(base);
     }
 
-    // `push_f32` formats a non-finite float as the literal `NaN`/`inf`, a token
-    // no PDF number grammar admits: the drawn stream would be unparseable.
     for spec in &drawable {
-        if !spec.rect.iter().all(|v| v.is_finite()) {
-            return Err(PdfError::new(
-                CODE_BAD_RECT,
-                format!(
-                    "field `{}` has a non-finite /Rect: {:?}",
-                    spec.name, spec.rect
-                ),
-            ));
-        }
+        spec.assert_finite_rect()?;
     }
 
     let pdf = base;
@@ -68,10 +58,10 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
     up.objects.push(type1_font_object(
         helv_id,
         typography::TEXT_FONT,
-        Some("WinAnsiEncoding"),
-    ));
+        Some(b"WinAnsiEncoding"),
+    )?);
     up.objects
-        .push(type1_font_object(zadb_id, typography::CHECK_FONT, None));
+        .push(type1_font_object(zadb_id, typography::CHECK_FONT, None)?);
 
     let mut fields_by_page: Vec<Vec<&FieldSpec>> = vec![Vec::new(); page_count];
     for spec in drawable {
@@ -99,7 +89,7 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
         up.objects.push(content_stream_object(
             stream_id,
             &build_content_stream(page_fields, &names),
-        ));
+        )?);
 
         let new_pg = rewrite_page_for_flatten(
             &idx,
@@ -428,29 +418,6 @@ fn add_font_resources(
             out
         }
     })
-}
-
-/// Build a base-14 Type1 font object. Symbol fonts pass `encoding: None` to keep
-/// their built-in encoding; text fonts name `WinAnsiEncoding`.
-fn type1_font_object(id: u32, base_font: &str, encoding: Option<&str>) -> UpdatedObject {
-    let enc = match encoding {
-        Some(name) => format!(" /Encoding /{name}"),
-        None => String::new(),
-    };
-    UpdatedObject::new(
-        id,
-        format!(
-            "{id} 0 obj\n<< /Type /Font /Subtype /Type1 /BaseFont /{base_font}{enc} >>\nendobj\n"
-        )
-        .into_bytes(),
-    )
-}
-
-fn content_stream_object(id: u32, content: &[u8]) -> UpdatedObject {
-    let mut bytes = format!("{id} 0 obj\n<< /Length {} >>\nstream\n", content.len()).into_bytes();
-    bytes.extend_from_slice(content);
-    bytes.extend_from_slice(b"\nendstream\nendobj\n");
-    UpdatedObject::new(id, bytes)
 }
 
 /// Append `v` as a compact `%.2f` float, stripping trailing zeros and dot.
@@ -825,5 +792,15 @@ mod tests {
             BASE,
             "no drawable value must append no revision"
         );
+    }
+
+    #[test]
+    fn a_non_finite_rect_is_refused_rather_than_drawn() {
+        for bad in [f32::NAN, f32::INFINITY, f32::NEG_INFINITY] {
+            let mut spec = text_field("FullName", "Ada Lovelace");
+            spec.rect[1] = bad;
+            let err = flatten(BASE.to_vec(), &[spec]).expect_err("non-finite rect rejected");
+            assert_eq!(err.code, "pdf::bad_rect", "{bad}");
+        }
     }
 }

--- a/crates/backends/pdfform/src/typography.rs
+++ b/crates/backends/pdfform/src/typography.rs
@@ -4,11 +4,11 @@
 //! flatten path must commit to a concrete font and size. Keeping that decision
 //! here is what makes preview and flattening agree exactly.
 
-/// Base-14 Helvetica, for text and choice values.
-pub(crate) const TEXT_FONT: &str = "Helvetica";
+/// Base-14 Helvetica `/BaseFont`, for text and choice values.
+pub(crate) const TEXT_FONT: &[u8] = b"Helvetica";
 
-/// Base-14 ZapfDingbats, for the checkbox check glyph.
-pub(crate) const CHECK_FONT: &str = "ZapfDingbats";
+/// Base-14 ZapfDingbats `/BaseFont`, for the checkbox check glyph.
+pub(crate) const CHECK_FONT: &[u8] = b"ZapfDingbats";
 
 /// Preferred `/Font` resource name for [`TEXT_FONT`], shared with the `/DA` the
 /// stamp path writes. A page already binding it gets a derived name instead.

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -34,6 +34,8 @@ pub use reader::ObjectIndex;
 pub use stamp::{regions_of, stamp, StampOptions, CHECKBOX_ON_STATE};
 pub use update::PdfUpdate;
 
+const CODE_BAD_RECT: &str = "pdf::bad_rect";
+
 /// The `/MediaBox` of every page of `base`, normalized to `[x0, y0, x1, y1]`
 /// (lower-left, upper-right), in document order. A backend owning top-left
 /// page-relative rects flips against these before building a [`FieldSpec`].
@@ -87,6 +89,23 @@ impl FieldSpec {
             font_size: None,
             align: TextAlign::default(),
         }
+    }
+
+    /// `Err` with code `pdf::bad_rect` unless every [`rect`](Self::rect)
+    /// coordinate is finite. `rect` is public and every writer here prints a
+    /// float verbatim, so an unchecked one reaches a widget `/Rect` or a drawn
+    /// content stream as `NaN`/`inf`, a token no PDF number grammar admits.
+    pub fn assert_finite_rect(&self) -> Result<(), PdfError> {
+        if self.rect.iter().all(|v| v.is_finite()) {
+            return Ok(());
+        }
+        Err(PdfError::new(
+            CODE_BAD_RECT,
+            format!(
+                "field `{}` has a non-finite /Rect: {:?}",
+                self.name, self.rect
+            ),
+        ))
     }
 }
 

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -23,11 +23,12 @@ use quillmark_core::RenderedRegion;
 use crate::error::PdfError;
 use crate::reader::{err, find_dict_value, parse_indirect_ref, ObjectIndex, UpdatedObject};
 use crate::update::PdfUpdate;
-use crate::writer::{alloc_id, append_refs_to_array_key, dict_object, to_ref, OnNonArray};
+use crate::writer::{
+    alloc_id, append_refs_to_array_key, dict_object, to_ref, type1_font_object, OnNonArray,
+};
 use crate::{FieldSpec, FieldType, FormFont, TextAlign};
 
 const CODE_PARSE: &str = "pdf::stamp_parse";
-const CODE_BAD_RECT: &str = "pdf::bad_rect";
 const CODE_EXISTING_ACROFORM: &str = "pdf::existing_acroform";
 
 /// The fixed checkbox on-state export name. A checkbox [`FieldSpec`] carries
@@ -115,20 +116,8 @@ pub fn stamp(
         return Ok(base);
     }
 
-    // pdf-writer prints a non-finite float verbatim, so an unchecked rect puts
-    // `inf`/`NaN` in the widget's `/Rect` — tokens no PDF number grammar
-    // admits. `rect` is public, as `font_size` is, and guarded for the same
-    // reason.
     for spec in fields {
-        if !spec.rect.iter().all(|v| v.is_finite()) {
-            return Err(err(
-                CODE_BAD_RECT,
-                format!(
-                    "field `{}` has a non-finite /Rect: {:?}",
-                    spec.name, spec.rect
-                ),
-            ));
-        }
+        spec.assert_finite_rect()?;
     }
 
     let pdf = base;
@@ -172,14 +161,8 @@ pub fn stamp(
         }
 
         for (font, &fid) in fonts.iter().zip(&font_ids) {
-            let mut fchunk = Chunk::new();
-            fchunk
-                .type1_font(to_ref(fid)?)
-                .base_font(Name(font.base_font()));
-            up.objects.push(UpdatedObject {
-                id: fid,
-                bytes: fchunk.as_bytes().to_vec(),
-            });
+            up.objects
+                .push(type1_font_object(fid, font.base_font(), None)?);
         }
 
         let has_signature = fields

--- a/crates/quillmark-pdf/src/writer.rs
+++ b/crates/quillmark-pdf/src/writer.rs
@@ -2,7 +2,7 @@
 //! the two emit identical bytes for an object, a text string, and the `/Info`
 //! `/Producer` stamp.
 
-use pdf_writer::Ref;
+use pdf_writer::{Chunk, Name, Ref};
 
 use crate::error::PdfError;
 use crate::reader::{err, find_dict_value, splice_dict_value, ObjectIndex, UpdatedObject};
@@ -20,6 +20,31 @@ pub fn dict_object(id: u32, inner: &[u8]) -> UpdatedObject {
     bytes.extend_from_slice(inner);
     bytes.extend_from_slice(b" >>\nendobj\n");
     UpdatedObject { id, bytes }
+}
+
+/// One base-14 Type1 font object, never embedded. `encoding` names a predefined
+/// encoding; a symbol font passes `None` to keep its built-in one.
+pub fn type1_font_object(
+    id: u32,
+    base_font: &[u8],
+    encoding: Option<&[u8]>,
+) -> Result<UpdatedObject, PdfError> {
+    let mut chunk = Chunk::new();
+    {
+        let mut font = chunk.type1_font(to_ref(id)?);
+        font.base_font(Name(base_font));
+        if let Some(name) = encoding {
+            font.encoding_predefined(Name(name));
+        }
+    }
+    Ok(UpdatedObject::new(id, chunk.as_bytes().to_vec()))
+}
+
+/// One uncompressed content stream object carrying `content`.
+pub fn content_stream_object(id: u32, content: &[u8]) -> Result<UpdatedObject, PdfError> {
+    let mut chunk = Chunk::new();
+    chunk.stream(to_ref(id)?, content);
+    Ok(UpdatedObject::new(id, chunk.as_bytes().to_vec()))
 }
 
 /// Hand out the next object id from `next`, bounded at `i32::MAX` so a


### PR DESCRIPTION
Closes #1537.
Closes #1539.

## The change

Both issue premises hold at head: the 12-line non-finite `/Rect` loop sat verbatim in `crates/quillmark-pdf/src/stamp.rs` and `crates/backends/pdfform/src/flatten.rs`, and flatten hand-formatted the Type1 font dict and the `<< /Length N >> stream … endstream` object.

`FieldSpec::assert_finite_rect()` in `quillmark-pdf` is now the only place `pdf::bad_rect` is minted; stamp and flatten each call it in place of their own loop, keeping their existing scopes (stamp checks every field, flatten only the drawable ones). Flatten's own parse failure moves to `pdfform::flatten_parse`, matching every other pdfform code: a page dict or `/Contents` the flattener cannot read is backend code failing, not the spine.

`writer::type1_font_object` and `writer::content_stream_object` write those two objects with pdf-writer (`type1_font(..).base_font(..).encoding_predefined(Name(b"WinAnsiEncoding"))`, `Chunk::stream(id, &bytes)`) and return an `UpdatedObject`. Both paths call them, so the stamp path's font bytes are unchanged and the flatten path now emits the identical dict, with no `/Length` bookkeeping of its own. `typography::TEXT_FONT` / `CHECK_FONT` become byte strings, the shape a PDF `/BaseFont` name takes; pdf-writer stays a dev-dependency of pdfform.

## Docs

None needed. No canon or user doc names `pdf::flatten_parse` (grepped `prose/` and `docs/`), ERROR.md's namespace list already carries `pdfform::*`, and ARCHITECTURE.md's "a non-finite widget `/Rect`" line under `quillmark-pdf` is now literally true of one owner. The `pdf::*` namespace paragraph is left to PR #1599.

## Verification

- `cargo test --workspace`: green, 0 failures. The flatten/raster tests that rasterise through hayro (`canvas_conformance`, `render_formats`, `sample_form`) pass on the new object bytes, and a dumped flattened PDF confirms the emitted font dict is `/Type /Font /Subtype /Type1 /BaseFont /Helvetica /Encoding /WinAnsiEncoding` and the stream object carries the right `/Length`.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `cargo clippy -p quillmark-pdf -p quillmark-pdfform --all-targets`: no warnings in either crate (the ones printed come from `quillmark-typst`/`quillmark-content` through the dev-dependency).
- No binding build: the change is Rust-side only and reached by Rust tests.

## For review

One test added, `a_non_finite_rect_is_refused_rather_than_drawn`, since the shared guard had a direct test on the stamp path only. The changelog carries one `fix(pdfform)!:` entry for the code rename; the pdf-writer refactor changes flatten's intermediate PDF bytes (pretty-printed dicts) but that PDF is raster input only, since the AcroForm deliverable is stamped, so no consumer sees it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_