### PR TITLE
fix(pdf): one trailer `/Info`, decided once when the update opens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,14 @@
   document-level pair rather than a `store` / `load` pair. The old names are
   removed rather than aliased. Stored blobs, the `schema` tag, and every byte
   these verbs write are untouched.
+- fix(pdf): **a stamped trailer carries one `/Info`, whatever shape the base's
+  `/Info` had.** The producer stamp allocated a fresh information dictionary
+  whenever the trailer's `/Info` did not parse as an indirect reference, while
+  the trailer writer copied the old value forward regardless, so a direct-dict
+  `/Info << /Title (x) >>` came out as two `/Info` keys in one dict — undefined
+  per spec, parser-dependent in practice. The fresh reference now supersedes the
+  old value, and a direct dict's entries seed the object it names, so `/Title`
+  and the rest survive the stamp.
 - fix(pdf): **the object index skips literal strings, `%`-comments and stream
   bodies, so `N G obj` bytes carried as content cannot shadow the real object.**
   The scan accepted any `<id> <gen> obj` at a token boundary and a later

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -73,16 +73,52 @@ pub(crate) fn find_trailer_dict(pdf: &[u8], xref_offset: usize) -> Result<&[u8],
         .ok_or_else(|| err(CODE_PARSE, "trailer dict not parseable"))
 }
 
