### PR TITLE
fix(content): an island alone on a line takes the kind its type projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- fix(content): **an island alone on a line takes the line kind its type
+  projects.** An `image` slot alone on a `LineKind::Island` line and the same
+  slot on a `Para` line both wrote `![alt](url)`, which re-imports as `Para`,
+  and a `table` alone on a `Para` line wrote a pipe table, which re-imports as
+  `Island`: two normalized contents per document and one markdown, so any write
+  and read back flipped the kind. `KnownIslandType::block_only` names which
+  markup is a block, and `Content::normalize` writes the kind the round trip
+  yields — `Island` for a `table`, `Para` for an `image`. A type this build
+  cannot read keeps the kind it was stored with, its placeholder naming none.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -411,11 +411,15 @@ export type LineOp =
  * A `set` stores the `loss` it is given; nothing re-derives the class from the
  * new `props`.
  *
- * An island is *inline* (a slot inside a paragraph) unless its line says
- * otherwise. A **block** island is one bundle of all three channels, in the
- * order they apply: `delta` inserts the `\n` that opens the line, `islandOps`
- * inserts the slot, `lineOps` tags the line `{ op: "setKind", kind: "island" }`.
- * `{ op: "split" }` cannot open that line, since line ops run after island ops.
+ * An island is *inline* (a slot inside a paragraph) or a **block** (that slot
+ * alone on a line under `kind: "island"`), and for a slot alone on a line the
+ * type settles which: markdown writes a `table` as a block and an image inline,
+ * so the line's `kind` is read off the type and a `setKind` spelling it
+ * otherwise does not survive. Landing a block island is one bundle of all three
+ * channels, in the order they apply: `delta` inserts the `\n` that opens the
+ * line, `islandOps` inserts the slot, `lineOps` tags the line
+ * `{ op: "setKind", kind: "island" }`. `{ op: "split" }` cannot open that line,
+ * since line ops run after island ops.
  */
 export type IslandOp =
     | ({ op: "set" } & ContentIsland)

--- a/crates/content/src/island.rs
+++ b/crates/content/src/island.rs
@@ -55,6 +55,17 @@ impl KnownIslandType {
         }
     }
 
+    /// Whether this type's markdown projection is a **block**: markup no
+    /// paragraph line can hold, so its slot has to sit alone on its line. A
+    /// pipe table is one; an image is inline (`![alt](url)`), and an unknown
+    /// type's placeholder comment is inline too.
+    pub fn block_only(self) -> bool {
+        match self {
+            Self::Table => true,
+            Self::Image => false,
+        }
+    }
+
     /// This type's `(text, marks)` cells: the set that participates in mark
     /// normalization and cell-mark validation. Empty for a type with no cell
     /// model.

--- a/crates/content/src/model.rs
+++ b/crates/content/src/model.rs
@@ -111,7 +111,12 @@ pub enum LineKind {
     Code {
         lang: Option<String>,
     },
-    /// A block-level island: the line's sole content is one [`ISLAND_SLOT`].
+    /// A block-level island: the line's sole content is one [`ISLAND_SLOT`]
+    /// backing an island whose markdown *is* a block
+    /// ([`KnownIslandType::block_only`](crate::KnownIslandType::block_only)).
+    /// An image is inline markup, so a line holding one alone is
+    /// [`Para`](LineKind::Para) — the kind re-importing `![alt](url)` yields,
+    /// and the kind [`Content::normalize`] writes there.
     Island,
     /// A thematic break (`---`/`***`/`___`). The line carries no text.
     Rule,
@@ -911,6 +916,34 @@ pub fn line_kind_mismatch(kind: &LineKind, seg: &str) -> Option<LineKindMismatch
     }
 }
 
