### PR TITLE
fix(typst,pdfform)!: page selection is one contract on every backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- fix(typst,pdfform)!: **`RenderOptions::pages` means one thing on every
+  backend, under `backend::*` codes.** The PDF-form backend ignored the option:
+  SVG and PNG rendered every page whatever was asked for, PDF returned bytes
+  instead of refusing, and an out-of-range index passed silently. It now
+  narrows SVG and PNG to the named pages, in the order given, and refuses a
+  selection for PDF. Both backends mint the two refusals from the shared
+  constructors in `quillmark_core::backend`, so the codes are
+  `backend::page_index_out_of_bounds` and
+  `backend::page_selection_not_supported` in place of the Typst-private
+  `typst::page_index_out_of_bounds` and
+  `typst::pdf_page_selection_not_supported`.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/backends/pdfform/Cargo.toml
+++ b/crates/backends/pdfform/Cargo.toml
@@ -32,5 +32,5 @@ quillmark-fixtures = { workspace = true }
 # an unpublishable cycle; cargo strips path-only dev-deps at packaging.
 quillmark = { path = "../../quillmark" }
 lopdf = { workspace = true }
-# Builds the page-tree shapes the flatten tests need but no fixture carries.
+# Builds the page-tree shapes the tests need but no fixture carries.
 pdf-writer = { workspace = true }

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -157,24 +157,28 @@ impl SessionHandle for PdfformSession {
             ));
         }
 
+        if format == OutputFormat::Pdf {
+            if opts.pages.is_some() {
+                return Err(quillmark_core::page_selection_not_supported(format));
+            }
+
+            // PDF output is always an interactive AcroForm; value-flattening
+            // backs only the raster paths, never a PDF deliverable.
+            let producer = opts.producer.clone().unwrap_or_else(default_producer);
+            let stamp_opts = StampOptions::default().with_producer(producer);
+            let stamped = stamp(self.base_pdf.clone(), &self.field_specs, &stamp_opts)?;
+
+            return Ok(RenderResult::new(
+                vec![Artifact::new(stamped, OutputFormat::Pdf)],
+                OutputFormat::Pdf,
+            ));
+        }
+
+        let pages = quillmark_core::selected_pages(opts.pages.as_deref(), self.flat.pages().len())?;
         if format == OutputFormat::Svg {
-            return self.render_svg();
+            return self.render_svg(&pages);
         }