-/// Carry `/Info` and `/ID` forward into the update's trailer: many readers
-/// (lopdf included) consult only the last trailer, so dropping them would lose
-/// the document `/Info` and file identifier. Callers append `/Size`, `/Root` and
-/// `/Prev` themselves.
-fn write_preserved_trailer_keys(out: &mut Vec<u8>, prior_trailer: &[u8]) {
-    for key in ["Info", "ID"] {
-        if let Some(value) = find_dict_value(prior_trailer, key) {
-            out.extend_from_slice(format!(" /{} ", key).as_bytes());
-            out.extend_from_slice(value.trim_ascii());
+/// What the trailer's `/Info` gives the producer stamp to rewrite.
+pub(crate) enum InfoSource<'a> {
+    /// Object `id`, rewritten in place under the trailer's existing reference.
+    Object(u32),
+    /// Entries for a fresh object whose reference replaces the trailer's
+    /// `/Info`: a direct dict's — ISO 32000-1 Table 15 asks for an indirect
+    /// reference, which not every writer honours — or none, when the trailer
+    /// carries no `/Info` or one this reader cannot read.
+    Entries(&'a [u8]),
+}
+
+pub(crate) fn read_info_source(trailer: &[u8]) -> InfoSource<'_> {
+    let Some(value) = find_dict_value(trailer, "Info") else {
+        return InfoSource::Entries(b"");
+    };
+    if let Some((id, _)) = parse_indirect_ref(value) {
+        return InfoSource::Object(id);
+    }
+    let trimmed = value.trim_ascii();
+    if trimmed.starts_with(b"<<")
+        && let Some(entries) = extract_outer_dict(trimmed)
+    {
+        return InfoSource::Entries(entries);
+    }
+    InfoSource::Entries(b"")
+}
+
+/// Carry the prior trailer's `/ID` and `/Info` forward into the update's
+/// trailer: many readers (lopdf included) consult only the last trailer, so
+/// dropping them would lose the document `/Info` and file identifier.
+/// `new_info_ref` supersedes that `/Info` rather than joining it, so the new
+/// trailer holds one `/Info` whatever shape the old value had. Callers append
+/// `/Size`, `/Root` and `/Prev` themselves.
+fn write_trailer_tail(out: &mut Vec<u8>, prior_trailer: &[u8], new_info_ref: Option<u32>) {
+    match new_info_ref {
+        Some(id) => out.extend_from_slice(format!(" /Info {id} 0 R").as_bytes()),
+        None => {
+            if let Some(value) = find_dict_value(prior_trailer, "Info") {
+                out.extend_from_slice(b" /Info ");
+                out.extend_from_slice(value.trim_ascii());
+            }
         }
+    }
+    if let Some(value) = find_dict_value(prior_trailer, "ID") {
+        out.extend_from_slice(b" /ID ");
+        out.extend_from_slice(value.trim_ascii());
     }
 }
 
@@ -103,23 +139,25 @@ impl UpdatedObject {
 /// Append one incremental update to `pdf`: each object in `objects`, then an
 /// xref subsection table and a trailer chaining to the prior xref via `/Prev`.
 ///
-/// `extra_info_ref` adds an explicit `/Info <id> 0 R` for the case where the
-/// prior trailer had none. `new_size` is the updated `/Size` (highest object
-/// number + 1) and `root_id` the document catalog.
+/// `new_info_ref` names an information dictionary written in this update, which
+/// the new trailer's `/Info` points at in place of the prior trailer's own.
+/// `new_size` is the updated `/Size` (highest object number + 1) and `root_id`
+/// the document catalog.
 pub(crate) fn append_incremental_update(
     mut pdf: Vec<u8>,
     prev_xref: usize,
     root_id: u32,
     new_size: u32,
-    extra_info_ref: Option<u32>,
+    new_info_ref: Option<u32>,
     objects: &[UpdatedObject],
 ) -> Result<Vec<u8>, PdfError> {
     // Built while the prior trailer at `prev_xref` is still intact.
     let mut trailer_tail = Vec::new();
-    write_preserved_trailer_keys(&mut trailer_tail, find_trailer_dict(&pdf, prev_xref)?);
-    if let Some(id) = extra_info_ref {
-        trailer_tail.extend_from_slice(format!(" /Info {id} 0 R").as_bytes());
-    }
+    write_trailer_tail(
+        &mut trailer_tail,
+        find_trailer_dict(&pdf, prev_xref)?,
+        new_info_ref,
+    );
 
     if !pdf.ends_with(b"\n") {
         pdf.push(b'\n');

--- a/crates/quillmark-pdf/src/update.rs
+++ b/crates/quillmark-pdf/src/update.rs
@@ -6,7 +6,7 @@
 use crate::error::PdfError;
 use crate::reader::{
     append_incremental_update, assert_unrotated_pages, err, find_dict_value, open_trailer,
-    parse_indirect_ref, walk_page_tree, ObjectIndex, Page, UpdatedObject,
+    read_info_source, walk_page_tree, ObjectIndex, Page, UpdatedObject,
 };
 use crate::writer::apply_producer_stamp;
 use crate::FieldSpec;
@@ -25,8 +25,9 @@ pub struct PdfUpdate {
     /// Objects to write in this revision; callers push their own onto it.
     pub objects: Vec<UpdatedObject>,
     /// `Some` when the producer stamp allocated a fresh `/Info`, which
-    /// [`finish`](PdfUpdate::finish) threads into the new trailer.
-    extra_info_ref: Option<u32>,
+    /// [`finish`](PdfUpdate::finish) makes the new trailer's `/Info`, in place
+    /// of whatever the base's trailer held.
+    new_info_ref: Option<u32>,
 }
 
 impl PdfUpdate {
@@ -49,17 +50,15 @@ impl PdfUpdate {
             .and_then(|v| std::str::from_utf8(v.trim_ascii()).ok())
             .and_then(|s| s.parse::<u32>().ok())
             .ok_or_else(|| err(CODE_PARSE, "/Size missing or malformed in trailer"))?;
-        let info_ref = find_dict_value(trailer, "Info").and_then(parse_indirect_ref);
-
         // One counter seeded at `/Size`, so created ids never collide with the
         // base's. `alloc_id` bounds it: a malformed large `/Size` errors instead
         // of handing out an id that collides or that no reference admits.
         let mut next_id = size;
         let mut objects: Vec<UpdatedObject> = Vec::new();
-        let mut extra_info_ref = None;
+        let mut new_info_ref = None;
         if let Some(producer) = producer {
-            extra_info_ref =
-                apply_producer_stamp(idx, info_ref, producer, &mut next_id, &mut objects)?;
+            let info = read_info_source(trailer);
+            new_info_ref = apply_producer_stamp(idx, info, producer, &mut next_id, &mut objects)?;
         }
 
         Ok(Self {
@@ -67,7 +66,7 @@ impl PdfUpdate {
             catalog_id,
             next_id,
             objects,
-            extra_info_ref,
+            new_info_ref,
         })
     }
 
@@ -117,8 +116,67 @@ impl PdfUpdate {
             self.xref_offset,
             self.catalog_id,
             self.next_id,
-            self.extra_info_ref,
+            self.new_info_ref,
             &self.objects,
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::reader::{find_startxref, find_trailer_dict, parse_indirect_ref};
+
+    /// A base whose whole trailer dict is `entries`, over one catalog object.
+    fn base_with_trailer(entries: &str) -> Vec<u8> {
+        let head = "%PDF-1.7\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n";
+        format!(
+            "{head}xref\n0 1\n0000000000 65535 f \ntrailer\n<< {entries} >>\n\
+             startxref\n{}\n%%EOF\n",
+            head.len()
+        )
+        .into_bytes()
+    }
+
+    fn stamped(base: &[u8]) -> Vec<u8> {
+        let idx = ObjectIndex::new(base);
+        PdfUpdate::begin(&idx, Some("Quillmark test"))
+            .expect("begin")
+            .finish(base.to_vec())
+            .expect("finish")
+    }
+
+    #[test]
+    fn a_non_reference_trailer_info_becomes_one_reference_carrying_its_entries() {
+        for (value, title) in [
+            ("<< /Title (x) >>", Some(&b"(x)"[..])),
+            ("(not a dictionary)", None),
+        ] {
+            let base = base_with_trailer(&format!("/Size 6 /Root 1 0 R /Info {value}"));
+            let out = stamped(&base);
+
+            let trailer =
+                find_trailer_dict(&out, find_startxref(&out).unwrap()).expect("new trailer");
+            assert_eq!(
+                trailer.windows(5).filter(|w| *w == b"/Info").count(),
+                1,
+                "trailer: {}",
+                String::from_utf8_lossy(trailer)
+            );
+            let (info_id, _) = find_dict_value(trailer, "Info")
+                .and_then(parse_indirect_ref)
+                .expect("/Info is an indirect reference");
+            let info = ObjectIndex::new(&out)
+                .dict(info_id, CODE_PARSE, "/Info")
+                .expect("/Info dict");
+            assert_eq!(
+                find_dict_value(info, "Producer").unwrap().trim_ascii(),
+                b"(Quillmark test)"
+            );
+            assert_eq!(
+                find_dict_value(info, "Title").map(<[u8]>::trim_ascii),
+                title
+            );
+        }
     }
 }

--- a/crates/quillmark-pdf/src/writer.rs
+++ b/crates/quillmark-pdf/src/writer.rs
@@ -5,7 +5,9 @@
 use pdf_writer::Ref;
 
 use crate::error::PdfError;
-use crate::reader::{err, find_dict_value, splice_dict_value, ObjectIndex, UpdatedObject};
+use crate::reader::{
+    err, find_dict_value, splice_dict_value, InfoSource, ObjectIndex, UpdatedObject,
+};
 
 const CODE_PARSE: &str = "pdf::write";
 
@@ -149,17 +151,17 @@ pub(crate) fn upsert_producer(info_dict: &[u8], literal: &[u8]) -> Vec<u8> {
 
 /// Stamp `/Info` `/Producer = producer`, pushing the updated or freshly created
 /// `/Info` onto `objects`. Returns `Some(info_id)` when a new `/Info` was
-/// allocated, which the caller threads into the trailer.
+/// allocated, which the caller points the new trailer at.
 pub(crate) fn apply_producer_stamp(
     idx: &ObjectIndex,
-    info_ref: Option<(u32, u16)>,
+    info: InfoSource<'_>,
     producer: &str,
     next_id: &mut u32,
     objects: &mut Vec<UpdatedObject>,
 ) -> Result<Option<u32>, PdfError> {
     let literal = pdf_text_string(producer);
-    match info_ref {
-        Some((info_id, _)) => {
+    match info {
+        InfoSource::Object(info_id) => {
             // Overwritten in place at generation 0; a non-zero-generation
             // `/Info` would be silently corrupted.
             idx.assert_overwrite_gen_zero(info_id, "/Info")?;
@@ -168,11 +170,10 @@ pub(crate) fn apply_producer_stamp(
             objects.push(dict_object(info_id, &upsert_producer(info_dict, &literal)));
             Ok(None)
         }
-        None => {
+        InfoSource::Entries(entries) => {
             let info_id = alloc_id(next_id)?;
-            let mut inner = b"/Producer ".to_vec();
-            inner.extend_from_slice(&literal);
-            objects.push(dict_object(info_id, &inner));
+            let inner = upsert_producer(entries.trim_ascii(), &literal);
+            objects.push(dict_object(info_id, inner.trim_ascii()));
             Ok(Some(info_id))
         }
     }


### PR DESCRIPTION
Closes #1506.

## The change

The issue's premise held exactly: a trailer `<< /Size 6 /Root 1 0 R /Info << /Title (x) >> >>` plus a producer stamp came out as `/Size 7 /Root 1 0 R /Info << /Title (x) >> /Info 6 0 R /Prev 58`.

`PdfUpdate::begin` now reads the trailer's `/Info` once, through `reader::read_info_source`, and hands the stamp path an `InfoSource`: `Object(id)` for an indirect reference, rewritten in place as before, or `Entries(bytes)` for anything else. `apply_producer_stamp` returns the fresh id in the second case, and `append_incremental_update` takes it as `new_info_ref`: the trailer writer either points `/Info` at the new object or copies the old value forward, never both. `/ID` is copied as it always was.

A direct-dict `/Info` is not refused. ISO 32000-1 Table 15 asks for an indirect reference and not every writer honours it, so the value is replaced rather than treated as out-of-contract input the way a second `/AcroForm` is (#1412), and its entries seed the object replacing it: `/Title` and the rest survive beside the stamped `/Producer`. A value that is neither a reference nor a dict seeds nothing and is dropped. Without a producer nothing is allocated and the trailer's `/Info` is carried forward untouched, so `flatten`'s `PdfUpdate::begin(&idx, None)` is unaffected.

## Docs

None. `ARCHITECTURE.md`'s refusal list for `quillmark-pdf` is unchanged; this adds no refusal.

## Verification

- `cargo test --workspace`: green. The new `update::tests::a_non_reference_trailer_info_becomes_one_reference_carrying_its_entries` fails on `main`'s code with `left: 2, right: 1` and the exact trailer from the issue; it stamps the issue's reproduction and a non-dict `/Info`, then parses the result back with the crate's own `find_startxref` / `find_trailer_dict` / `find_dict_value` / `ObjectIndex`.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `cargo clippy -p quillmark-pdf --all-targets`: no warnings from the crate.
- `cargo check -p quillmark-fuzz -p quillmark-pdfform --all-targets`: clean (both reach `PdfUpdate::begin`).
- No binding built: the change is Rust-side and reached by the crate's own tests.

## For review

The choice between "replace a non-reference `/Info`" and "refuse it" is the one open decision; replace is taken, with a direct dict's entries preserved. Nothing in `stamp.rs` or `flatten.rs` was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_