### PR TITLE
fix(content)!: refuse a url the markdown projection cannot write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- fix(content)!: **a link or image `url` carrying a line ending is refused
+  where it is authored, and percent-encoded where it is written.** CommonMark
+  admits no line ending in a destination, bare or angle-wrapped, so `"a\nb"`
+  exported as `[t](<a\nb>)`, which pulldown reads as an inline HTML tag: the
+  re-import came back `[t]()` with the mark gone, and an image the same way
+  with its island gone. An authored lane that *stores* a url now refuses one —
+  `MarkOp::Add` of a `link`, `IslandOp::Insert` and `IslandOp::Set` of an
+  `image`, and the whole-content doors (`install`, `overwrite`,
+  `CardInput.body`) — the way an unwritable code-fence `lang` is refused.
+  `MarkOp::Remove` still takes it, matching on kind equality against a mark the
+  field already holds. Storage stays lenient, and `to_markdown` writes the line
+  ending as `%0A`/`%0D`, so the link survives and re-imports addressing the
+  encoded url.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -19,14 +19,18 @@
 //!
 //! ## Documented codec limits
 //!
-//! Three shapes markdown cannot represent do **not** round-trip. A mark spanning
+//! Four shapes markdown cannot represent do **not** round-trip. A mark spanning
 //! a hard break splits into two per-line marks, and an empty first line in a
 //! hard-break block is dropped, markdown having no blank-then-forced-break
 //! syntax (`tests::known_hard_break_limits`). An image `alt` loses its edge
 //! whitespace: the parser trims alt *after* decoding the character reference
 //! that carries an edge run everywhere else (`tests::known_image_alt_limit`).
-//! Each arises only from adversarial delimiter/break placement or a hand-built
-//! island prop.
+//! A link or image `url` carrying a line ending comes back percent-encoded
+//! (`%0A`/`%0D`): CommonMark admits none in a destination, and the import
+//! decodes no percent escape
+//! (`tests::a_url_carrying_a_line_ending_still_projects_as_a_link`). Each arises
+//! only from adversarial delimiter/break placement, a hand-built island prop, or
+//! a stored url the authored lanes refuse.
 
 use crate::island::KnownIslandType;
 use crate::model::{Container, Island, LineKind, Mark, MarkKind, Content, Normalized, ISLAND_SLOT};
@@ -456,12 +460,16 @@ fn emit_image(isl: &Island, out: &mut String) {
     out.push(')');
 }
 
