### PR TITLE
fix(content)!: land a block-only island only on a line of its own

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## Unreleased
 
+- fix(content)!: **a block-only island lands only on a line of its own, and the
+  markdown write breaks the paragraph around one already stored inline.** A
+  `table`'s markdown is a block, so a slot spliced into a paragraph exported as
+  pipes mid-line — `a| h |\n| --- |\n| c |b` — which re-imported as prose with
+  the island gone. `IslandOp::Insert` refuses an `at` that is not an empty line,
+  `IslandOp::Set` refuses retyping an inline island into a block-only one
+  (`ApplyError::BlockIslandNotAlone`), and the authored whole-content door
+  (`overwrite`, through `serial::from_authored_value`) refuses the same
+  placement. Storage stays lenient: `to_markdown` writes a content already in
+  that shape as a paragraph, the table, and a paragraph, so the island survives
+  re-import.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -416,6 +416,10 @@ export type LineOp =
  * order they apply: `delta` inserts the `\n` that opens the line, `islandOps`
  * inserts the slot, `lineOps` tags the line `{ op: "setKind", kind: "island" }`.
  * `{ op: "split" }` cannot open that line, since line ops run after island ops.
+ *
+ * A `table` has no inline placement: markdown writes it as a block, so an
+ * `insert` whose `at` is not an empty line throws, as does a `set` retyping an
+ * inline island into one.
  */
 export type IslandOp =
     | ({ op: "set" } & ContentIsland)

--- a/crates/content/src/export.rs
+++ b/crates/content/src/export.rs
@@ -29,7 +29,10 @@
 //! island prop.
 
 use crate::island::KnownIslandType;
-use crate::model::{Container, Island, LineKind, Mark, MarkKind, Content, Normalized, ISLAND_SLOT};
+use crate::model::{
+    Container, Island, Line, LineKind, Mark, MarkKind, Content, Normalized, ISLAND_SLOT,
+};
+use std::borrow::Cow;
 
 /// Render a content to markdown. An island projects by **type**: a type this
 /// build knows emits its markdown, any other a placeholder comment.
