### PR TITLE
fix(pdfform)!: measure canvas geometry from the page's canvas box

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- fix(pdfform)!: **canvas geometry measures from the page's canvas box.** hayro
+  rasterizes `/CropBox` ∩ `/MediaBox` and draws that box's lower-left corner at
+  the raster's origin, while `page_size_pt` reported the `/MediaBox` extent and
+  `regions()` reported widget `/Rect`s in raw user space. An overlay over a
+  `pdfcrop`ped background (`/MediaBox [96 133 500 700]`) therefore sat 96 × 133
+  pt off its ink, and a `/CropBox` inside the MediaBox reported a page bigger
+  than its own raster. `page_size_pt` is the canvas box's extent, `regions()`
+  subtracts its lower-left corner, and `form.json`'s top-left rects flip against
+  it, so `pageSize`, `regions`, the point queries, and the raster share one
+  origin. Values move only on a page whose canvas box does not start at
+  `(0, 0)`: a background on `[0 0 W H]` with no `/CropBox` reports what it always
+  did. The stamped PDF's widget `/Rect`s stay in user space.
+  `quillmark_pdf::page_media_boxes` is `page_canvas_boxes`, and it refuses a
+  canvas box under a point per side (`pdf::degenerate_page_box`) and a page box
+  that is not a direct array of numbers.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/backends/pdfform/src/bind.rs
+++ b/crates/backends/pdfform/src/bind.rs
@@ -92,14 +92,14 @@ impl std::fmt::Display for BindError {
 pub fn bind_widgets(
     spec: &FormSpec,
     config: &QuillConfig,
-    page_boxes: &[[f32; 4]],
+    canvas_boxes: &[[f32; 4]],
 ) -> Result<Vec<BoundWidget>, BindError> {
     let mut bound = Vec::with_capacity(spec.fields.len() + spec.widgets.len());
     for field in &spec.fields {
-        bound.push(bind_field(field, config, page_boxes)?);
+        bound.push(bind_field(field, config, canvas_boxes)?);
     }
     for widget in &spec.widgets {
-        bound.push(bind_unbound(widget, page_boxes)?);
+        bound.push(bind_unbound(widget, canvas_boxes)?);
     }
     Ok(bound)
 }
@@ -108,7 +108,7 @@ pub fn bind_widgets(
 fn bind_field(
     field: &BoundField,
     config: &QuillConfig,
-    page_boxes: &[[f32; 4]],
+    canvas_boxes: &[[f32; 4]],
 ) -> Result<BoundWidget, BindError> {
     let schema = bind(config, &field.name, &field.schema_field)?;
     let field_type = project_kind(schema, &field.name, &field.schema_field)?;
@@ -120,7 +120,7 @@ fn bind_field(
         name: field.name.clone(),
         schema_field: Some(field.schema_field.clone()),
         page: field.page,
-        rect: place(&field.name, field.page, field.rect, page_boxes)?,
+        rect: place(&field.name, field.page, field.rect, canvas_boxes)?,
         field_type,
         tooltip,
     })
@@ -128,13 +128,13 @@ fn bind_field(
 
 fn bind_unbound(
     widget: &UnboundWidget,
-    page_boxes: &[[f32; 4]],
+    canvas_boxes: &[[f32; 4]],
 ) -> Result<BoundWidget, BindError> {
     Ok(BoundWidget {
         name: widget.name.clone(),
         schema_field: None,
         page: widget.page,
-        rect: place(&widget.name, widget.page, widget.rect, page_boxes)?,
+        rect: place(&widget.name, widget.page, widget.rect, canvas_boxes)?,
         field_type: widget_type(&widget.kind),
         tooltip: widget.tooltip.clone(),
     })
@@ -144,22 +144,26 @@ fn place(
     name: &str,
     page: usize,
     rect: Rect,
-    page_boxes: &[[f32; 4]],
+    canvas_boxes: &[[f32; 4]],
 ) -> Result<[f32; 4], BindError> {
-    let media_box = page_boxes.get(page).ok_or_else(|| BindError::PageOutOfRange {
-        name: name.to_string(),
-        page,
-        page_count: page_boxes.len(),
-    })?;
-    Ok(flip_rect(rect, *media_box))
+    let canvas_box = canvas_boxes
+        .get(page)
+        .ok_or_else(|| BindError::PageOutOfRange {
+            name: name.to_string(),
+            page,
+            page_count: canvas_boxes.len(),
+        })?;
+    Ok(flip_rect(rect, *canvas_box))
 }
 
 /// Page-relative top-left `{x,y,w,h}` → bottom-left `[x0, y0, x1, y1]` in PDF
-/// user space. Origins come from the MediaBox, not `(0,0)`, so a translated
-/// MediaBox (e.g. `[10 20 622 812]`) does not shift widgets by its origin.
-fn flip_rect(r: Rect, media_box: [f32; 4]) -> [f32; 4] {
-    let left = media_box[0];
-    let top = media_box[3];
+/// user space. `x`/`y` measure from the corner of the page a viewer displays, so
+/// they flip against the canvas box (`/CropBox` ∩ `/MediaBox`): on a page whose
+/// canvas starts at `[10 20 622 812]`, a widget lands 10 pt right and 20 pt up of
+/// where user-space `(0,0)` would put it.
+fn flip_rect(r: Rect, canvas_box: [f32; 4]) -> [f32; 4] {
+    let left = canvas_box[0];
+    let top = canvas_box[3];
     [left + r.x, top - (r.y + r.h), left + r.x + r.w, top - r.y]
 }
 
@@ -624,7 +628,7 @@ main:
             place("W", 0, r, &[[0.0, 0.0, 600.0, 800.0]]).unwrap(),
             [180.0, 800.0 - 104.0, 194.0, 800.0 - 90.0]
         );
-        // Translated MediaBox: widgets land offset by the origin.
+        // Translated canvas box: widgets land offset by the origin.
         assert_eq!(
             place("W", 0, r, &[[10.0, 20.0, 622.0, 812.0]]).unwrap(),
             [10.0 + 180.0, 812.0 - 104.0, 10.0 + 194.0, 812.0 - 90.0]

--- a/crates/backends/pdfform/src/lib.rs
+++ b/crates/backends/pdfform/src/lib.rs
@@ -78,11 +78,11 @@ impl Backend for PdfformBackend {
         let spec = FormSpec::parse(form_json)
             .map_err(|e| RenderError::coded(e.code(), e.to_string()))?;
 
-        // Page boxes drive the top-left → bottom-left flip (honouring a
-        // non-zero page origin), and reading them surfaces a malformed base early.
-        let page_boxes = quillmark_pdf::page_media_boxes(&base_pdf)?;
+        // Canvas boxes drive the top-left → bottom-left flip and the canvas
+        // coordinate space, and reading them surfaces a malformed base early.
+        let canvas_boxes = quillmark_pdf::page_canvas_boxes(&base_pdf)?;
 
-        let bound = bind::bind_widgets(&spec, source.config(), &page_boxes)
+        let bound = bind::bind_widgets(&spec, source.config(), &canvas_boxes)
             .map_err(|e| RenderError::coded(e.code(), e.to_string()))?;
 
         let field_specs = resolve_field_specs(&bound, json_data);
@@ -94,7 +94,7 @@ impl Backend for PdfformBackend {
                 base_pdf,
                 bound,
                 field_specs,
-                page_boxes,
+                canvas_boxes,
                 flat,
             }),
             source.config().clone(),
@@ -139,8 +139,10 @@ struct PdfformSession {
     base_pdf: Vec<u8>,
     bound: Vec<BoundWidget>,
     field_specs: Vec<FieldSpec>,
-    /// Cached so `page_size_pt` need not reparse.
-    page_boxes: Vec<[f32; 4]>,
+    /// Per page, `/CropBox` ∩ `/MediaBox`: the box hayro rasterizes, whose
+    /// lower-left corner is the canvas origin. Cached so `page_size_pt` need not
+    /// reparse.
+    canvas_boxes: Vec<[f32; 4]>,
     /// The base with `field_specs` baked in, parsed: the render paths hold
     /// pages rather than bytes to reparse per paint.
     flat: HayroPdf,
@@ -178,11 +180,11 @@ impl SessionHandle for PdfformSession {
     }
 
     fn page_count(&self) -> usize {
-        self.page_boxes.len()
+        self.canvas_boxes.len()
     }
 
     fn page_size_pt(&self, page: usize) -> Option<(f32, f32)> {
-        let [x0, y0, x1, y1] = *self.page_boxes.get(page)?;
+        let [x0, y0, x1, y1] = *self.canvas_boxes.get(page)?;
         Some((x1 - x0, y1 - y0))
     }
 
@@ -202,8 +204,19 @@ impl SessionHandle for PdfformSession {
         Some((w, h, bytes))
     }
 
+    /// A widget's `/Rect` is user space, which starts at the canvas box's
+    /// lower-left corner rather than at `(0, 0)`; the raster puts that corner at
+    /// the origin, so a region measures from it.
     fn regions(&self) -> Vec<RenderedRegion> {
-        regions_of(&self.field_specs)
+        let mut regions = regions_of(&self.field_specs);
+        for region in &mut regions {
+            let Some([x0, y0, ..]) = self.canvas_boxes.get(region.page) else {
+                continue;
+            };
+            let [rx0, ry0, rx1, ry1] = region.rect;
+            region.rect = [rx0 - x0, ry0 - y0, rx1 - x0, ry1 - y0];
+        }
+        regions
     }
 
     /// Specs and flat PDF swap together only after both succeed. The background
@@ -225,7 +238,7 @@ impl SessionHandle for PdfformSession {
         self.field_specs = field_specs;
         self.flat = flat;
 
-        Ok(ChangeSet::new(self.page_boxes.len(), dirty_pages))
+        Ok(ChangeSet::new(self.canvas_boxes.len(), dirty_pages))
     }
 }
 

--- a/crates/backends/pdfform/tests/canvas_conformance.rs
+++ b/crates/backends/pdfform/tests/canvas_conformance.rs
@@ -1,13 +1,16 @@
-//! Headless proof that the pdfform canvas raster is complete: the canvas
-//! contract (`prose/canon/PREVIEW.md`) requires a session returning `Some` from
-//! `render_rgba` to bake every piece of page content, field values included,
-//! into the pixels with no caller-side compositing.
+//! Headless proof that the pdfform canvas raster is complete and that region
+//! geometry lands on it: the canvas contract (`prose/canon/PREVIEW.md`) requires
+//! a session returning `Some` from `render_rgba` to bake every piece of page
+//! content, field values included, into the pixels with no caller-side
+//! compositing, and `page_size_pt` / `regions` to measure from the raster's own
+//! origin — the lower-left corner of the page's canvas box.
 //!
 //! Region geometry is in PDF points (bottom-left origin) and the raster is
 //! top-left device pixels, so locating a field box needs the canonical
 //! `y_canvas = (pageHeightPt - y_pdf) × scale` flip.
 
-use quillmark::{Document, Quillmark};
+use pdf_writer::{Content, Finish, Name, Pdf, Rect, Ref};
+use quillmark::{Document, FileTreeNode, Quill, Quillmark};
 
 const FILLED: &str = "~~~\n\
 $quill: sample_form\n\
@@ -98,4 +101,134 @@ fn pdfform_canvas_raster_is_complete() {
         ink > 0,
         "field region box must contain non-white opaque pixels"
     );
+}
+
+#[test]
+fn a_translated_media_box_keeps_page_geometry_on_the_ink() {
+    geometry_lands_on_the_ink(blank_page(NARROW_LETTER, None));
+}
+
+#[test]
+fn a_crop_box_keeps_page_geometry_on_the_ink() {
+    geometry_lands_on_the_ink(blank_page([0.0, 0.0, 612.0, 792.0], Some(NARROW_LETTER)));
+}
+
+/// A `pdfcrop`-style page box, its lower-left corner away from user-space
+/// `(0, 0)`.
+const NARROW_LETTER: [f32; 4] = [96.0, 133.0, 500.0, 700.0];
+
+/// One text widget on an otherwise blank page, so every non-white pixel in the
+/// raster is the field's flattened value: the reported page size must be the
+/// raster's, and the field's region must be the box that value drew in.
+fn geometry_lands_on_the_ink(form_pdf: Vec<u8>) {
+    const FORM_JSON: &str = r#"{
+      "schema": "quillmark/form@0.2.0",
+      "fields": [
+        {
+          "name": "FullName",
+          "schema_field": "full_name",
+          "page": 0,
+          "rect": { "x": 180, "y": 90, "w": 200, "h": 20 }
+        }
+      ]
+    }"#;
+
+    let mut tree = quillmark::tree_from_path(quillmark_fixtures::quills_path("sample_form"))
+        .expect("load sample_form tree");
+    tree.insert(
+        "form.pdf",
+        FileTreeNode::File { contents: form_pdf },
+    )
+    .expect("replace form.pdf");
+    tree.insert(
+        "form.json",
+        FileTreeNode::File {
+            contents: FORM_JSON.as_bytes().to_vec(),
+        },
+    )
+    .expect("replace form.json");
+
+    let quill = Quill::from_tree(tree).expect("load patched quill");
+    let doc = Document::parse(FILLED).expect("parse markdown").document;
+    let session = Quillmark::new().open(&quill, &doc).expect("open session");
+
+    let scale: f32 = 2.0;
+    let (width_pt, height_pt) = session.page_size_pt(0).expect("page 0 size");
+    let (px_w, px_h, rgba) = session.render_rgba(0, scale).expect("rasterize page 0");
+
+    assert!(
+        (px_w as i64 - (width_pt * scale).round() as i64).abs() <= 1
+            && (px_h as i64 - (height_pt * scale).round() as i64).abs() <= 1,
+        "raster {px_w}x{px_h} should match page_size_pt {width_pt}x{height_pt} × {scale}"
+    );
+
+    let region = session
+        .regions()
+        .into_iter()
+        .find(|r| r.page == 0 && r.field == "full_name")
+        .expect("a region for the bound text field");
+    let [x0, y0, x1, y1] = region.rect;
+    let box_px = (
+        (x0 * scale).floor() as i64,
+        ((height_pt - y1) * scale).floor() as i64,
+        (x1 * scale).ceil() as i64,
+        ((height_pt - y0) * scale).ceil() as i64,
+    );
+
+    let ink = ink_bounds(&rgba, px_w, px_h).expect("the field value draws ink");
+    assert!(
+        ink.0 >= box_px.0 && ink.1 >= box_px.1 && ink.2 <= box_px.2 && ink.3 <= box_px.3,
+        "ink at {ink:?} must lie inside the field's region box {box_px:?} in {px_w}x{px_h}"
+    );
+}
+
+/// The `(left, top, right, bottom)` pixel bounds of every non-white opaque
+/// pixel, or `None` when the raster is blank.
+fn ink_bounds(rgba: &[u8], px_w: u32, px_h: u32) -> Option<(i64, i64, i64, i64)> {
+    let mut bounds: Option<(i64, i64, i64, i64)> = None;
+    for y in 0..px_h as i64 {
+        for x in 0..px_w as i64 {
+            let i = ((y as usize) * (px_w as usize) + (x as usize)) * 4;
+            let (r, g, b, a) = (rgba[i], rgba[i + 1], rgba[i + 2], rgba[i + 3]);
+            if a == 255 && (r < 250 || g < 250 || b < 250) {
+                bounds = Some(match bounds {
+                    None => (x, y, x + 1, y + 1),
+                    Some((l, t, rt, bt)) => (l.min(x), t.min(y), rt.max(x + 1), bt.max(y + 1)),
+                });
+            }
+        }
+    }
+    bounds
+}
+
+/// A one-page background drawing nothing, with `media` as its `/MediaBox` and
+/// `crop` as its `/CropBox` when given.
+fn blank_page(media: [f32; 4], crop: Option<[f32; 4]>) -> Vec<u8> {
+    let mut pdf = Pdf::new();
+    let catalog_id = Ref::new(1);
+    let page_tree_id = Ref::new(2);
+    let page_id = Ref::new(3);
+    let content_id = Ref::new(4);
+    let media = Rect::new(media[0], media[1], media[2], media[3]);
+
+    pdf.catalog(catalog_id).pages(page_tree_id);
+    pdf.pages(page_tree_id)
+        .kids([page_id])
+        .count(1)
+        .media_box(media)
+        .finish();
+    {
+        let mut page = pdf.page(page_id);
+        page.parent(page_tree_id)
+            .media_box(media)
+            .contents(content_id);
+        if let Some(c) = crop {
+            page.pair(
+                Name(b"CropBox"),
+                Rect::new(c[0], c[1], c[2], c[3]),
+            );
+        }
+    }
+    pdf.stream(content_id, &Content::new().finish());
+    pdf.finish()
 }

--- a/crates/core/src/region.rs
+++ b/crates/core/src/region.rs
@@ -42,8 +42,12 @@
 
 /// One schema field placement's extent on a rendered page.
 ///
-/// `rect` is `[x0, y0, x1, y1]` in PDF points with a **bottom-left** origin:
-/// the same geometry the stamp spine writes to the widget `/Rect`.
+/// `rect` is `[x0, y0, x1, y1]` in PDF points with a **bottom-left** origin: the
+/// lower-left corner of the page as drawn, which is also the origin of the page
+/// raster and of [`page_size_pt`](crate::LiveSession::page_size_pt). On a PDF
+/// background that corner is the page's canvas box (`/CropBox` ∩ `/MediaBox`)
+/// rather than user-space `(0, 0)`, so a widget's `/Rect` in the stamped PDF and
+/// its region here differ by that box's origin.
 ///
 /// `field` is **not** unique within a region set: a content field breaks into
 /// one entry per segment and per page, a scalar referenced at several plate

--- a/crates/core/src/session.rs
+++ b/crates/core/src/session.rs
@@ -49,6 +49,13 @@ pub trait SessionHandle: Send + Sync + 'static {
     /// range. The canvas-preview seam: a backend that can rasterize pages
     /// overrides this and [`render_rgba`](Self::render_rgba). Default `None`
     /// marks the session as having no canvas painter.
+    ///
+    /// One coordinate space serves the three canvas reads: the page's lower-left
+    /// corner is the origin of this extent, of [`regions`](Self::regions), and of
+    /// the [`render_rgba`](Self::render_rgba) raster, whose size is this extent
+    /// times its `scale`. A backend drawing on a page whose own coordinates start
+    /// elsewhere (a PDF background with a `/CropBox` or a translated
+    /// `/MediaBox`) reports geometry relative to that corner.
     fn page_size_pt(&self, _page: usize) -> Option<(f32, f32)> {
         None
     }

--- a/crates/fuzz/src/pdf_fuzz.rs
+++ b/crates/fuzz/src/pdf_fuzz.rs
@@ -15,7 +15,7 @@ use std::sync::LazyLock;
 
 use proptest::prelude::*;
 use quillmark_pdf::{
-    page_media_boxes, reader::ObjectIndex, stamp, FieldSpec, FieldType, PdfUpdate, StampOptions,
+    page_canvas_boxes, reader::ObjectIndex, stamp, FieldSpec, FieldType, PdfUpdate, StampOptions,
 };
 
 /// A real AcroForm the spine accepts, so a mutant of it exercises parse paths a
@@ -45,7 +45,7 @@ fn every_field_kind() -> Vec<FieldSpec> {
 
 /// Drive every byte-taking entry point once; completing at all is the property.
 fn exercise(pdf: &[u8]) {
-    let _ = page_media_boxes(pdf);
+    let _ = page_canvas_boxes(pdf);
     let idx = ObjectIndex::new(pdf);
     let _ = PdfUpdate::begin(&idx, None);
     let _ = PdfUpdate::begin(&idx, Some("quillmark-fuzz"));

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -18,7 +18,7 @@ mod error;
 ///
 /// **Workspace-internal; not covered by this crate's semver.** `pub` only so
 /// `quillmark-pdfform` can reach it. The supported surface is [`stamp`],
-/// [`regions_of`], [`page_media_boxes`], [`PdfUpdate`], and the types they name.
+/// [`regions_of`], [`page_canvas_boxes`], [`PdfUpdate`], and the types they name.
 #[doc(hidden)]
 pub mod reader;
 mod stamp;
@@ -34,11 +34,21 @@ pub use reader::ObjectIndex;
 pub use stamp::{regions_of, stamp, StampOptions, CHECKBOX_ON_STATE};
 pub use update::PdfUpdate;
 
-/// The `/MediaBox` of every page of `base`, normalized to `[x0, y0, x1, y1]`
-/// (lower-left, upper-right), in document order. A backend owning top-left
-/// page-relative rects flips against these before building a [`FieldSpec`].
-pub fn page_media_boxes(base: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
-    reader::page_media_boxes(base)
+/// The canvas box of every page of `base` — `/CropBox` intersected with
+/// `/MediaBox`, normalized to `[x0, y0, x1, y1]` (lower-left, upper-right) — in
+/// document order. Both boxes resolve along the page's ancestor chain, and a
+/// page declaring no `/CropBox` takes its `/MediaBox`.
+///
+/// This is the box a viewer displays and a rasterizer draws, so a backend owning
+/// top-left page-relative rects flips against it before building a
+/// [`FieldSpec`], and page-canvas geometry measures from its lower-left corner.
+///
+/// # Errors
+///
+/// `pdf::degenerate_page_box` when a page's canvas box is under a point per
+/// side: nothing renders on it.
+pub fn page_canvas_boxes(base: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
+    reader::page_canvas_boxes(base)
 }
 
 /// One fully-resolved form field: the backend-agnostic currency of the spine.

--- a/crates/quillmark-pdf/src/reader.rs
+++ b/crates/quillmark-pdf/src/reader.rs
@@ -812,7 +812,7 @@ fn parse_rect_array(bytes: &[u8]) -> Option<[f32; 4]> {
     (count == 4).then_some(nums)
 }
 
-/// Normalize a `/MediaBox` so `(x0, y0)` is lower-left and `(x1, y1)`
+/// Normalize a page box so `(x0, y0)` is lower-left and `(x1, y1)`
 /// upper-right, whichever corners the array listed.
 fn normalize_rect(mb: [f32; 4]) -> [f32; 4] {
     [
@@ -823,30 +823,82 @@ fn normalize_rect(mb: [f32; 4]) -> [f32; 4] {
     ]
 }
 
-/// The `/MediaBox` of every page, normalized to `[x0, y0, x1, y1]`, in document
-/// order, taken from the nearest ancestor `/Pages` node carrying one when a page
-/// declares none. The full rect rather than width/height, so a caller flipping
-/// page-relative top-left geometry can honour a non-zero page origin.
-pub(crate) fn page_media_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
-    let (_, _, catalog_id) = open_trailer(pdf, CODE_PARSE)?;
-    media_boxes_of(&ObjectIndex::new(pdf), catalog_id)
+/// The overlap of two normalized rects. Disjoint inputs give an inverted rect,
+/// which [`canvas_box`] rejects on extent.
+fn intersect_rect(a: [f32; 4], b: [f32; 4]) -> [f32; 4] {
+    [
+        a[0].max(b[0]),
+        a[1].max(b[1]),
+        a[2].min(b[2]),
+        a[3].min(b[3]),
+    ]
 }
 
-fn media_boxes_of(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec<[f32; 4]>, PdfError> {
-    let pages = walk_page_tree(idx, catalog_id)?;
-    let mut out = Vec::with_capacity(pages.len());
-    for page in &pages {
-        let mb = page
-            .inherited_attribute(idx, "MediaBox", parse_rect_array)
-            .ok_or_else(|| {
-                err(
-                    CODE_PARSE,
-                    format!("page {} has no resolvable /MediaBox", page.id),
-                )
-            })?;
-        out.push(normalize_rect(mb));
+/// The canvas box of every page, in document order.
+pub(crate) fn page_canvas_boxes(pdf: &[u8]) -> Result<Vec<[f32; 4]>, PdfError> {
+    let (_, _, catalog_id) = open_trailer(pdf, CODE_PARSE)?;
+    canvas_boxes_of(&ObjectIndex::new(pdf), catalog_id)
+}
+
+fn canvas_boxes_of(idx: &ObjectIndex, catalog_id: u32) -> Result<Vec<[f32; 4]>, PdfError> {
+    walk_page_tree(idx, catalog_id)?
+        .iter()
+        .map(|page| canvas_box(idx, page))
+        .collect()
+}
+
+/// `/CropBox` ∩ `/MediaBox`, each resolved along the page's ancestor chain and
+/// normalized; a page reaching no `/CropBox` takes its `/MediaBox`.
+fn canvas_box(idx: &ObjectIndex, page: &Page) -> Result<[f32; 4], PdfError> {
+    let media = page_box(idx, page, "MediaBox")?.ok_or_else(|| {
+        err(
+            CODE_PARSE,
+            format!("page {} has no resolvable /MediaBox", page.id),
+        )
+    })?;
+    let canvas = match page_box(idx, page, "CropBox")? {
+        Some(crop) => intersect_rect(media, crop),
+        None => media,
+    };
+    let (w, h) = (canvas[2] - canvas[0], canvas[3] - canvas[1]);
+    // hayro draws a page under a point per side at a clamped or A4 size
+    // (`hayro_syntax::page::Page::base_dimensions`), so its raster would not
+    // match the extent reported here.
+    if w < 1.0 || h < 1.0 {
+        return Err(err(
+            "pdf::degenerate_page_box",
+            format!(
+                "page {} has a {w} × {h} pt canvas box (/CropBox ∩ /MediaBox); \
+                 a page under a point per side has no renderable canvas",
+                page.id
+            ),
+        ));
     }
-    Ok(out)
+    Ok(canvas)
+}
+
+/// The page box `key`, normalized, from the first ancestor-chain node carrying
+/// one. The first *present* value binds, and one that is not a direct
+/// `[x0 y0 x1 y1]` array — an indirect reference, say — is an error rather than
+/// an absence to climb past: a renderer resolving it would draw a different box.
+fn page_box(idx: &ObjectIndex, page: &Page, key: &str) -> Result<Option<[f32; 4]>, PdfError> {
+    let Some(raw) = page.inherited_attribute(idx, key, |raw| Some(raw.trim_ascii().to_vec()))
+    else {
+        return Ok(None);
+    };
+    parse_rect_array(&raw)
+        .map(normalize_rect)
+        .map(Some)
+        .ok_or_else(|| {
+            err(
+                CODE_PARSE,
+                format!(
+                    "page {} has /{key} {}, which is not an [x0 y0 x1 y1] array of numbers",
+                    page.id,
+                    String::from_utf8_lossy(&raw)
+                ),
+            )
+        })
 }
 
 #[cfg(test)]
@@ -1118,15 +1170,47 @@ mod tests {
     }
 
     #[test]
-    fn media_box_resolves_to_the_nearest_ancestor_carrying_it() {
+    fn page_boxes_resolve_to_the_nearest_ancestor_carrying_them() {
         let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
                     2 0 obj\n<< /Type /Pages /Kids [5 0 R 4 0 R] /Count 2 \
-                    /MediaBox [0 0 612 792] >>\nendobj\n\
+                    /MediaBox [0 0 612 792] /CropBox [0 0 612 792] >>\nendobj\n\
                     5 0 obj\n<< /Type /Pages /Parent 2 0 R /Kids [3 0 R] /Count 1 \
                     /MediaBox [0 0 200 400] >>\nendobj\n\
-                    3 0 obj\n<< /Type /Page /Parent 5 0 R >>\nendobj\n\
+                    3 0 obj\n<< /Type /Page /Parent 5 0 R /CropBox [10 20 150 300] >>\nendobj\n\
                     4 0 obj\n<< /Type /Page /Parent 2 0 R >>\nendobj\n";
-        let boxes = media_boxes_of(&ObjectIndex::new(pdf), 1).expect("media boxes resolve");
-        assert_eq!(boxes, [[0.0, 0.0, 200.0, 400.0], [0.0, 0.0, 612.0, 792.0]]);
+        let boxes = canvas_boxes_of(&ObjectIndex::new(pdf), 1).expect("canvas boxes resolve");
+        assert_eq!(boxes, [[10.0, 20.0, 150.0, 300.0], [0.0, 0.0, 612.0, 792.0]]);
+    }
+
+    #[test]
+    fn the_canvas_box_is_the_crop_box_clipped_to_the_media_box() {
+        let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+                    2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\
+                    3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+                    /CropBox [-40 100 500 900] >>\nendobj\n";
+        let boxes = canvas_boxes_of(&ObjectIndex::new(pdf), 1).expect("canvas boxes resolve");
+        assert_eq!(boxes, [[0.0, 100.0, 500.0, 792.0]]);
+    }
+
+    #[test]
+    fn a_canvas_box_under_a_point_per_side_is_rejected() {
+        let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+                    2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 >>\nendobj\n\
+                    3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+                    /CropBox [700 0 900 792] >>\nendobj\n";
+        let e = canvas_boxes_of(&ObjectIndex::new(pdf), 1).expect_err("disjoint boxes rejected");
+        assert_eq!(e.code, "pdf::degenerate_page_box");
+    }
+
+    #[test]
+    fn a_page_box_that_is_not_a_number_array_is_rejected() {
+        let pdf = b"%PDF\n1 0 obj\n<< /Type /Catalog /Pages 2 0 R >>\nendobj\n\
+                    2 0 obj\n<< /Type /Pages /Kids [3 0 R] /Count 1 \
+                    /CropBox [0 0 100 100] >>\nendobj\n\
+                    3 0 obj\n<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] \
+                    /CropBox 9 0 R >>\nendobj\n";
+        let e = canvas_boxes_of(&ObjectIndex::new(pdf), 1).expect_err("indirect /CropBox rejected");
+        assert_eq!(e.code, CODE_PARSE);
+        assert!(e.message.contains("/CropBox"), "{}", e.message);
     }
 }

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -617,7 +617,7 @@ fn xref_stream_rejected_cleanly() {
 #[test]
 fn nonzero_mediabox_origin_flows_through() {
     let base = build_base_pdf_origin(1, [10.0, 20.0, 622.0, 812.0]);
-    let boxes = quillmark_pdf::page_media_boxes(&base).expect("media boxes");
+    let boxes = quillmark_pdf::page_canvas_boxes(&base).expect("canvas boxes");
     assert_eq!(boxes, vec![[10.0, 20.0, 622.0, 812.0]]);
 }
 

--- a/docs/quills/pdfform-backend.md
+++ b/docs/quills/pdfform-backend.md
@@ -175,7 +175,9 @@ A bound field's kind is derived from the **capability of the resolved schema fie
 
 ### Top-left coordinates
 
-`rect` is authored **top-left origin**: `x`/`y` measured from the top-left corner of the page, the way a human reads a form. The backend flips to PDF's native bottom-left origin when it builds the widget, reading the page height from `form.pdf` and honouring a non-zero `/MediaBox` origin. You never reason about page height or coordinate flipping yourself.
+`rect` is authored **top-left origin**: `x`/`y` measured from the top-left corner of the page, the way a human reads a form. The corner is the one a viewer shows you — the page's canvas box, `/CropBox` intersected with `/MediaBox` — so a background cropped or shifted away from PDF user-space `(0,0)` (anything through `pdfcrop`, say) needs no adjustment on your side. The backend flips to PDF's native bottom-left origin when it builds the widget. You never reason about page height or coordinate flipping yourself.
+
+A page whose canvas box is under a point per side carries no canvas to place anything on, and loading refuses it with `pdf::degenerate_page_box`.
 
 ### Schema versioning and unknown keys
 

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -74,8 +74,9 @@ incremental-update appender that splices a fresh `/AcroForm` (and `/Info`
 `/Producer` stamp) onto a base PDF. Deliberately small: it hard-errors on
 out-of-contract input (xref streams, encryption, indirect `/Annots`,
 non-zero-generation base objects, a base that already carries an `/AcroForm`,
-a non-finite widget `/Rect`, a page `/Rotate` it cannot resolve to zero) rather
-than parsing the full format.
+a non-finite widget `/Rect`, a page `/Rotate` it cannot resolve to zero, a page
+box that is not a direct array of numbers, a canvas box under a point per side)
+rather than parsing the full format.
 
 ### `bindings/*`
 

--- a/prose/canon/PREVIEW.md
+++ b/prose/canon/PREVIEW.md
@@ -414,6 +414,17 @@ paint is always a full repaint: consumers never call `clearRect`.
 
 ### Regions overlay transform
 
+One origin serves the whole canvas surface: `pageSize`, `regions`, the point
+queries, and the raster all measure from the **page's lower-left corner as
+drawn**, so `(0, 0)` is the raster's first pixel and `pageSize × renderScale` is
+its extent. A Typst page starts there already. A pdfform background's page need
+not. The file's own numbers are in PDF user space, and the page a viewer shows
+is the **canvas box**, `/CropBox` ∩ `/MediaBox`, which `pdfcrop` leaves
+translated away from `(0, 0)`. The backend reports that box's extent as the page
+size and subtracts its corner from every region, matching what hayro rasterizes.
+The widget `/Rect`s in the PDF the same session renders stay in user space:
+canvas geometry is box-relative, the deliverable is not.
+
 A consumer drawing overlays from `regions` must flip the Y axis: region
 `rect = [x0, y0, x1, y1]` is in PDF points with a **bottom-left** origin, a
 canvas is **top-left** in device pixels. For a page `pageHeightPt` tall (from


### PR DESCRIPTION
Closes #1505.

## The change

Verified the premise at each cited site, and read hayro 0.7.2 (`hayro-syntax/src/page.rs`) rather than trusting the summary: `crop_box` falls back through `/Parent` to the MediaBox, `intersected_crop_box` clips crop to media, `base_dimensions` substitutes A4 for a near-zero box and clamps each side up to 1 pt, and `initial_transform` translates by the intersected box's origin.

The preferred route, box-relative geometry, is taken. `quillmark-pdf` reads `/CropBox` alongside `/MediaBox` (both inherited along the page's ancestor chain) and reports their intersection: `page_media_boxes` becomes `page_canvas_boxes`. `page_size_pt` is that box's extent, `regions()` subtracts its lower-left corner, and `form.json`'s top-left rects flip against it, so `pageSize`, `regions`, the point queries, and the raster share one origin. The stamped AcroForm's widget `/Rect`s stay in user space.

Two shapes hayro renders at a size the reader cannot mirror are refused at load: a canvas box under a point per side (`pdf::degenerate_page_box`, beside `pdf::rotated_page`), and a page box that is not a direct number array. An indirect `/CropBox` would otherwise be silently ignored here and honoured by hayro.

## Docs

PREVIEW.md's overlay section now states the shared origin before the flip formula; `SessionHandle::page_size_pt` and `RenderedRegion` carry it in rustdoc (the latter claimed regions were the stamped `/Rect`); ARCHITECTURE.md's spine refusal list and `docs/quills/pdfform-backend.md`'s top-left-coordinates section gained the two new cases.

## Verification

- `cargo test --workspace`: green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: OK.
- `cargo clippy` on the three changed crates: no warnings in changed files.
- Both new `canvas_conformance` cases (translated `/MediaBox`, `/CropBox` inside a letter MediaBox, fixtures built with pdf-writer) were confirmed to fail with the region shift reverted, and the CropBox one with the CropBox read reverted.
- Bindings not built: no binding code changed, and the WASM canvas tests use the `[0 0 612 792]` fixture and assert only positive extents.

## For review

- `page_media_boxes` is renamed, not kept beside the new function; nothing in the workspace wanted the raw MediaBox.
- On a page with a `/CropBox`, widget `/Rect`s in the output PDF move: they now flip against the page a form author measures on. No fixture had one.
- Rotation is left alone. `/Rotate ≠ 0` is refused by the stamp and flatten spine, but a document whose fields are all blank skips flatten, so a rotated base can still reach the raster with swapped dimensions. That is the same symptom from a different cause, and a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_