+/// The [`LineKind`] a line whose sole content is one [`ISLAND_SLOT`] carries in
+/// canonical form: [`LineKind::Island`] where markdown writes that island as a
+/// block ([`KnownIslandType::block_only`](crate::KnownIslandType::block_only)),
+/// [`LineKind::Para`] where it writes it inline. Both spell one markdown, so the
+/// model keeps the one re-importing it yields, and [`Content::normalize`] writes
+/// that one.
+///
+/// `None` leaves the stored kind standing, on the three counts the projection
+/// settles nothing: a line holding more than the slot, a kind whose own contract
+/// carries a slot ([`LineKind::Heading`], the open [`LineKind::Unknown`]), and
+/// an island type this build cannot read — its placeholder projects no kind
+/// back, and its spelling is not this build's to move.
+fn island_line_kind(kind: &LineKind, seg: &str, island: Option<&Island>) -> Option<LineKind> {
+    if !matches!(kind, LineKind::Para | LineKind::Island) {
+        return None;
+    }
+    let mut chars = seg.chars();
+    if (chars.next(), chars.next()) != (Some(ISLAND_SLOT), None) {
+        return None;
+    }
+    let known = crate::island::KnownIslandType::parse(&island?.island_type)?;
+    Some(if known.block_only() {
+        LineKind::Island
+    } else {
+        LineKind::Para
+    })
+}
+
 impl Content {
     /// The text and its per-line attributes; marks and islands start empty.
     ///
@@ -1004,10 +1037,15 @@ impl Content {
         // un-repaired line projects its content away. Demote to `Para`, which is
         // what re-importing the line's own markdown yields. A *deliberate*
         // mis-tag is refused up front by the op channel instead.
+        let mut slot = 0usize;
         for (line, seg) in self.lines.iter_mut().zip(self.text.split('\n')) {
             if line_kind_mismatch(&line.kind, seg).is_some() {
                 line.kind = LineKind::Para;
             }
+            if let Some(kind) = island_line_kind(&line.kind, seg, self.islands.get(slot)) {
+                line.kind = kind;
+            }
+            slot += seg.chars().filter(|&c| c == ISLAND_SLOT).count();
             if let LineKind::Unknown { attrs, .. } = &mut line.kind {
                 canonicalize_keys(attrs);
                 collapse_empty_bag(attrs);
@@ -1529,17 +1567,65 @@ mod tests {
         let mut rt = tagged("text on a rule line", LineKind::Rule);
         rt.normalize();
         assert_eq!(rt.lines[0].kind, LineKind::Para);
-        // A well-formed island line is left alone.
+        // A well-formed island line — a block island's slot alone — is left alone.
         let mut rt = tagged(&ISLAND_SLOT.to_string(), LineKind::Island);
-        rt.islands = vec![Island {
-            id: "isl-0".into(),
-            island_type: "image".into(),
-            props: serde_json::json!({"alt": "x", "url": "y.png"}),
-            loss: Loss::LOSSLESS,
-        }];
+        rt.islands = vec![table_island()];
         rt.normalize();
         assert_eq!(rt.lines[0].kind, LineKind::Island);
         assert_eq!(rt.validate(), Ok(()));
+    }
+
+    /// A one-cell table: the island type markdown writes as a block.
+    fn table_island() -> Island {
+        Island::new("isl-0".into(), "table".into()).with_props(serde_json::json!({
+            "aligns": ["none"],
+            "header": [{"marks": [], "text": "h"}],
+            "rows": [[{"marks": [], "text": "c"}]],
+        }))
+    }
+
+    /// Markdown spells a slot-alone `Para` line and a slot-alone `Island` line
+    /// alike, so which one a document holds is the island type's to settle:
+    /// table markup is a block and re-imports as `Island`, an image is inline
+    /// and re-imports as `Para`. Both spellings of each converge on the one the
+    /// round trip yields, so no document holds a kind its own markdown denies.
+    #[test]
+    fn an_island_alone_on_a_line_takes_the_kind_its_type_projects() {
+        let image = Island::new("isl-0".into(), "image".into())
+            .with_props(serde_json::json!({"alt": "a", "url": "u"}));
+        for (island, canonical) in [
+            (table_island(), LineKind::Island),
+            (image, LineKind::Para),
+        ] {
+            for stored in [LineKind::Para, LineKind::Island] {
+                let what = format!("{} as {stored:?}", island.island_type);
+                let rt = tagged(&ISLAND_SLOT.to_string(), stored)
+                    .with_islands(vec![island.clone()])
+                    .into_normalized();
+                assert_eq!(rt.validate(), Ok(()), "{what}");
+                assert_eq!(rt.lines[0].kind, canonical, "{what}");
+                let md = crate::export::to_markdown(&rt);
+                assert_eq!(
+                    crate::import::from_markdown(&md).expect("re-imports"),
+                    rt,
+                    "{what} is not a fixed point: {md:?}"
+                );
+            }
+        }
+    }
+
+    /// An island type this build cannot read projects to a placeholder that
+    /// carries no island back, so nothing in the markdown names a kind for its
+    /// line. The stored spelling stands: reading a document is not licence to
+    /// move the bytes of a construct this build does not understand.
+    #[test]
+    fn an_unknown_island_keeps_the_line_kind_it_was_stored_with() {
+        for stored in [LineKind::Para, LineKind::Island] {
+            let mut rt = tagged(&ISLAND_SLOT.to_string(), stored.clone())
+                .with_islands(vec![Island::new("isl-0".into(), "widget".into())]);
+            rt.normalize();
+            assert_eq!(rt.lines[0].kind, stored);
+        }
     }
 
     #[test]

--- a/crates/content/src/ops.rs
+++ b/crates/content/src/ops.rs
@@ -2051,7 +2051,8 @@ mod tests {
             delta: diff("intro", "intro\n"),
             island_ops: vec![IslandOp::Insert {
                 at: 6,
-                island: image("isl-a"),
+                island: Island::new("isl-a".into(), "table".into())
+                    .with_props(table_props("H", "a")),
             }],
             line_ops: vec![LineOp::SetKind {
                 line: 1,
@@ -2062,6 +2063,7 @@ mod tests {
         .unwrap();
         let before = rt.clone();
         let held = rt.islands[0].clone();
+        assert_eq!(before.lines[1].kind, LineKind::Island);
 
         rt.apply_field_change(&ChangeBundle::from_delta(diff(&before.text, "intro\n")))
             .unwrap();


### PR DESCRIPTION
Closes #1498.

## The change

The issue's premise holds on `origin/main`: an `image` slot alone on a `LineKind::Island` line and the same slot on a `Para` line both write `[alt](url)`, which re-imports as `Para`. The mirror is live too: a `table` alone on a `Para` line writes a pipe table, which re-imports as `Island`. Two normalized contents, one markdown, either way.

`Para` is canonical for an image-only line and `Island` for a table-only line, decided from the code rather than preference: `export`'s stated contract is `from_markdown(to_markdown(rt)) == rt` for a content import produced, so import defines the canonical form, and import already mints `Para` for a standalone image (`emit_image` opens a `Para`) and `Island` for a table (`Tag::Table` opens an `Island` line). That is exactly the `block_only` axis: a table's markup is a block, an image's is inline.

`KnownIslandType::block_only` names it (same spelling and semantics as PR #1607's, so a merge resolves by keeping one copy), and `Content::normalize` writes the kind the round trip yields for a line whose sole content is one slot. Import is therefore a fixed point of the rule and every other producer (storage decode, a hand-built `Content`, an op bundle) converges on it. An island type this build cannot read keeps its stored kind: its placeholder projects no island back, so nothing in the markdown names a kind, and moving that byte for an unrecognized construct is what DOCUMENT_STORAGE forbids.

Normalize repairs rather than the op channel refusing, which is the split the codebase already makes for a canonicalization (container `ordinal`/`instance` normalize silently; `validate` checks neither). Nothing is lost: the two spellings project identically, so the demotion is invisible in both projections.

`block_island_restore_retags_its_line` now builds a `table`, the block island its name is about; with an image it would have passed vacuously.

## Docs

`LineKind::Island`'s rustdoc states which islands take it. The WASM `IslandOp` doc said "an island is inline unless its line says otherwise"; for a slot alone on a line the type says, so a `setKind` against it does not survive. No canon claim went stale: nothing in `prose/canon` names the island line kind beyond CONVERT.md's "a heading, an island and a rule are one line", which still holds.

## Verification

- `cargo test --workspace`: green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `cargo clippy -p quillmark-content --all-targets` and `-p quillmark-wasm`: 5 pre-existing warnings, unchanged from the baseline on `origin/main`.
- New: `an_island_alone_on_a_line_takes_the_kind_its_type_projects` exhausts {stored `Para`, stored `Island`} × {`table`, `image`}, asserting the kind normalize picks and that `from_markdown(to_markdown(rt)) == rt`; `an_unknown_island_keeps_the_line_kind_it_was_stored_with` pins the open-vocabulary carve-out.
- Bindings not built: the only binding edit is a doc comment, and no committed `.d.ts` carries it.

## For review

Both directions are fixed, not only the image one the issue names: the mirror is the same predicate and the new fixed-point test would otherwise have had to exclude tables to stay green.

`IslandOp::Insert`'s Rust doc still says a block island "takes three channels in one bundle"; with the promotion the `SetKind` is now redundant for a table rather than required. Left alone deliberately, since PR #1607 edits that same doc block and the sentence is not false.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_