-        if format == OutputFormat::Png {
-            let scale = opts.ppi_or_default() / 72.0;
-            return self.render_png(scale);
-        }
-
-        // PDF output is always an interactive AcroForm; value-flattening backs
-        // only the raster paths, never a PDF deliverable.
-        let producer = opts.producer.clone().unwrap_or_else(default_producer);
-        let stamp_opts = StampOptions::default().with_producer(producer);
-        let stamped = stamp(self.base_pdf.clone(), &self.field_specs, &stamp_opts)?;
-
-        Ok(RenderResult::new(
-            vec![Artifact::new(stamped, OutputFormat::Pdf)],
-            OutputFormat::Pdf,
-        ))
+        self.render_png(&pages, opts.ppi_or_default() / 72.0)
     }
 
     fn page_count(&self) -> usize {
@@ -230,18 +234,17 @@ impl SessionHandle for PdfformSession {
 }
 
 impl PdfformSession {
-    fn render_svg(&self) -> Result<RenderResult, RenderError> {
+    fn render_svg(&self, pages: &[usize]) -> Result<RenderResult, RenderError> {
         let interp = standard_font_settings();
         let svg_settings = SvgRenderSettings {
             bg_color: [255, 255, 255, 255],
         };
-        let artifacts: Vec<Artifact> = self
-            .flat
-            .pages()
+        let all = self.flat.pages();
+        let artifacts: Vec<Artifact> = pages
             .iter()
-            .map(|page| {
+            .map(|&idx| {
                 let cache = SvgCache::new();
-                let svg = hayro_svg_convert(page, &cache, &interp, &svg_settings);
+                let svg = hayro_svg_convert(&all[idx], &cache, &interp, &svg_settings);
                 Artifact::new(svg.into_bytes(), OutputFormat::Svg)
             })
             .collect();
@@ -250,12 +253,14 @@ impl PdfformSession {
     }
 
     /// `scale` is device pixels per PDF point (`ppi / 72`).
-    fn render_png(&self, scale: f32) -> Result<RenderResult, RenderError> {
+    fn render_png(&self, pages: &[usize], scale: f32) -> Result<RenderResult, RenderError> {
         let interp = standard_font_settings();
         let render_settings = scaled_render_settings(scale);
 
-        let mut artifacts = Vec::with_capacity(self.flat.pages().len());
-        for page in self.flat.pages().iter() {
+        let all = self.flat.pages();
+        let mut artifacts = Vec::with_capacity(pages.len());
+        for &idx in pages {
+            let page = &all[idx];
             let cache = RenderCache::new();
             let pixmap = hayro_render(page, &cache, &interp, &render_settings);
             let png = pixmap.into_png().map_err(|e| {

--- a/crates/backends/pdfform/tests/render_formats.rs
+++ b/crates/backends/pdfform/tests/render_formats.rs
@@ -1,7 +1,9 @@
 //! SVG and PNG are views of the *flattened* form — values baked into the page
 //! content — so they render without viewer appearance synthesis.
 
-use quillmark::{Document, OutputFormat, Quillmark, RenderOptions};
+use pdf_writer::{Pdf, Rect, Ref};
+use quillmark::{Document, FileTreeNode, OutputFormat, Quill, Quillmark, RenderOptions};
+use quillmark_core::RenderError;
 
 const FILLED: &str = "~~~\n\
 $quill: sample_form\n\
@@ -49,5 +51,124 @@ fn renders_png_per_page() {
             "artifact must carry the PNG signature"
         );
     }
+}
+
+/// Two widgets, one per page, so a bound field exercises each page box.
+const TWO_PAGE_FORM_JSON: &str = r#"{
+  "schema": "quillmark/form@0.2.0",
+  "fields": [
+    {
+      "name": "FullName",
+      "schema_field": "full_name",
+      "page": 0,
+      "rect": { "x": 180, "y": 100, "w": 340, "h": 20 }
+    },
+    {
+      "name": "Comments",
+      "schema_field": "comments",
+      "page": 1,
+      "rect": { "x": 180, "y": 140, "w": 340, "h": 80 }
+    }
+  ]
+}"#;
+
+/// Two US-Letter pages drawing a rule at different heights, so one page's ink
+/// never matches the other's.
+fn two_page_background() -> Vec<u8> {
+    let letter = Rect::new(0.0, 0.0, 612.0, 792.0);
+    let mut pdf = Pdf::new();
+    pdf.catalog(Ref::new(1)).pages(Ref::new(2));
+    pdf.pages(Ref::new(2))
+        .kids([Ref::new(3), Ref::new(5)])
+        .count(2)
+        .media_box(letter);
+    pdf.page(Ref::new(3))
+        .parent(Ref::new(2))
+        .media_box(letter)
+        .contents(Ref::new(4));
+    pdf.stream(Ref::new(4), b"0.75 w 180 672 340 20 re S");
+    pdf.page(Ref::new(5))
+        .parent(Ref::new(2))
+        .media_box(letter)
+        .contents(Ref::new(6));
+    pdf.stream(Ref::new(6), b"0.75 w 180 472 340 20 re S");
+    pdf.finish()
+}
+
+/// The fixture quill on a two-page background: page selection needs a document
+/// with more than one page to select from.
+fn two_page_quill() -> Quill {
+    let mut tree = quillmark::tree_from_path(quillmark_fixtures::quills_path("sample_form"))
+        .expect("load sample_form tree");
+    tree.insert(
+        "form.pdf",
+        FileTreeNode::File {
+            contents: two_page_background(),
+        },
+    )
+    .expect("replace form.pdf");
+    tree.insert(
+        "form.json",
+        FileTreeNode::File {
+            contents: TWO_PAGE_FORM_JSON.as_bytes().to_vec(),
+        },
+    )
+    .expect("replace form.json");
+    Quill::from_tree(tree).expect("load two-page quill")
+}
+
+fn render_two_page(
+    format: OutputFormat,
+    pages: Option<Vec<usize>>,
+) -> Result<quillmark::RenderResult, RenderError> {
+    let quill = two_page_quill();
+    let doc = Document::parse(FILLED).expect("parse markdown").document;
+    let mut opts = RenderOptions::default().with_output_format(format);
+    opts.pages = pages;
+    Quillmark::new().render(&quill, &doc, &opts)
+}
+
+fn refusal_code(format: OutputFormat, pages: Vec<usize>) -> String {
+    let err = render_two_page(format, Some(pages)).expect_err("the selection is refused");
+    err.diagnostics()[0]
+        .code
+        .clone()
+        .expect("a refusal carries its code")
+}
+
+#[test]
+fn page_selection_narrows_raster_output_to_the_named_page() {
+    for format in [OutputFormat::Svg, OutputFormat::Png] {
+        let whole = render_two_page(format, None).expect("render whole document");
+        assert_eq!(whole.artifacts.len(), 2, "{format:?}: one artifact per page");
+
+        let first = render_two_page(format, Some(vec![0])).expect("render page 0");
+        let second = render_two_page(format, Some(vec![1])).expect("render page 1");
+        assert_eq!(first.artifacts.len(), 1, "{format:?}: one page selected");
+        assert_eq!(second.artifacts.len(), 1, "{format:?}: one page selected");
+        assert_ne!(
+            first.artifacts[0].bytes, second.artifacts[0].bytes,
+            "{format:?}: the selection renders the named page, not always the first"
+        );
+    }
+}
+
+#[test]
+fn a_page_past_the_form_is_refused() {
+    for format in [OutputFormat::Svg, OutputFormat::Png] {
+        assert_eq!(
+            refusal_code(format, vec![2]),
+            "backend::page_index_out_of_bounds",
+            "{format:?}"
+        );
+    }
+}
+
+#[test]
+fn pdf_refuses_a_page_selection() {
+    assert_eq!(
+        refusal_code(OutputFormat::Pdf, vec![0]),
+        "backend::page_selection_not_supported"
+    );
 }
 

--- a/crates/backends/typst/src/compile.rs
+++ b/crates/backends/typst/src/compile.rs
@@ -11,7 +11,10 @@ use typst_svg::SvgOptions;
 use crate::error_mapping::map_typst_errors;
 use crate::overlay;
 use crate::world::QuillWorld;
-use quillmark_core::{Artifact, Diagnostic, OutputFormat, RenderError, RenderResult};
+use quillmark_core::{
+    page_selection_not_supported, selected_pages, Artifact, Diagnostic, OutputFormat, RenderError,
+    RenderResult,
+};
 use quillmark_pdf::{stamp, FieldSpec, StampOptions};
 
 pub(crate) fn render_options(pixel_per_pt: f32) -> RenderOptions {
@@ -51,29 +54,10 @@ pub(crate) fn render_document_pages(
     producer: Option<&str>,
 ) -> Result<RenderResult, RenderError> {
     if format == OutputFormat::Pdf && pages.is_some() {
-        return Err(RenderError::coded(
-            "typst::pdf_page_selection_not_supported",
-            "PDF does not support page selection; pass null/None to render the full document, or use PNG/SVG",
-        ));
+        return Err(page_selection_not_supported(format));
     }
 
-    let page_count = document.pages().len();
-    let selected_indices: Vec<usize> = match pages {
-        Some(slice) => {
-            let out_of_bounds: Vec<usize> =
-                slice.iter().copied().filter(|&i| i >= page_count).collect();
-            if !out_of_bounds.is_empty() {
-                return Err(RenderError::coded(
-                    "typst::page_index_out_of_bounds",
-                    format!(
-                        "Page index out of bounds (page_count={page_count}); offending indices: {out_of_bounds:?}. Check `LiveSession.pageCount` before requesting pages."
-                    ),
-                ));
-            }
-            slice.to_vec()
-        }
-        None => (0..page_count).collect(),
-    };
+    let selected_indices = selected_pages(pages, document.pages().len())?;
 
     match format {
         OutputFormat::Svg => {

--- a/crates/backends/typst/tests/page_selection.rs
+++ b/crates/backends/typst/tests/page_selection.rs
@@ -1,0 +1,67 @@
+//! `RenderOptions::pages` is backend-neutral: this backend answers it under the
+//! same `backend::*` codes the PDF-form backend does.
+
+use quillmark_core::{Backend, LiveSession, OutputFormat, RenderOptions};
+use quillmark_typst::TypstBackend;
+use serde_json::json;
+
+mod common;
+
+const PLATE: &str = r#"#import "@local/quillmark-helper:0.1.0": data
+#set page(width: 300pt, height: 200pt, margin: 20pt)
+#data.at("msg")
+#pagebreak()
+second
+"#;
+
+fn session() -> LiveSession {
+    let yaml = "quill:\n  name: pages\n  version: 0.1.0\n  backend: typst\n  description: page-selection acceptance quill\n\ntypst:\n  plate_file: plate.typ\n\nmain:\n  fields:\n    msg:\n      description: message\n      type: string\n";
+    TypstBackend
+        .open(
+            &common::quill_with_plate(yaml, PLATE),
+            &json!({ "msg": "first" }),
+        )
+        .expect("open")
+}
+
+fn refusal_code(format: OutputFormat, pages: Vec<usize>) -> String {
+    let mut opts = RenderOptions::default().with_output_format(format);
+    opts.pages = Some(pages);
+    let err = session()
+        .render(&opts)
+        .expect_err("the selection is refused");
+    err.diagnostics()[0]
+        .code
+        .clone()
+        .expect("a refusal carries its code")
+}
+
+#[test]
+fn page_selection_narrows_svg_to_the_named_page() {
+    let session = session();
+    assert_eq!(session.page_count(), 2, "the plate breaks onto a second page");
+
+    let mut opts = RenderOptions::default().with_output_format(OutputFormat::Svg);
+    opts.pages = Some(vec![1]);
+    let selected = session.render(&opts).expect("render page 1");
+    assert_eq!(selected.artifacts.len(), 1);
+
+    opts.pages = None;
+    assert_eq!(session.render(&opts).expect("render whole").artifacts.len(), 2);
+}
+
+#[test]
+fn a_page_past_the_document_is_refused() {
+    assert_eq!(
+        refusal_code(OutputFormat::Svg, vec![2]),
+        "backend::page_index_out_of_bounds"
+    );
+}
+
+#[test]
+fn pdf_refuses_a_page_selection() {
+    assert_eq!(
+        refusal_code(OutputFormat::Pdf, vec![0]),
+        "backend::page_selection_not_supported"
+    );
+}

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -328,8 +328,8 @@ pub struct RenderOptions {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ppi: Option<f32>,
     /// 0-based page indices to render; `undefined` renders all pages. An index
-    /// `>= pageCount` throws `typst::page_index_out_of_bounds`. Not supported
-    /// for PDF output: throws `typst::pdf_page_selection_not_supported`.
+    /// `>= pageCount` throws `backend::page_index_out_of_bounds`. Not supported
+    /// for PDF output: throws `backend::page_selection_not_supported`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pages: Option<Vec<usize>>,
     /// PDF `/Info` `/Producer` override; defaults to `Quillmark <version>`.

--- a/crates/core/src/backend.rs
+++ b/crates/core/src/backend.rs
@@ -51,6 +51,57 @@ pub fn unsupported_format(format: OutputFormat, backend: &str, supported: &[Outp
     )
 }
 
+/// The pages a render covers: `pages` as given, or every page of `page_count`
+/// when it is `None`. An index at or past `page_count` fails under
+/// `backend::page_index_out_of_bounds`, naming every offending index.
+///
+/// The indices come back as given: order and repeats are the caller's.
+pub fn selected_pages(
+    pages: Option<&[usize]>,
+    page_count: usize,
+) -> Result<Vec<usize>, RenderError> {
+    let Some(requested) = pages else {
+        return Ok((0..page_count).collect());
+    };
+
+    let out_of_bounds: Vec<usize> = requested
+        .iter()
+        .copied()
+        .filter(|&i| i >= page_count)
+        .collect();
+    if !out_of_bounds.is_empty() {
+        return Err(RenderError::from_diag(
+            crate::Diagnostic::new(
+                crate::Severity::Error,
+                format!(
+                    "Page index out of bounds (page_count={page_count}); offending indices: {out_of_bounds:?}"
+                ),
+            )
+            .with_code("backend::page_index_out_of_bounds".to_string())
+            .with_hint("Read the session's page count before requesting pages.".to_string()),
+        ));
+    }
+
+    Ok(requested.to_vec())
+}
+
+/// The refusal a backend owes a `pages` selection on a format it emits whole,
+/// under `backend::page_selection_not_supported`. `format` names it in the
+/// message.
+pub fn page_selection_not_supported(format: OutputFormat) -> RenderError {
+    RenderError::from_diag(
+        crate::Diagnostic::new(
+            crate::Severity::Error,
+            format!("{format:?} output does not support page selection"),
+        )
+        .with_code("backend::page_selection_not_supported".to_string())
+        .with_hint(
+            "Drop the page selection to render the whole document, or ask for a per-page format."
+                .to_string(),
+        ),
+    )
+}
+
 /// Pre-session hint for whether a backend with these `formats` can paint pages
 /// to a canvas, used before a session exists (e.g. a GUI deciding whether to
 /// mount a canvas preview without first paying to open one).
@@ -71,6 +122,22 @@ pub fn formats_support_canvas(formats: &[OutputFormat]) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn no_selection_covers_every_page_and_a_selection_is_taken_verbatim() {
+        assert_eq!(selected_pages(None, 3).unwrap(), [0, 1, 2]);
+        assert_eq!(selected_pages(None, 0).unwrap(), [] as [usize; 0]);
+        assert_eq!(selected_pages(Some(&[2, 0, 0]), 3).unwrap(), [2, 0, 0]);
+    }
+
+    #[test]
+    fn a_page_past_the_document_is_refused() {
+        let err = selected_pages(Some(&[0, 3]), 3).unwrap_err();
+        assert_eq!(
+            err.diagnostics()[0].code.as_deref(),
+            Some("backend::page_index_out_of_bounds")
+        );
+    }
 
     #[test]
     fn formats_support_canvas_keys_off_visual_formats() {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -34,7 +34,10 @@ pub mod reader;
 pub use reader::{CardReader, TypedReader};
 
 pub mod backend;
-pub use backend::{formats_support_canvas, unsupported_format, Backend};
+pub use backend::{
+    formats_support_canvas, page_selection_not_supported, selected_pages, unsupported_format,
+    Backend,
+};
 
 pub mod error;
 pub use error::{

--- a/crates/core/src/types.rs
+++ b/crates/core/src/types.rs
@@ -163,11 +163,10 @@ pub struct RenderOptions {
     /// Optional 0-based page indices to render (e.g., `vec![0, 2]` for
     /// the first and third pages). `None` renders all pages. Any index
     /// `>= page_count` fails with a `RenderError` carrying the
-    /// `typst::page_index_out_of_bounds` code: call
-    /// `LiveSession::page_count()` first if validation is needed.
-    /// Backends that do not support page selection (notably PDF) fail with a
-    /// `RenderError` carrying `typst::pdf_page_selection_not_supported` when
-    /// this is `Some`.
+    /// `backend::page_index_out_of_bounds` code: call
+    /// `LiveSession::page_count()` first if validation is needed. A format the
+    /// backend emits whole — PDF on both built-in backends — fails with
+    /// `backend::page_selection_not_supported` when this is `Some`.
     pub pages: Option<Vec<usize>>,
     /// Override for the PDF `/Info` `/Producer` metadata string. `None` uses
     /// the backend default (`Quillmark <version>` for the Typst backend).

--- a/docs/quills/pdfform-backend.md
+++ b/docs/quills/pdfform-backend.md
@@ -233,6 +233,11 @@ The backend's formats are `[Pdf, Svg, Png]`: every `OutputFormat` there is. A
 format added to the enum and not to this backend errors with
 `backend::format_not_supported`, the code both built-in backends share.
 
+`RenderOptions::pages` narrows SVG and PNG to the named pages, in the order
+given; an index past the form's last page errors with
+`backend::page_index_out_of_bounds`. PDF is emitted whole, so a selection there
+errors with `backend::page_selection_not_supported`.
+
 **Canvas** is a separate surface from the `render()` output formats above: it is
 the WASM `paint()` raster path (`render_rgba`), not an `OutputFormat`. See
 [PREVIEW.md](https://github.com/borb-sh/quillmark/blob/main/prose/canon/PREVIEW.md).

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -57,6 +57,10 @@ for a backend session that does not override the incremental-`update` seam
 (both built-in backends override it); `backend::format_not_supported`: the
 requested format is outside the backend's `supported_formats`, one code on
 every backend so a caller matches the condition once;
+`backend::page_index_out_of_bounds` / `backend::page_selection_not_supported`:
+a `RenderOptions::pages` selection naming a page the document does not have, or
+asked of a format the backend emits whole (PDF on both built-in backends), both
+minted by the shared constructors in `crates/core/src/backend.rs`;
 `engine::backend_not_found`: the quill's declared backend is not registered.
 
 **`edit::*`: mutator diagnostics.** Document and card mutators fail with the


### PR DESCRIPTION
Closes #1476.

## The change

The issue's premise held: pdfform's `render` never read `opts.pages`, and `RenderOptions::pages` named two Typst-private codes as its contract.

`quillmark_core::backend` now owns both refusals, beside `unsupported_format`. `selected_pages(pages, page_count)` resolves a request: `None` covers every page, a selection comes back verbatim (order and repeats are the caller's), an index at or past `page_count` fails under `backend::page_index_out_of_bounds`. `page_selection_not_supported(format)` is what a format emitted whole owes a selection. Hoisting the resolution rather than only the code constructors is what stops the two backends carrying two copies of the bounds check.

Both backends call them. pdfform narrows SVG and PNG to the named pages and refuses a selection for PDF; Typst keeps its behaviour and loses its two private codes. The selection is bounded by the pages being indexed, so it can never index past them.

Neither code carries args, as neither did before, so the ERROR.md args table is untouched and `diagnostic_args_match_canon` is unaffected.

## Docs

`RenderOptions::pages` (core and the WASM mirror) states the neutral codes and the rule. ERROR.md's notable-codes list carries the pair and points at the shared constructors. `docs/quills/pdfform-backend.md` states what pdfform now does with a selection.

## Verification

- `cargo test --workspace`: green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: canon spine OK.
- `cargo clippy` on core, pdfform and typst: no warning in a changed file.
- New tests: pdfform renders a two-page form (the `sample_form` tree on a `pdf-writer` background, one widget per page); a selection yields one artifact per named page and page 0's bytes differ from page 1's, an index past the form is refused, and PDF refuses a selection. Typst gets the same three against a plate that breaks onto a second page. Core unit-tests the resolution itself.
- No binding suite was built: no binding test pinned the old codes, and the only binding edit is a doc comment (the WASM typecheck is a structural drift guard). CI runs both.

## For review

The migration guide `docs/migrations/0.112-to-0.113.md` is not touched. A diagnostic-code rename is the kind of break the guide is meant to lead with, but the guide is framed around four document-surface changes and the last `!` commit on main (`Retire MAX_YAML_DEPTH`) likewise left it for release assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_