### PR TITLE
fix(content): drop a paragraph left empty by HTML stripping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(content): **a paragraph emptied by HTML stripping leaves no line.**
+  `<span></span>` on its own imported as an empty `Para` line, which markdown
+  has no syntax to write, so `to_markdown` emitted a stray blank line and
+  re-import collapsed it: `from_markdown("a\n\n<span></span>\n\nb")` was not a
+  fixed point. Import now drops such a paragraph. An empty heading, code block
+  and container keep their line, markdown being able to write those back.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/content/src/import.rs
+++ b/crates/content/src/import.rs
@@ -14,8 +14,9 @@
 //! - **Adjacent sibling containers keep their boundary.** Two consecutive lists
 //!   of one shape, and two consecutive block quotes, are told apart by
 //!   `Container::instance`, minted here and canonicalized by `normalize`.
-//! - **Empty blocks and containers keep their line**, so the structure survives
-//!   rather than vanishing.
+//! - **An empty heading, code block or container keeps its line**, so the
+//!   structure survives rather than vanishing. An empty paragraph drops,
+//!   markdown having no syntax to write one back.
 //! - **Island ids are minted sequentially** (`isl-0`, `isl-1`, …), so import is
 //!   a deterministic function of its markdown and never reads an ambient source.
 //!   Export drops the ids and re-import re-mints the same sequence.
@@ -328,12 +329,20 @@ impl Builder {
     }
 
     /// Open a line for a block that ended with no inline content (an empty
-    /// heading `#`, an empty paragraph): otherwise the block, and any content
-    /// model it carries, is silently lost.
+    /// heading `#`): otherwise the block, and any content model it carries, is
+    /// silently lost. An empty *paragraph* — all of whose inline content was
+    /// stripped HTML — is the exception: markdown spells it with nothing, so a
+    /// line kept here would export as a blank line that re-import collapses,
+    /// costing the fixed point. A container the drop leaves empty still gets
+    /// its line from [`Self::close_container`].
     fn flush_empty_block(&mut self) {
-        if let Some((k, cont)) = self.pending.take() {
-            self.open_line(k, cont);
+        let Some((kind, continues)) = self.pending.take() else {
+            return;
+        };
+        if matches!(kind, LineKind::Para) {
+            return;
         }
+        self.open_line(kind, continues);
     }
 
     /// Close a container: if it emitted no line, give it one empty `Para` line
@@ -1224,6 +1233,30 @@ mod tests {
     fn empty_list_item_keeps_its_line() {
         let rt = imp("- a\n-\n- b");
         assert_eq!(rt.lines.len(), 3, "empty middle item preserved");
+    }
+
+    /// A paragraph whose inline content is entirely stripped HTML leaves no
+    /// line, markdown having no syntax to write one back; an empty heading or
+    /// container keeps the line `# `, `- ` and `>` can write. Either way the
+    /// import is a fixed point.
+    #[test]
+    fn empty_paragraph_drops_while_empty_heading_and_container_keep_their_line() {
+        let cases: &[(&str, usize)] = &[
+            ("a\n\n<span></span>\n\nb", 2),
+            ("a\n\n<span></span>", 1),
+            ("- a\n\n  <span></span>", 1),
+            ("> a\n>\n> <span></span>", 1),
+            ("# <span></span>", 1),
+            ("- <span></span>", 1),
+            ("> <span></span>", 1),
+        ];
+        for (md, lines) in cases {
+            let rt = imp(md);
+            assert_eq!(rt.lines.len(), *lines, "{md:?} -> {:?}", rt.lines);
+            let rt2 = from_markdown(&crate::export::to_markdown(&rt)).unwrap();
+            assert_eq!(rt2, rt, "{md:?} is not a fixed point");
+        }
+        assert_eq!(imp("a\n\n<span></span>\n\nb").text, "a\nb");
     }
 
     #[test]


### PR DESCRIPTION
Closes #1500.

## The change

`crates/content/src/import.rs`: `flush_empty_block` opens a line only for a block markdown can write back. An empty heading still gets one; an empty paragraph, every inline event of it stripped HTML, does not.

The issue's first option is taken, and applied to the whole defect rather than only the top-level case. Probing showed the same non-fixed-point in a container that already emitted a line: `- a\n\n  <span></span>` exported to `- a` and re-imported to one line, as did `> a\n>\n> <span></span>`. Restricting the drop to `containers.is_empty()` would have fixed the reported input and left those two. A container the drop leaves with nothing still gets its line from `close_container`, so `- <span></span>` and `> <span></span>` keep their single line exactly as `- ` and `>` did.

The export module doc's "three shapes" list stays at three: the fourth shape now round-trips, so there is nothing to add there. The typst backend already emits nothing for an empty paragraph (`emit::emit_leaf_terminated`), so no rendered value moves. The edit-op lane that can build an empty `Para` line is untouched.

## Docs

The import module doc's canonicalization bullet said "Empty blocks and containers keep their line". It now names the heading, code block and container as the keepers and states that an empty paragraph drops.

## Verification

- `cargo test --workspace`: green, no failures.
- `cargo clippy -p quillmark-content`: the same five warnings as `origin/main`, none new.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- New `empty_paragraph_drops_while_empty_heading_and_container_keep_their_line` pins seven inputs on line count and on `from_markdown(to_markdown(rt)) == rt`, plus the issue's `text == "a\nb"`. Every existing import and export test, including `known_hard_break_limits` and the proptest fixed-point suite, is unchanged and green.

## For review

Two behaviours change beyond the reported input, both toward the fixed point and both untested before: an empty paragraph inside a non-empty container is dropped, and a trailing hard break whose continuation line is entirely stripped HTML (`a\<newline><span></span>`) now yields one line instead of two. Neither had a markdown spelling.

Sibling branches `...-1494` and `...-1497` touch `export.rs`, `ops.rs` and `island.rs`; this change is confined to `import.rs` and `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_