@@ -39,13 +42,14 @@ use crate::model::{Container, Island, LineKind, Mark, MarkKind, Content, Normali
 /// whether a projection exists at all. So a known type stamped with a loss class
 /// this build lacks still emits its table.
 pub fn to_markdown(rt: &Normalized) -> String {
-    let segments = line_segments(rt);
+    let (lines, segments) = projected_lines(rt);
     let ctx = Ctx {
         rt,
+        lines: &lines,
         segments: &segments,
     };
     let mut out = String::new();
-    emit_block(&ctx, 0..rt.lines.len(), 0, &mut out);
+    emit_block(&ctx, 0..ctx.lines.len(), 0, &mut out);
     // `to_markdown` projects a *value*, not a file: it emits no final newline,
     // so `writer.set("subject", "Hello")` reads back as `"Hello"`. Document-file
     // writers own the file-final newline, and import is newline-insensitive, so
@@ -70,6 +74,10 @@ pub fn to_plaintext(rt: &Content) -> String {
 
 struct Ctx<'a> {
     rt: &'a Content,
+    /// The block structure being written, which is `rt.lines` unless
+    /// [`projected_lines`] had to break a line around a block-only island.
+    lines: &'a [Line],
+    /// One entry per [`Ctx::lines`] entry.
     segments: &'a [Segment],
 }
 
@@ -143,6 +151,129 @@ pub fn line_segments(rt: &Content) -> Vec<Segment> {
     segs
 }
 
+/// The lines the block walk writes, one [`Segment`] each: the content's own,
+/// unless a **block-only** island's slot
+/// ([`KnownIslandType::block_only`]) shares its line with other content.
+///
+/// A table's markdown is a block. Left inline it writes pipes into the middle of
+/// the paragraph, which re-imports as prose with the island gone, so the
+/// projection breaks the line around such a slot: the prose on each side becomes
+/// its own block and the island takes the line its markup needs. The break is
+/// the write's alone — the stored content keeps its paragraph — and the lanes
+/// that *author* an island refuse the placement outright
+/// ([`ApplyError::BlockIslandNotAlone`](crate::ApplyError::BlockIslandNotAlone)).
+fn projected_lines(rt: &Content) -> (Cow<'_, [Line]>, Vec<Segment>) {
+    let segments = line_segments(rt);
+    let breaks = |i: usize| {
+        let seg = segments[i];
+        seg.end - seg.start > 1 && holds_block_island(rt, seg)
+    };
+    if !(0..rt.lines.len()).any(breaks) {
+        return (Cow::Borrowed(&rt.lines), segments);
+    }
+
+    let mut lines: Vec<Line> = Vec::with_capacity(rt.lines.len());
+    let mut segs: Vec<Segment> = Vec::with_capacity(segments.len());
+    for (i, line) in rt.lines.iter().enumerate() {
+        let seg = segments[i];
+        if !breaks(i) {
+            lines.push(line.clone());
+            segs.push(seg);
+            continue;
+        }
+        // Only the line's first fragment can continue the block above it; each
+        // later one opens a block of its own, which is what the break is.
+        let mut first = true;
+        let mut start = seg.start;
+        let mut byte_start = seg.byte_start;
+        let mut prose_slots = seg.slots_before;
+        let mut slot = seg.slots_before;
+        let mut pos = seg.start;
+        for (b, c) in rt.text[seg.byte_start..seg.byte_end].char_indices() {
+            let byte = seg.byte_start + b;
+            if c == ISLAND_SLOT
+                && rt
+                    .islands
+                    .get(slot)
+                    .is_some_and(crate::island::island_is_block_only)
+            {
+                if pos > start {
+                    lines.push(prose_fragment(line, first));
+                    segs.push(Segment {
+                        start,
+                        end: pos,
+                        byte_start,
+                        byte_end: byte,
+                        slots_before: prose_slots,
+                    });
+                }
+                lines.push(Line {
+                    kind: LineKind::Island,
+                    containers: line.containers.clone(),
+                    continues: false,
+                });
+                segs.push(Segment {
+                    start: pos,
+                    end: pos + 1,
+                    byte_start: byte,
+                    byte_end: byte + c.len_utf8(),
+                    slots_before: slot,
+                });
+                first = false;
+                start = pos + 1;
+                byte_start = byte + c.len_utf8();
+                prose_slots = slot + 1;
+            }
+            if c == ISLAND_SLOT {
+                slot += 1;
+            }
+            pos += 1;
+        }
+        if pos > start {
+            lines.push(prose_fragment(line, first));
+            segs.push(Segment {
+                start,
+                end: pos,
+                byte_start,
+                byte_end: seg.byte_end,
+                slots_before: prose_slots,
+            });
+        }
+    }
+    // A line ending in a block-only island leaves the line after it continuing a
+    // block that renders one line, where the walk would take the continuation
+    // into the island's segment and write only the island. `normalize` clears
+    // the flag in the model; the projection clears it in what it writes.
+    for i in 1..lines.len() {
+        if lines[i].continues && !lines[i - 1].kind.takes_continuations() {
+            lines[i].continues = false;
+        }
+    }
+    (Cow::Owned(lines), segs)
+}
+
+/// One prose piece of a broken line, keeping the line's role and container path.
+fn prose_fragment(line: &Line, first: bool) -> Line {
+    Line {
+        kind: line.kind.clone(),
+        containers: line.containers.clone(),
+        continues: first && line.continues,
+    }
+}
+
+/// Whether the line `seg` covers carries a block-only island's slot.
+fn holds_block_island(rt: &Content, seg: Segment) -> bool {
+    rt.text[seg.byte_start..seg.byte_end]
+        .chars()
+        .filter(|&c| c == ISLAND_SLOT)
+        .enumerate()
+        .any(|(n, _)| {
+            rt.islands
+                .get(seg.slots_before + n)
+                .is_some_and(crate::island::island_is_block_only)
+        })
+}
+
 /// One open level of the block walk: `at` is the next line of `range` to emit,
 /// `buf` the markdown emitted for the level so far, and `container` the one
 /// whose syntax prefixes `buf` when the level closes (`None` at the root).
@@ -178,7 +309,7 @@ impl<'a> Frame<'a> {
 /// past [`MAX_NESTING_DEPTH`](crate::MAX_NESTING_DEPTH) freely, and a call
 /// frame per level aborts the process where this returns a projection.
 fn emit_block(ctx: &Ctx, range: std::ops::Range<usize>, depth: usize, out: &mut String) {
-    let lines = &ctx.rt.lines;
+    let lines = ctx.lines;
     let mut stack = vec![Frame::open(None, range, depth)];
     while let Some(frame) = stack.last_mut() {
         if frame.at < frame.range.end {
@@ -326,7 +457,7 @@ fn emit_code(ctx: &Ctx, range: std::ops::Range<usize>, lang: Option<&str>, out: 
 /// break (`\` + newline); a code block renders one fence; a heading/island is a
 /// single line.
 fn emit_leaf_block(ctx: &Ctx, range: std::ops::Range<usize>, out: &mut String) {
-    let first = &ctx.rt.lines[range.start];
+    let first = &ctx.lines[range.start];
     match &first.kind {
         LineKind::Code { lang } => emit_code(ctx, range, lang.as_deref(), out),
         LineKind::Island => {
@@ -1636,6 +1767,59 @@ mod tests {
         let back = from_markdown(&to_markdown(&rt)).unwrap();
         assert_eq!(back.text, "ab");
         assert_eq!(back.lines.len(), 1);
+    }
+
+    /// A one-cell table island, the block-only type.
+    fn table() -> Island {
+        Island::new("isl-0".into(), "table".into()).with_props(serde_json::json!({
+            "aligns": ["none"],
+            "header": [{"marks": [], "text": "h"}],
+            "rows": [[{"marks": [], "text": "c"}]],
+        }))
+    }
+
+    /// A table is block markup, so a slot storage holds inside a paragraph gets
+    /// the line its markup needs: the paragraph breaks around it and the island
+    /// re-imports, where writing the pipes inline re-imports as prose with the
+    /// island gone. The prose on each side keeps its marks in the coordinates
+    /// the break leaves.
+    #[test]
+    fn a_block_island_inside_a_paragraph_breaks_the_paragraph_around_it() {
+        let rt = Content {
+            text: format!("a{ISLAND_SLOT}bold"),
+            lines: vec![Line::new(LineKind::Para)],
+            marks: vec![Mark::new(2, 6, MarkKind::Strong)],
+            islands: vec![table()],
+        }
+        .into_normalized();
+        assert_eq!(rt.validate(), Ok(()), "hand-built content invalid");
+        let md = to_markdown(&rt);
+        let back = from_markdown(&md).unwrap();
+        assert_eq!(back.text, format!("a\n{ISLAND_SLOT}\nbold"), "{md:?}");
+        assert_eq!(back.islands.len(), 1, "island lost: {md:?}");
+        assert_eq!(back.lines[1].kind, LineKind::Island);
+        assert_eq!(back.marks, vec![Mark::new(4, 8, MarkKind::Strong)], "{md:?}");
+    }
+
+    /// The break leaves an island line where a paragraph line was, and a block
+    /// island renders one line, so a hard-break continuation after it would be
+    /// text the write never reaches. The projection clears the flag the way
+    /// `normalize` does in the model.
+    #[test]
+    fn a_hard_break_after_a_broken_line_keeps_its_text() {
+        let mut second = Line::new(LineKind::Para);
+        second.continues = true;
+        let rt = Content {
+            text: format!("a{ISLAND_SLOT}\nmore"),
+            lines: vec![Line::new(LineKind::Para), second],
+            marks: vec![],
+            islands: vec![table()],
+        }
+        .into_normalized();
+        assert_eq!(rt.validate(), Ok(()), "hand-built content invalid");
+        let md = to_markdown(&rt);
+        let back = from_markdown(&md).unwrap();
+        assert_eq!(back.text, format!("a\n{ISLAND_SLOT}\nmore"), "{md:?}");
     }
 
     /// The placeholder re-imports as no content text, so the net's expected text

--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -55,6 +55,17 @@ impl KnownIslandType {
         }
     }
 
+    /// Whether this type's markdown projection is a **block**: markup no
+    /// paragraph line can hold, so its slot has to sit alone on its line. A
+    /// pipe table is one; an image is inline (`![alt](url)`), and an unknown
+    /// type's placeholder comment is inline too.
+    pub fn block_only(self) -> bool {
+        match self {
+            Self::Table => true,
+            Self::Image => false,
+        }
+    }
+
     /// This type's `(text, marks)` cells: the set that participates in mark
     /// normalization and cell-mark validation. Empty for a type with no cell
     /// model.
@@ -85,8 +96,8 @@ impl KnownIslandType {
     }
 }
 
-// These three wrappers answer the open set's unknown arm once each, so callers
-// get a total function and no site re-decides what an unknown type does.
+// These wrappers answer the open set's unknown arm once each, so callers get a
+// total function and no site re-decides what an unknown type does.
 
 pub(crate) fn normalize_island_structure(island: &mut Island) {
     if let Some(k) = KnownIslandType::parse(&island.island_type) {
@@ -103,6 +114,10 @@ pub(crate) fn island_cell_marks(island: &Island) -> Vec<(String, Vec<Mark>)> {
 
 pub(crate) fn island_shape_error(island: &Island) -> Option<Invariant> {
     KnownIslandType::parse(&island.island_type).and_then(|k| k.shape_error(&island.props))
+}
+
+pub(crate) fn island_is_block_only(island: &Island) -> bool {
+    KnownIslandType::parse(&island.island_type).is_some_and(KnownIslandType::block_only)
 }
 
 #[cfg(test)]

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -911,6 +911,13 @@ pub fn line_kind_mismatch(kind: &LineKind, seg: &str) -> Option<LineKindMismatch
     }
 }
 
+/// Whether `[start, end)` is a whole line of `chars`: a line boundary on each
+/// side and nothing else between them. An empty range asks it of the position a
+/// splice would fill.
+pub(crate) fn is_whole_line(chars: &[char], start: Usv, end: Usv) -> bool {
+    (start == 0 || chars.get(start - 1) == Some(&'\n')) && matches!(chars.get(end), None | Some('\n'))
+}
+
 impl Content {
     /// The text and its per-line attributes; marks and islands start empty.
     ///

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -4,8 +4,8 @@
 
 use crate::delta::{Assoc, Delta, Op};
 use crate::model::{
-    line_kind_mismatch, Container, Island, Line, LineKind, LineKindMismatch, Mark, MarkKind,
-    Content, Usv, ISLAND_SLOT,
+    is_whole_line, line_kind_mismatch, Container, Island, Line, LineKind, LineKindMismatch, Mark,
+    MarkKind, Content, Usv, ISLAND_SLOT,
 };
 use crate::normalize::admit_char;
 use crate::usv::char_to_byte;
@@ -82,6 +82,10 @@ pub enum IslandOp {
     ///
     /// `props`, `island_type` and `loss` all come from the op; nothing derives
     /// `loss` from the props.
+    ///
+    /// The type comes from the op too, so retyping an inline island into a
+    /// block-only one over a slot that shares its line is
+    /// [`ApplyError::BlockIslandNotAlone`], as landing one there is.
     Set { island: Island },
     /// Insert an island: the [`ISLAND_SLOT`] at `at` and its backing entry in
     /// one op, so a slot never exists without the [`Island`] behind it.
@@ -104,6 +108,11 @@ pub enum IslandOp {
     /// *before* line ops: `SetKind` validates the kind against the text already
     /// on the line. `LineOp::Split` cannot stand in for the delta's `\n`: it
     /// runs in the later stage.
+    ///
+    /// A type markdown writes as a block
+    /// ([`KnownIslandType::block_only`](crate::KnownIslandType::block_only), a
+    /// `table`) has no inline placement: `at` must be an empty line, else
+    /// [`ApplyError::BlockIslandNotAlone`].
     ///
     /// A slot inserted onto a line whose kind names its content (`Code`, `Rule`)
     /// contradicts that kind; `normalize` demotes the line to `Para` at the end
@@ -377,6 +386,13 @@ pub enum ApplyError {
     /// An [`IslandOp::Insert`] whose `at` is past the end of the text the delta
     /// and this bundle's earlier island ops left.
     IslandInsertOutOfRange { at: Usv, len: Usv },
+    /// An island op would leave a **block-only** island's slot
+    /// ([`KnownIslandType::block_only`](crate::KnownIslandType::block_only), a
+    /// `table`) sharing its line with other content. Markdown writes such an
+    /// island by breaking the line around it, so the op that lands one mid-line
+    /// is refused rather than restructuring the author's blocks. `at` is the
+    /// slot's position.
+    BlockIslandNotAlone { at: Usv },
     /// A [`LineOp::SetKind`] whose kind contradicts the line's text: tagging
     /// prose `Island` or `Rule`, or a slot-bearing line `Code`. Export trusts
     /// the kind over the text, so the write would silently drop the line's
@@ -588,6 +604,15 @@ impl Content {
                         .ok_or_else(|| ApplyError::UnknownIslandId {
                             id: island.id.clone(),
                         })?;
+                    // The type comes from the op, so a `Set` can turn an inline
+                    // island into a block-only one over a slot that stays put.
+                    if crate::island::island_is_block_only(island) {
+                        let chars: Vec<char> = self.text.chars().collect();
+                        let at = nth_slot(&chars, idx);
+                        if !is_whole_line(&chars, at, at + 1) {
+                            return Err(ApplyError::BlockIslandNotAlone { at });
+                        }
+                    }
                     // In place: the slot does not move, so no anchor pays.
                     self.islands[idx] = island.clone();
                 }
@@ -606,6 +631,13 @@ impl Content {
                             at: *at,
                             len: chars.len(),
                         });
+                    }
+                    // The slot lands alone on its line only where the line is
+                    // empty now, which is the `\n` the bundle's delta opened.
+                    if crate::island::island_is_block_only(island)
+                        && !is_whole_line(&chars, *at, *at)
+                    {
+                        return Err(ApplyError::BlockIslandNotAlone { at: *at });
                     }
                     // Islands are stored in slot order.
                     let slot_idx = chars[..*at].iter().filter(|&&c| c == ISLAND_SLOT).count();
@@ -955,6 +987,18 @@ fn sync_for_delta(
         .filter_map(|(island, keep)| keep.then_some(island))
         .collect();
     (lines, islands)
+}
+
+/// The USV position of the `n`th [`ISLAND_SLOT`] in `chars`, or the end of the
+/// text where the slots run out — a slot-synced island list has no such index.
+fn nth_slot(chars: &[char], n: usize) -> Usv {
+    chars
+        .iter()
+        .enumerate()
+        .filter(|&(_, &c)| c == ISLAND_SLOT)
+        .map(|(i, _)| i)
+        .nth(n)
+        .unwrap_or(chars.len())
 }
 
 fn newline_at_line_boundary(text: &str, line: usize) -> Result<Usv, ApplyError> {
@@ -2079,6 +2123,61 @@ mod tests {
         })
         .unwrap();
         assert_eq!(rt, before, "same content, original id and kind included");
+    }
+
+    /// Markdown writes a table as a block, so its slot has to be a line's whole
+    /// content: an op landing one inside a paragraph would write pipes that
+    /// re-import as prose. An image is inline markup and keeps every position,
+    /// and `Set` carries the type, so retyping one is the same refusal.
+    #[test]
+    fn a_block_only_island_lands_only_on_a_line_of_its_own() {
+        let table = |id: &str| {
+            Island::new(id.into(), "table".into()).with_props(table_props("H", "a"))
+        };
+        let mut rt = from_markdown("ab").unwrap();
+        let before = rt.clone();
+        assert_eq!(
+            rt.apply_field_change(&island_bundle(vec![IslandOp::Insert {
+                at: 1,
+                island: table("isl-t"),
+            }])),
+            Err(ApplyError::BlockIslandNotAlone { at: 1 })
+        );
+        assert_eq!(rt, before, "the refusal commits nothing");
+
+        // The three-channel bundle a block island takes: the delta opens the
+        // line, this op fills it, `SetKind` tags it.
+        rt.apply_field_change(&ChangeBundle {
+            delta: diff("ab", "ab\n"),
+            island_ops: vec![IslandOp::Insert {
+                at: 3,
+                island: table("isl-t"),
+            }],
+            line_ops: vec![LineOp::SetKind {
+                line: 1,
+                kind: LineKind::Island,
+            }],
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(rt.validate(), Ok(()));
+
+        rt.apply_field_change(&island_bundle(vec![IslandOp::Insert {
+            at: 1,
+            island: image("isl-i"),
+        }]))
+        .unwrap();
+        assert_eq!(rt.text, format!("a{ISLAND_SLOT}b\n{ISLAND_SLOT}"));
+        assert_eq!(
+            rt.apply_field_change(&island_bundle(vec![IslandOp::Set {
+                island: table("isl-i"),
+            }])),
+            Err(ApplyError::BlockIslandNotAlone { at: 1 })
+        );
+        rt.apply_field_change(&island_bundle(vec![IslandOp::Set {
+            island: table("isl-t"),
+        }]))
+        .expect("the block island's own slot is a whole line");
     }
 
     /// An inserted island's id is caller-supplied on an anchor id's terms:

--- a/crates/content/src/serial.rs
+++ b/crates/content/src/serial.rs
@@ -594,10 +594,33 @@ pub(crate) fn reject_unreadable_mark(v: &Value) -> Result<(), ParseError> {
 /// [`from_canonical_value`] for a content the **host authored just now**: the
 /// `install` input, not a blob read back from storage. Same decode, plus the
 /// legacy-spelling rule on every axis [`Content::validate`] checks: line kinds,
-/// containers, prose marks, and table-cell marks.
+/// containers, prose marks, and table-cell marks, and the placement rule on a
+/// block-only island.
 pub fn from_authored_value(v: &Value) -> Result<Normalized, ParseError> {
     reject_legacy_siblings_deep(v)?;
-    from_canonical_value(v)
+    let rt = from_canonical_value(v)?;
+    reject_inline_block_island(&rt)?;
+    Ok(rt)
+}
+
+/// A block-only island's slot sharing its line with other content: markdown
+/// writes a table as a block, so `export::to_markdown` breaks the line around
+/// one, splitting a paragraph the host did not ask to split. The op wire refuses
+/// the same placement ([`crate::ApplyError::BlockIslandNotAlone`]).
+fn reject_inline_block_island(rt: &Content) -> Result<(), ParseError> {
+    let chars: Vec<char> = rt.text.chars().collect();
+    let slots = chars
+        .iter()
+        .enumerate()
+        .filter(|&(_, &c)| c == crate::model::ISLAND_SLOT);
+    for ((at, _), island) in slots.zip(&rt.islands) {
+        if crate::island::island_is_block_only(island)
+            && !crate::model::is_whole_line(&chars, at, at + 1)
+        {
+            return Err(ParseError::Shape("block island in a line's prose"));
+        }
+    }
+    Ok(())
 }
 
 /// The authored-lane scan [`from_authored_value`] runs. Structural rather than a
@@ -1665,6 +1688,39 @@ mod tests {
             line_kind_from_authored_value(&v),
             Err(ParseError::Shape("code lang"))
         ));
+    }
+
+    /// The same split on a block-only island's placement. A table's markdown is
+    /// a block, so `export::to_markdown` breaks the line around a slot sitting
+    /// in a paragraph's prose: storage decodes the shape it holds and the write
+    /// settles it, while a host authoring that placement is told, rather than
+    /// having its paragraph split for it. An inline island keeps the position.
+    #[test]
+    fn an_inline_block_island_decodes_on_storage_and_is_refused_when_authored() {
+        let content = |island_type: &str, props: &str| {
+            format!(
+                concat!(
+                    r#"{{"islands":[{{"id":"isl-0","loss":"lossless","props":{},"#,
+                    r#""type":"{}"}}],"lines":[{{"containers":[],"kind":"para"}}],"#,
+                    r#""marks":[],"text":"a￼b"}}"#
+                ),
+                props, island_type
+            )
+        };
+        let table = content(
+            "table",
+            r#"{"aligns":["none"],"header":[{"marks":[],"text":"h"}],"rows":[[{"marks":[],"text":"c"}]]}"#,
+        );
+        assert!(
+            Content::from_canonical_json(&table).is_ok(),
+            "storage lane rejected: {table}"
+        );
+        let v: Value = serde_json::from_str(&table).unwrap();
+        assert!(matches!(from_authored_value(&v), Err(ParseError::Shape(_))));
+
+        let image = content("image", r#"{"alt":"a","url":"u"}"#);
+        let v: Value = serde_json::from_str(&image).unwrap();
+        assert!(from_authored_value(&v).is_ok(), "inline island refused");
     }
 
     /// The `@0.93.0` spelling — every built-in's payload in named siblings —

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -374,6 +374,17 @@ The same split governs an unreadable **table-cell mark**. Storage skips it:
 authored lane refuses it, because a host's malformed mark vanishing with no
 signal is the silent corruption the split exists to catch.
 
+It governs a **block-only island's placement** too. Markdown writes a `table` as
+a block (`KnownIslandType::block_only`, which an inline `image` is not), so a
+slot sharing its line with prose has no inline spelling: written there it lands
+as pipes inside the paragraph, which re-imports as prose with the island gone.
+The authored lanes refuse the placement — `ApplyError::BlockIslandNotAlone` from
+`IslandOp::Insert` and from a `Set` that retypes an inline island, a shape error
+from `serial::from_authored_value` — so a host learns at the write. Storage takes
+what it holds and the projection settles it: `export::to_markdown` breaks the
+line around the slot, so the prose on each side becomes its own block and the
+island keeps the line its markup needs.
+
 The opaque attrs are hash input like everything else in the canonical form, so
 they are recursively key-sorted along with the rest (see Byte-stability). What
 *does* remain a schema event is a change to the content object's own structure:


### PR DESCRIPTION
Closes #1497.

## The change

Verified the premise: `IslandOp::Insert { at: 1, island: table }` on `from_markdown("ab")` validated clean and exported `"a| h |\n| --- |\n| c |b"`, re-importing as prose with zero islands.

Takes the issue's first route in the lane-split shape PR #1606 documents, because `serial::from_canonical_value` runs `validate`, so a stricter invariant would refuse content already stored in that shape.

`KnownIslandType::block_only` names the property: `table` true, `image` false (it is emitted inline), an unknown type false (its placeholder comment is one inline line). It is the only type axis; the wrapper `island::island_is_block_only` answers the open set's unknown arm as its three siblings do.

Authoring refuses the placement with a new `ApplyError::BlockIslandNotAlone { at }`: `IslandOp::Insert` takes only an `at` whose line is empty (the `\n` the bundle's delta opened, which is the block-island recipe the op's own doc already states), and `IslandOp::Set` refuses retyping an inline island into a block-only one over a slot that stays put. The whole-content authored door `serial::from_authored_value` (behind `overwrite`) refuses a content in that shape too.

Storage stays lenient and the writer is made total: `export::projected_lines` breaks the line around such a slot, so the prose on each side becomes its own block and the island takes the line its markup needs. It hands `Ctx` a `Cow<[Line]>` plus one `Segment` each and borrows unchanged where nothing needs breaking, so no other export path moves. It also clears `continues` after a fragment that cannot take one, the way `normalize` does, or a hard break following the break would land inside the island's segment and lose its text.

## Docs

`DOCUMENT_STORAGE.md` gains a paragraph in the lane-split section. The WASM `IslandOp` TS doc gains the rule. No ERROR.md row: every `ApplyError` collapses to `edit::content_apply`, a fallback code with no args.

## Verification

- `cargo test --workspace`: green, before and after the change.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: canon spine OK.
- `cargo clippy -p quillmark-content --all-targets`: same 5 warnings as `origin/main`, none new.
- Bindings not built: the only binding edit is a doc comment inside a TS custom section, which `cargo` already compiles. The WASM JS suite inserts islands only as images and `set`s a table already alone on its line, so both stay accepted.

## For review

The whole-content authored door now refuses a shape a host could previously write back after reading it. That follows the sibling branch's rule (authored lanes refuse what the projection rewrites) and the fix is to put the table on its own line, but it is the one break a type checker will not report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_