-/// Emit a link/image destination that re-imports to `url` verbatim. A bare
-/// (unbracketed) destination round-trips only for CommonMark's unbracketed form:
-/// no whitespace, control char, `<`, `>`, `\`, or `&`, and balanced parentheses.
-/// Anything else is angle-wrapped, with `<`, `>`, `\` and `&` backslash-escaped,
-/// since unescaped `<`/`>` are illegal even inside the wrap and `\`/`&` would be
-/// consumed as an escape or entity reference on re-import.
+/// Emit a link/image destination. A bare (unbracketed) destination round-trips
+/// only for CommonMark's unbracketed form: no whitespace, control char, `<`,
+/// `>`, `\`, or `&`, and balanced parentheses. Anything else is angle-wrapped,
+/// with `<`, `>`, `\` and `&` backslash-escaped, since unescaped `<`/`>` are
+/// illegal even inside the wrap and `\`/`&` would be consumed as an escape or
+/// entity reference on re-import.
+///
+/// Every character re-imports to itself except the two
+/// [`url_is_writable`] refuses: a line ending is illegal inside the wrap too, so
+/// it is percent-encoded and comes back in that form.
 fn emit_url(url: &str, out: &mut String) {
     if url_is_bare_safe(url) {
         out.push_str(url);
@@ -469,12 +477,27 @@ fn emit_url(url: &str, out: &mut String) {
     }
     out.push('<');
     for c in url.chars() {
-        if matches!(c, '<' | '>' | '\\' | '&') {
-            out.push('\\');
+        match c {
+            '\n' => out.push_str("%0A"),
+            '\r' => out.push_str("%0D"),
+            '<' | '>' | '\\' | '&' => {
+                out.push('\\');
+                out.push(c);
+            }
+            _ => out.push(c),
         }
-        out.push(c);
     }
     out.push('>');
+}
+
+/// Whether a link or image `url` survives [`to_markdown`] unchanged. CommonMark
+/// admits no line ending in a destination, bare or angle-wrapped, so an authored
+/// lane that stores a url refuses one
+/// ([`crate::serial::reject_unwritable_link_url`],
+/// [`crate::serial::island_from_authored_value`]) and [`emit_url`]
+/// percent-encodes the one a storage-lane or hand-built content still holds.
+pub(crate) fn url_is_writable(url: &str) -> bool {
+    !url.contains(['\n', '\r'])
 }
 
 fn url_is_bare_safe(url: &str) -> bool {
@@ -1931,6 +1954,40 @@ mod tests {
         let mut esc = String::new();
         emit_url("a&<\\b", &mut esc);
         assert_eq!(esc, "<a\\&\\<\\\\b>", "specials escaped inside the wrap");
+    }
+
+    /// A line ending in a `url` has no destination spelling at all, so the
+    /// writer percent-encodes it: the mark survives, addressing the encoded URL.
+    /// Only a storage-lane or hand-built content reaches this — the authored
+    /// lanes refuse the url outright.
+    #[test]
+    fn a_url_carrying_a_line_ending_still_projects_as_a_link() {
+        let rt = Content::new("t x".to_string(), vec![Line::new(LineKind::Para)])
+            .with_marks(vec![Mark::new(
+                0,
+                1,
+                MarkKind::Link {
+                    url: "a\nb".into(),
+                },
+            )])
+            .into_normalized();
+        let back = from_markdown(&to_markdown(&rt)).expect("re-imports");
+        assert_eq!(back.text, "t x", "the display text did not leak");
+        assert_eq!(
+            back.marks.first().map(|m| &m.kind),
+            Some(&MarkKind::Link {
+                url: "a%0Ab".into()
+            })
+        );
+
+        let isl = crate::model::Island::new("i1".into(), "image".into())
+            .with_props(serde_json::json!({"alt": "a", "url": "u\rv"}));
+        let rt = Content::new(format!("x{ISLAND_SLOT}"), vec![Line::new(LineKind::Para)])
+            .with_islands(vec![isl])
+            .into_normalized();
+        let back = from_markdown(&to_markdown(&rt)).expect("re-imports");
+        assert_eq!(back.islands.len(), 1, "the island survived");
+        assert_eq!(back.islands[0].props["url"], "u%0Dv");
     }
 
     /// A strong mark whose delimiters land where CommonMark won't read them as a

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -180,19 +180,21 @@ impl ChangeBundle {
 // and no encoder answers these.
 
 use crate::serial::{
-    container_from_authored_value, island_from_value, line_kind_from_authored_value,
-    mark_from_authored_value, usv_from, ParseError,
+    container_from_authored_value, island_from_authored_value, line_kind_from_authored_value,
+    mark_from_authored_value, reject_unwritable_link_url, usv_from, ParseError,
 };
 use serde_json::Value;
 
 /// Decode a [`MarkOp`] from its wire object (`{op, start, end, type, attrs}` for
 /// `add`/`remove`, `{op, id}` for `removeAnchor`). `add`/`remove` read the mark
 /// vocabulary on the authored lane, which refuses the `@0.93.0` payload
-/// spelling rather than guessing which of the two a stale host meant.
+/// spelling rather than guessing which of the two a stale host meant. `add`
+/// carries the url rule too, `remove` naming a mark the field already holds.
 pub fn mark_op_from_value(v: &Value) -> Result<MarkOp, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("mark op"))?;
     match o.get("op").and_then(Value::as_str) {
         Some("add") => {
+            reject_unwritable_link_url(v)?;
             let mark = mark_from_authored_value(v)?;
             Ok(MarkOp::Add {
                 start: mark.start,
@@ -255,10 +257,12 @@ pub fn line_op_from_value(v: &Value) -> Result<LineOp, ParseError> {
 }
 
 /// Decode an [`IslandOp`] from its wire object. Both arms carry the island
-/// vocabulary (`{id, type, props, loss}`) flattened alongside `op`.
+/// vocabulary (`{id, type, props, loss}`) flattened alongside `op`, read on the
+/// authored lane, which refuses an image `url` the markdown projection cannot
+/// write.
 pub fn island_op_from_value(v: &Value) -> Result<IslandOp, ParseError> {
     let o = v.as_object().ok_or(ParseError::Shape("island op"))?;
-    let island = || island_from_value(v);
+    let island = || island_from_authored_value(v);
     match o.get("op").and_then(Value::as_str) {
         Some("set") => Ok(IslandOp::Set { island: island()? }),
         Some("insert") => Ok(IslandOp::Insert {
@@ -1164,6 +1168,45 @@ mod tests {
         ] {
             assert!(line_op_from_value(&ok).is_ok(), "rejected: {ok}");
         }
+    }
+
+    /// A markdown destination admits no line ending, bare or angle-wrapped, so
+    /// a `url` carrying one exports as markup that re-imports without its link
+    /// or image. An op that stores a url refuses it rather than landing a mark
+    /// the projection dissolves; `remove` names a mark the field already holds,
+    /// so a legacy link stays removable.
+    #[test]
+    fn a_url_the_projection_cannot_write_is_refused_where_an_op_stores_it() {
+        let link = |op: &str, url: &str| {
+            serde_json::json!({"op": op, "start": 0, "end": 1, "type": "link", "attrs": {"url": url}})
+        };
+        for url in ["a\nb", "a\rb"] {
+            assert!(
+                matches!(
+                    mark_op_from_value(&link("add", url)),
+                    Err(ParseError::Shape(_))
+                ),
+                "accepted: {url:?}"
+            );
+            assert!(
+                mark_op_from_value(&link("remove", url)).is_ok(),
+                "unremovable: {url:?}"
+            );
+        }
+        let image = |url: &str| {
+            serde_json::json!({
+                "op": "insert", "at": 0, "id": "i1", "type": "image",
+                "props": {"alt": "a", "url": url},
+            })
+        };
+        assert!(matches!(
+            island_op_from_value(&image("u\nv")),
+            Err(ParseError::Shape(_))
+        ));
+        assert!(
+            island_op_from_value(&image("u v")).is_ok(),
+            "a space angle-wraps and round-trips"
+        );
     }
 
     #[test]

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -587,16 +587,69 @@ pub(crate) fn mark_from_authored_value(v: &Value) -> Result<Mark, ParseError> {
 /// reaches no strict decode that would raise the error on its own.
 pub(crate) fn reject_unreadable_mark(v: &Value) -> Result<(), ParseError> {
     reject_mark_legacy(v)?;
+    reject_unwritable_link_url(v)?;
     mark_shape(v)?;
     Ok(())
 }
 
+/// [`island_from_value`] for the authored lane: an image `url` the markdown
+/// projection cannot write is a shape error rather than a silent rewrite, the
+/// rule [`line_kind_from_authored_value`] carries for a code fence's `lang`.
+pub(crate) fn island_from_authored_value(v: &Value) -> Result<Island, ParseError> {
+    reject_unwritable_image_url(v)?;
+    island_from_value(v)
+}
+
+/// A link `url` [`crate::export::url_is_writable`] refuses is a shape error: the
+/// emitter writes it into the destination slot of `[…](…)`, which admits no line
+/// ending, so the export's percent-encoding of it is a rewrite the host did not
+/// ask for.
+///
+/// The rule is on the lanes that **store** a url. An op naming a mark already in
+/// the field matches on kind equality, and a url the model holds has no other
+/// spelling, so refusing it there would leave a legacy link unremovable.
+pub(crate) fn reject_unwritable_link_url(v: &Value) -> Result<(), ParseError> {
+    let Some(o) = v.as_object() else {
+        return Ok(());
+    };
+    if o.get("type").and_then(Value::as_str) != Some("link") {
+        return Ok(());
+    }
+    reject_unwritable_url(
+        payload(o, legacy_mark_keys("link"), "url").and_then(Value::as_str),
+        "link url",
+    )
+}
+
+/// [`reject_unwritable_link_url`] on an `image` island's `url` prop, which the
+/// emitter writes into the same slot.
+fn reject_unwritable_image_url(v: &Value) -> Result<(), ParseError> {
+    let image = crate::island::KnownIslandType::Image.as_str();
+    if v.get("type").and_then(Value::as_str) != Some(image) {
+        return Ok(());
+    }
+    reject_unwritable_url(
+        v.get("props")
+            .and_then(|p| p.get("url"))
+            .and_then(Value::as_str),
+        "image url",
+    )
+}
+
+fn reject_unwritable_url(url: Option<&str>, err: &'static str) -> Result<(), ParseError> {
+    match url {
+        Some(u) if !crate::export::url_is_writable(u) => Err(ParseError::Shape(err)),
+        _ => Ok(()),
+    }
+}
+
 /// [`from_canonical_value`] for a content the **host authored just now**: the
 /// `install` input, not a blob read back from storage. Same decode, plus the
-/// legacy-spelling rule on every axis [`Content::validate`] checks: line kinds,
-/// containers, prose marks, and table-cell marks.
+/// legacy-spelling rule on every axis [`Content::validate`] checks — line kinds,
+/// containers, prose marks, table-cell marks — and the writability rule on the
+/// urls the projection spells.
 pub fn from_authored_value(v: &Value) -> Result<Normalized, ParseError> {
-    reject_legacy_siblings_deep(v)?;
+    authored_lane_scan(v)?;
     from_canonical_value(v)
 }
 
@@ -604,19 +657,20 @@ pub fn from_authored_value(v: &Value) -> Result<Normalized, ParseError> {
 /// blind recursive walk: an unknown's `attrs` is opaque host payload that may
 /// legitimately contain an object spelled `{"type": "link", "url": …}`, and
 /// rejecting that would make the carrier unable to carry.
-fn reject_legacy_siblings_deep(v: &Value) -> Result<(), ParseError> {
+fn authored_lane_scan(v: &Value) -> Result<(), ParseError> {
     for line in arr_or_empty(v, "lines") {
         reject_line_kind_legacy(line)?;
         for c in arr_or_empty(line, "containers") {
             reject_container_legacy(c)?;
         }
     }
-    // Only the legacy-spelling half here: a prose mark that will not parse is
-    // rejected by the strict decode `from_canonical_value` runs next.
+    // Both rules here: the strict decode `from_canonical_value` runs next reads
+    // prose marks on the storage lane, so it carries neither.
     for m in arr_or_empty(v, "marks") {
         reject_mark_legacy(m)?;
+        reject_unwritable_link_url(m)?;
     }
-    // Cell marks ride the prose mark shape, so the rule follows them in, plus
+    // Cell marks ride the prose mark shape, so the rules follow them in, plus
     // the readability check, since no strict decode reaches them. Dispatch goes
     // through `KnownIslandType`, so a new mark-carrying type is a compile error
     // here rather than a silent skip.
@@ -633,8 +687,10 @@ fn reject_legacy_siblings_deep(v: &Value) -> Result<(), ParseError> {
                     }
                 }
             }
-            // No cells: an image's props are flat, an unknown type's are opaque.
-            Some(crate::island::KnownIslandType::Image) | None => {}
+            // No cells; the one prop the projection writes is the url.
+            Some(crate::island::KnownIslandType::Image) => reject_unwritable_image_url(island)?,
+            // An unknown type's props are opaque.
+            None => {}
         }
     }
     Ok(())
@@ -1665,6 +1721,58 @@ mod tests {
             line_kind_from_authored_value(&v),
             Err(ParseError::Shape("code lang"))
         ));
+    }
+
+    /// The same split on a link or image `url`: CommonMark admits no line
+    /// ending in a destination, so a lane that stores one refuses it, while
+    /// storage keeps what it holds and [`crate::export::emit_url`]
+    /// percent-encodes it.
+    #[test]
+    fn an_unwritable_url_decodes_on_storage_and_is_refused_when_authored() {
+        let mark =
+            serde_json::json!({"type": "link", "start": 0, "end": 1, "attrs": {"url": "a\nb"}});
+        assert_eq!(
+            mark_from_value(&mark).unwrap().kind,
+            MarkKind::Link { url: "a\nb".into() }
+        );
+        assert!(matches!(
+            reject_unwritable_link_url(&mark),
+            Err(ParseError::Shape("link url"))
+        ));
+
+        let island =
+            serde_json::json!({"id": "i1", "type": "image", "props": {"alt": "a", "url": "u\rv"}});
+        assert_eq!(island_from_value(&island).unwrap().props["url"], "u\rv");
+        assert!(matches!(
+            island_from_authored_value(&island),
+            Err(ParseError::Shape("image url"))
+        ));
+    }
+
+    /// The whole-content authored door (`install`, `overwrite`) carries the
+    /// url rule as deep as the values the projection writes.
+    #[test]
+    fn the_authored_content_door_refuses_an_unwritable_url() {
+        for json in [
+            concat!(
+                r#"{"islands":[],"lines":[{"containers":[],"kind":"para"}],"#,
+                r#""marks":[{"attrs":{"url":"a\nb"},"end":1,"start":0,"type":"link"}],"text":"x"}"#
+            ),
+            concat!(
+                r#"{"islands":[{"id":"i1","loss":"lossless","props":{"alt":"a","url":"u\nv"},"#,
+                r#""type":"image"}],"lines":[{"containers":[],"kind":"para"}],"marks":[],"text":"￼"}"#
+            ),
+        ] {
+            let v: Value = serde_json::from_str(json).unwrap();
+            assert!(
+                matches!(from_authored_value(&v), Err(ParseError::Shape(_))),
+                "accepted: {json}"
+            );
+            assert!(
+                Content::from_canonical_json(json).is_ok(),
+                "storage lane rejected: {json}"
+            );
+        }
     }
 
     /// The `@0.93.0` spelling — every built-in's payload in named siblings —

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -351,11 +351,12 @@ payload spelled as a **named sibling**, which is how every release through
     retirable on tag evidence, no tag naming those rows. Read-repair converges
     the population; cold rows keep it alive.
   - **The authored lane rejects it.** A legacy payload sibling is a shape error
-    (`serial::line_kind_from_authored_value` and its two twins for the op wire,
-    `serial::from_authored_value` for a whole content). A host writing it now
-    holds a stale copy of the encoding, and where a bag sits beside it the
-    sibling it meant is not the one the decoder reads. Reads that hand back
-    stored content (`exportMarkdown`, `rebase`) are storage-lane, not this one.
+    (`serial::line_kind_from_authored_value` and its container and mark twins
+    for the op wire, `serial::from_authored_value` for a whole content). A host
+    writing it now holds a stale copy of the encoding, and where a bag sits
+    beside it the sibling it meant is not the one the decoder reads. Reads that
+    hand back stored content (`exportMarkdown`, `rebase`) are storage-lane, not
+    this one.
 
   Both read one frozen table (`serial::legacy_*_keys`): the fallback reads
   exactly the keys the rejection refuses, so a key a later promotion adds is in
@@ -373,6 +374,20 @@ The same split governs an unreadable **table-cell mark**. Storage skips it:
 `serial::parse_cell` is lenient, and normalization makes the skip permanent. The
 authored lane refuses it, because a host's malformed mark vanishing with no
 signal is the silent corruption the split exists to catch.
+
+It governs a **value the markdown projection cannot write** as well: a code
+fence's `lang` outside the identifier shape it is emitted in unquoted, and a
+link or image `url` carrying a line ending, which CommonMark admits in no
+destination form. The authored lane refuses both, so a host learns at the write
+that its markdown would come back without the fence header or the mark. Storage
+takes what it holds and the projection settles it — `import::sanitize_lang`
+reduces the `lang`, `export::emit_url` percent-encodes the line ending, and the
+encoded url is what a re-import reads back.
+
+The url rule is on the lanes that **store** one, not on `MarkOp::Remove`, which
+matches on kind equality against a mark the field already holds: a url in the
+model has no second spelling, so refusing it there would make a stored link
+unremovable.
 
 The opaque attrs are hash input like everything else in the canonical form, so
 they are recursively key-sorted along with the rest (see Byte-stability). What


### PR DESCRIPTION
Closes #1494.

## The change

Both reproductions confirmed against current code: `[t](<a\nb>)` re-imports as `[t]()` with the mark gone, and an image url with `\n` loses its island.

The issue offers two routes; both are needed and both are here, split by lane the way `lang` is after #1386.

An authored lane that **stores** a url now refuses a line ending (`ParseError::Shape`): `MarkOp::Add` of a `link`, `IslandOp::Insert`/`Set` of an `image` (`island_op_from_value` moves onto a new `serial::island_from_authored_value`), and the whole-content doors through `from_authored_value`, which now carries the rule over prose marks, table-cell marks and image islands. `MarkOp::Remove` deliberately still takes it: it matches on kind equality against a mark the field already holds, and a url in the model has no second spelling, so guarding it there would leave a stored link unremovable.

Storage stays lenient, since content decoded from a blob predates the guard, so `emit_url` is total over what the model can hold: `\n`/`\r` are written `%0A`/`%0D` inside the angle wrap. Re-import does **not** decode the percent form (it stays `%0A`), and that drift is recorded rather than fixed; decoding it would corrupt a url that genuinely carries `%0A`.

`validate()` has no url invariant and gains none: `from_canonical_value` runs `validate`, so an invariant there would refuse stored content the storage lane exists to open. The writer being total is what makes validate and the writer agree.

## Docs

- `export` module docs: the codec-limits list gains the percent-encoding drift with its test name; `emit_url` no longer claims every url re-imports verbatim.
- `prose/canon/DOCUMENT_STORAGE.md`: the storage/authored split now states the "value the projection cannot write" rule (`lang` and `url` both; the `lang` half was undocumented), and why `MarkOp::Remove` is outside it. Fixed the stale "its two twins" count.
- `CHANGELOG.md`: `fix(content)!`, since an op that succeeded now fails.

## Verification

- `cargo test --workspace`: green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: canon spine OK.
- `cargo clippy -p quillmark-content --all-targets`: 5 warnings, identical to the pre-change baseline.
- Bindings not built: no binding code changed, and no JS/Python test authors a url with a line ending.

## For review

- Whether `MarkOp::Remove` should be guarded too. Symmetry with the legacy-spelling rule argues yes; a legacy link becoming unremovable argues no. No is taken.
- `IslandOp::Insert` of a *table* still does not check its cell marks (the whole-content door does). That gap predates this change and covers every cell-mark rule, not just urls, so it is left.
- The 0.112→0.113 migration guide is untouched: the sibling `change(core)!` in this Unreleased block is not in it either, so the guide appears to be written at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_