### PR TITLE
fix(wasm,python): order quill.metadata by the quill, not by HashMap iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+- fix(wasm,python): **`quill.metadata` key order is a function of the quill.**
+  The five standard keys (`name`, `version`, `backend`, `author`,
+  `description`) come first in that order, then the extra keys sorted by name,
+  so `JSON.stringify` / `json.dumps` of a metadata snapshot is stable across
+  processes. The extras rode core's `HashMap` iteration order.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -47,9 +47,10 @@ render session and canvas preview; Python renders in one shot via
 [`@quillmark/wasm`](../wasm)'s.
 
 A `Quill` is portable, declarative config data, and `quill.metadata` a pure,
-infallible snapshot of the `quill:` section. The engine resolves the declared
-backend, so only the format probe (`supported_formats`) and `render` raise
-`engine::backend_not_found`.
+infallible snapshot of the `quill:` section: `name`, `version`, `backend`,
+`author`, `description`, then any extra keys in sorted order. The engine
+resolves the declared backend, so only the format probe (`supported_formats`)
+and `render` raise `engine::backend_not_found`.
 
 ### `Quillmark`
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -8,6 +8,7 @@ use pyo3::Bound;
 use quillmark::{
     quill_from_path, Diagnostic, Document, Location, OutputFormat, Quill, Quillmark, RenderResult,
 };
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::time::Instant;
 
@@ -143,6 +144,10 @@ impl PyQuill {
     /// Identity snapshot mirroring the `quill:` section of `Quill.yaml`. A pure
     /// config read: capability lives on the engine, as
     /// `Quillmark.supported_formats(quill)`.
+    ///
+    /// The five standard keys come first in their declared order, then the
+    /// extra keys sorted by name, so the dict's key order is a function of the
+    /// quill alone.
     #[getter]
     fn metadata<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         let source = &self.inner;
@@ -155,13 +160,13 @@ impl PyQuill {
         dict.set_item("author", &config.author)?;
         dict.set_item("description", &config.description)?;
 
-        for (key, value) in source.metadata() {
-            if quillmark_core::STANDARD_METADATA_KEYS.contains(&key.as_str()) {
-                continue;
-            }
-            if dict.contains(key)? {
-                continue;
-            }
+        let extras: BTreeMap<&str, &quillmark_core::QuillValue> = source
+            .metadata()
+            .iter()
+            .filter(|(key, _)| !quillmark_core::STANDARD_METADATA_KEYS.contains(&key.as_str()))
+            .map(|(key, value)| (key.as_str(), value))
+            .collect();
+        for (key, value) in extras {
             dict.set_item(key, quillvalue_to_py(py, value)?)?;
         }
 

--- a/crates/bindings/python/tests/test_quill.py
+++ b/crates/bindings/python/tests/test_quill.py
@@ -32,3 +32,41 @@ def test_quill_from_path_bad_backend_loads_then_fails_at_render(tmp_path):
     )
     with pytest.raises(QuillmarkError):
         Quillmark().render(quill, doc, OutputFormat.PDF)
+
+
+def test_metadata_orders_standard_keys_then_extras_sorted(tmp_path):
+    """metadata's key order is a function of the quill: the five standard keys
+    in their declared order, then the extra keys sorted by name."""
+    quill_dir = tmp_path / "meta_quill"
+    quill_dir.mkdir()
+    (quill_dir / "Quill.yaml").write_text(
+        "quill:\n"
+        '  name: "meta_quill"\n'
+        '  version: "0.1.0"\n'
+        '  backend: "typst"\n'
+        '  description: "Metadata test"\n'
+        "typst:\n"
+        "  zeta: z\n"
+        "  plate_file: plate.typ\n"
+        "  alpha: a\n"
+        "  nu: n\n"
+        "  beta: b\n"
+        "  mu: m\n"
+    )
+    (quill_dir / "plate.typ").write_text("= Test\n")
+
+    quill = Quill.from_path(str(quill_dir))
+
+    assert list(quill.metadata) == [
+        "name",
+        "version",
+        "backend",
+        "author",
+        "description",
+        "typst_alpha",
+        "typst_beta",
+        "typst_mu",
+        "typst_nu",
+        "typst_plate_file",
+        "typst_zeta",
+    ]

--- a/crates/bindings/wasm/basic.test.js
+++ b/crates/bindings/wasm/basic.test.js
@@ -1690,6 +1690,40 @@ card_kinds:
     expect(schema.card_kinds.indorsement.fields.CARD).toBeUndefined()
   })
 
+  it('orders the five standard keys first, then the extra keys sorted by name', () => {
+    const EXTRAS_QUILL_YAML = `quill:
+  name: meta_test_quill
+  version: "0.2.1"
+  backend: typst
+  description: Metadata test
+
+typst:
+  zeta: z
+  plate_file: plate.typ
+  alpha: a
+  nu: n
+  beta: b
+  mu: m
+`
+    const quill = Quill.fromTree(
+      makeQuill({ name: 'meta_test_quill', plate: TEST_PLATE, quillYaml: EXTRAS_QUILL_YAML }),
+    )
+
+    expect(Object.keys(quill.metadata)).toEqual([
+      'name',
+      'version',
+      'backend',
+      'author',
+      'description',
+      'typst_alpha',
+      'typst_beta',
+      'typst_mu',
+      'typst_nu',
+      'typst_plate_file',
+      'typst_zeta',
+    ])
+  })
+
   it('metadata and schema are JSON.stringify-able (plain objects)', () => {
     const quill = Quill.fromTree(
       makeQuill({ name: 'meta_test_quill', plate: TEST_PLATE, quillYaml: META_QUILL_YAML }),

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -4,9 +4,8 @@ use crate::types::Diagnostic;
 use crate::types::{ChangeSet, ContentHit, FieldRegion, RenderOptions, RenderResult};
 use js_sys::{Array, Uint8Array};
 #[cfg(any(feature = "typst", feature = "pdfform"))]
-use serde::Deserialize;
-use serde::Serialize;
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use std::collections::{BTreeMap, HashMap};
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -115,6 +114,9 @@ export interface QuillSchema {
  * Identity snapshot mirroring the `quill:` section of `Quill.yaml`. The schema
  * lives on `Quill.schema`; output formats are a resolved-backend capability read
  * from `Quillmark.supportedFormats`, not part of this config snapshot.
+ *
+ * These five keys come first in the order below; any extra `quill:` keys follow
+ * in sorted order.
  */
 export interface QuillMetadata {
     name: string;
@@ -592,10 +594,7 @@ impl Quillmark {
             .supported_formats(&quill.inner)
             .map_err(|e| WasmError::from(e).to_js_value())?;
         let out: Vec<crate::types::OutputFormat> = formats.iter().map(|f| (*f).into()).collect();
-        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        out.serialize(&serializer).map_err(|e| {
-            WasmError::from(format!("supportedFormats: serialization failed: {e}")).to_js_value()
-        })
+        serialize_or_throw(&out, "supportedFormats")
     }
 
     /// Whether `quill`'s backend can paint sessions to a canvas; `false` when the
@@ -663,45 +662,36 @@ impl Quill {
     /// Identity snapshot of the `quill:` section of `Quill.yaml` plus any extra
     /// `quill:` keys. Pure config: output formats are a resolved-backend
     /// capability read from `Quillmark.supportedFormats`, not part of this.
+    ///
+    /// The five standard keys come first in their declared order, then the
+    /// extra keys sorted by name, so the object's key order is a function of
+    /// the quill alone.
     #[wasm_bindgen(getter, js_name = metadata, unchecked_return_type = "QuillMetadata")]
     pub fn metadata(&self) -> Result<JsValue, JsValue> {
         let source = &self.inner;
         let config = source.config();
 
-        let mut obj = serde_json::Map::new();
-        obj.insert(
-            "name".to_string(),
-            serde_json::Value::String(config.name.clone()),
-        );
-        obj.insert(
-            "version".to_string(),
-            serde_json::Value::String(config.version.clone()),
-        );
-        obj.insert(
-            "backend".to_string(),
-            serde_json::Value::String(config.backend.clone()),
-        );
-        obj.insert(
-            "author".to_string(),
-            serde_json::Value::String(config.author.clone()),
-        );
-        obj.insert(
-            "description".to_string(),
-            serde_json::Value::String(config.description.clone()),
-        );
-
-        for (key, value) in source.metadata() {
-            if quillmark_core::STANDARD_METADATA_KEYS.contains(&key.as_str()) {
-                continue;
-            }
-            if obj.contains_key(key) {
-                continue;
-            }
-            obj.insert(key.clone(), value.as_json().clone());
+        let mut value = serde_json::json!({
+            "name": config.name,
+            "version": config.version,
+            "backend": config.backend,
+            "author": config.author,
+            "description": config.description,
+        });
+        let serde_json::Value::Object(obj) = &mut value else {
+            unreachable!("json! builds an object")
+        };
+        let extras: BTreeMap<&str, &serde_json::Value> = source
+            .metadata()
+            .iter()
+            .filter(|(key, _)| !quillmark_core::STANDARD_METADATA_KEYS.contains(&key.as_str()))
+            .map(|(key, value)| (key.as_str(), value.as_json()))
+            .collect();
+        for (key, extra) in extras {
+            obj.insert(key.to_string(), extra.clone());
         }
 
-        let val = serde_json::Value::Object(obj);
-        serialize_or_throw(&val, "metadata")
+        serialize_or_throw(&value, "metadata")
     }
 
     /// Validate `doc` against this quill's schema, returning every diagnostic
@@ -711,12 +701,7 @@ impl Quill {
     #[wasm_bindgen(js_name = validate, unchecked_return_type = "Diagnostic[]")]
     pub fn validate(&self, doc: &Document) -> Result<JsValue, JsValue> {
         let diags = self.inner.validate(&doc.inner);
-        let serializer = serde_wasm_bindgen::Serializer::new()
-            .serialize_maps_as_objects(true)
-            .serialize_missing_as_null(true);
-        diags.serialize(&serializer).map_err(|e| {
-            WasmError::from(format!("validate: serialization failed: {e}")).to_js_value()
-        })
+        serialize_or_throw(&diags, "validate")
     }
 
     /// Parse `markdown` and conform it against this quill: the primary ingestion
@@ -758,12 +743,7 @@ impl Quill {
             .conform(&mut doc.inner)
             .map_err(WasmError::from)
             .map_err(|e| e.to_js_value())?;
-        let serializer = serde_wasm_bindgen::Serializer::new()
-            .serialize_maps_as_objects(true)
-            .serialize_missing_as_null(true);
-        diags.serialize(&serializer).map_err(|e| {
-            WasmError::from(format!("conform: serialization failed: {e}")).to_js_value()
-        })
+        serialize_or_throw(&diags, "conform")
     }
 
     /// The resolved-value view of `doc`: the ABI under `reader.resolve()`. For
@@ -775,12 +755,7 @@ impl Quill {
     #[wasm_bindgen(js_name = _resolve, skip_typescript, unchecked_return_type = "Resolved")]
     pub fn resolve(&self, doc: &Document) -> Result<JsValue, JsValue> {
         let states = self.inner.resolve(&doc.inner);
-        let serializer = serde_wasm_bindgen::Serializer::new()
-            .serialize_maps_as_objects(true)
-            .serialize_missing_as_null(true);
-        states.serialize(&serializer).map_err(|e| {
-            WasmError::from(format!("resolve: serialization failed: {e}")).to_js_value()
-        })
+        serialize_nullable_or_throw(&states, "resolve")
     }
 
     /// Seed a starter `Document` from the schema: the main card plus one instance
@@ -1731,20 +1706,16 @@ impl Document {
         addr.require_card_only("readerValues")?;
         let base = self.addr_base(&addr);
         let reader = quill.inner.reader(&self.inner);
-        let serializer = serde_wasm_bindgen::Serializer::new()
-            .serialize_maps_as_objects(true)
-            .serialize_missing_as_null(true);
-        let serialized = match addr.card {
-            None => reader.values().serialize(&serializer),
-            Some(index) => reader
-                .card(index)
-                .map_err(|e| edit_error_to_js(&e, &base))?
-                .values()
-                .serialize(&serializer),
-        };
-        serialized.map_err(|e| {
-            WasmError::from(format!("reader.values: serialization failed: {e}")).to_js_value()
-        })
+        match addr.card {
+            None => serialize_nullable_or_throw(&reader.values(), "reader.values"),
+            Some(index) => serialize_nullable_or_throw(
+                &reader
+                    .card(index)
+                    .map_err(|e| edit_error_to_js(&e, &base))?
+                    .values(),
+                "reader.values",
+            ),
+        }
     }
 
     /// Write the values form at `addr`: the ABI under `writer.setValues` (the
@@ -1872,10 +1843,7 @@ impl Document {
         let card = quillmark_core::Card::try_from(string_wire)
             .map_err(|e| WasmError::from(format!("makeCard: {e}")).to_js_value())?;
         let wire = quillmark_core::CardWire::from(&card);
-        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        wire.serialize(&serializer).map_err(|e| {
-            WasmError::from(format!("makeCard: serialization failed: {e}")).to_js_value()
-        })
+        serialize_or_throw(&wire, "makeCard")
     }
 
     /// Insert a card: `at` absent appends, a number inserts at that index (in
@@ -2283,15 +2251,11 @@ pub fn parse_doc_path(path: &str) -> Result<JsValue, JsValue> {
         .parse::<quillmark_core::DocPath>()
         .map_err(|e| WasmError::from(e.to_string()).to_js_value())?;
     // Via `serde_json::Value` so the tagged segments cross as plain objects,
-    // sidestepping serde-wasm-bindgen's tagged-enum handling; `missing_as_null`
-    // because the `DocPathSeg` contract is `kind: string | null`.
+    // sidestepping serde-wasm-bindgen's tagged-enum handling; nullable because
+    // the `DocPathSeg` contract is `kind: string | null`.
     let json = serde_json::to_value(&doc_path)
         .map_err(|e| WasmError::from(format!("parseDocPath: {e}")).to_js_value())?;
-    let serializer = serde_wasm_bindgen::Serializer::new()
-        .serialize_maps_as_objects(true)
-        .serialize_missing_as_null(true);
-    json.serialize(&serializer)
-        .map_err(|e| WasmError::from(format!("parseDocPath: {e}")).to_js_value())
+    serialize_nullable_or_throw(&json, "parseDocPath")
 }
 
 /// Serialize structured [`DocPathSeg`] segments back to the canonical path
@@ -2538,7 +2502,26 @@ fn serialize_or_throw<T: serde::Serialize + ?Sized>(
     value: &T,
     what: &str,
 ) -> Result<JsValue, JsValue> {
-    let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
+    serialize_inner(value, what, false)
+}
+
+/// [`serialize_or_throw`] for a shape whose declared type spells `null`: an
+/// absent `Option` crosses as `null` instead of as a missing property.
+fn serialize_nullable_or_throw<T: serde::Serialize + ?Sized>(
+    value: &T,
+    what: &str,
+) -> Result<JsValue, JsValue> {
+    serialize_inner(value, what, true)
+}
+
+fn serialize_inner<T: serde::Serialize + ?Sized>(
+    value: &T,
+    what: &str,
+    missing_as_null: bool,
+) -> Result<JsValue, JsValue> {
+    let serializer = serde_wasm_bindgen::Serializer::new()
+        .serialize_maps_as_objects(true)
+        .serialize_missing_as_null(missing_as_null);
     value
         .serialize(&serializer)
         .map_err(|e| WasmError::from(format!("{what}: serialization failed: {e}")).to_js_value())
@@ -2932,13 +2915,13 @@ impl LiveSession {
             .inner
             .page_size_pt(page)
             .ok_or_else(|| self.page_oob_error("pageSize", page))?;
-        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        PageSize {
-            width_pt,
-            height_pt,
-        }
-        .serialize(&serializer)
-        .map_err(|e| WasmError::from(format!("pageSize: serialization failed: {e}")).to_js_value())
+        serialize_or_throw(
+            &PageSize {
+                width_pt,
+                height_pt,
+            },
+            "pageSize",
+        )
     }
 
     /// Paint `page` into a `CanvasRenderingContext2D` or
@@ -3055,10 +3038,7 @@ impl LiveSession {
             clamped,
             effective_density_scale: effective_density,
         };
-        let serializer = serde_wasm_bindgen::Serializer::new().serialize_maps_as_objects(true);
-        result
-            .serialize(&serializer)
-            .map_err(|e| WasmError::from(format!("paint: serialization failed: {e}")).to_js_value())
+        serialize_or_throw(&result, "paint")
     }
 }
 

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -8,7 +8,7 @@ Quillmark exposes one core engine through several language surfaces: Python (PyO
 
 ## Shared model
 
-- **Capability principle.** A `Quill` is portable, declarative config data. Its format capability (`supportedFormats`) and rendering are resolved by the `Quillmark` engine *against* a quill at render time: never by the quill itself. So `quill.metadata` is a pure, infallible config snapshot, while `render` / `supportedFormats` can fail for an unregistered backend.
+- **Capability principle.** A `Quill` is portable, declarative config data. Its format capability (`supportedFormats`) and rendering are resolved by the `Quillmark` engine *against* a quill at render time: never by the quill itself. So `quill.metadata` is a pure, infallible config snapshot, while `render` / `supportedFormats` can fail for an unregistered backend. Its key order is a function of the quill, identical on both surfaces carrying it: `name`, `version`, `backend`, `author`, `description`, then any extra keys in sorted order.
 - **One model, serialized across every boundary.** The `Document`/`Card` model and `Diagnostic`s cross each language boundary as the same core `serde` shapes (`CardWire`, the versioned storage DTO, `Diagnostic`), so a card or an error reads identically no matter which surface emits it. See [DOCUMENT_STORAGE.md](DOCUMENT_STORAGE.md), [CARDS.md](CARDS.md), [ERROR.md](ERROR.md).
 - **Uniform errors.** Each binding raises a single error type that always carries a non-empty diagnostic list (`QuillmarkError.diagnostics` / thrown `Error.diagnostics`).
 


### PR DESCRIPTION
Closes #1513.
Closes #1532.

## The change

`quill.metadata` emits the five standard keys (`name`, `version`, `backend`, `author`, `description`) in that order, then the extra keys sorted by name. Both bindings collect the extras from core's `HashMap` into a `BTreeMap` before inserting, so `JSON.stringify` / `json.dumps` of a snapshot is stable across processes. The redundant "already present?" guard goes: `STANDARD_METADATA_KEYS` is exactly the set of keys inserted first, and the filter already excludes it.

In `crates/bindings/wasm/src/engine.rs`, the nine hand-rolled `serde_wasm_bindgen::Serializer` blocks route through `serialize_or_throw` and a new `serialize_nullable_or_throw` twin (a twin, not a `bool` parameter: twenty existing call sites would otherwise each grow a bare `false`). The twin carries `serialize_missing_as_null` at the three sites whose declared type spells `null` (`reader.values`, `resolve`, `parseDocPath`), and `validate` / `conform` take the plain one, verified against `quillmark_core::Diagnostic`, whose every `Option` is `skip_serializing_if` and whose `Location` has none. `Quill::metadata` builds the standard keys from a `json!` literal. `use serde::Serialize` moves under the `typst`/`pdfform` cfg with `Deserialize`, since the only remaining concrete-type `.serialize` call is behind those features and the core build otherwise warns.

## Docs

`prose/canon/BINDINGS.md` § "Shared model" and the Python README state the key order where the snapshot's shape is described; the `QuillMetadata` TS doc comment and both getters' doc comments say the extras follow in sorted order.

## Verification

- `cargo test --workspace`: green.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `node scripts/check-canon.mjs`: canon spine OK.
- `cargo clippy -p quillmark-wasm --target wasm32-unknown-unknown` (default, `--no-default-features`, and `--features pdfform`) and `cargo clippy -p quillmark-python`: no new warnings.
- WASM: `./scripts/build-wasm.sh --ci`, then `npx vitest run` (265 passed, 6 files) and `npm run typecheck` in `crates/bindings/wasm`. `npm install --legacy-peer-deps` was needed once in this sandbox.
- Python: `uv venv && uv pip install maturin pytest && maturin develop && pytest` in `crates/bindings/python`: 117 passed.
- Both new tests were confirmed to be real guards: with the Python sort reverted and the extension rebuilt, `test_metadata_orders_standard_keys_then_extras_sorted` failed in 4 of 5 runs (the residual pass is the 1-in-720 chance that a random `HashMap` order lands sorted; each test uses six extra keys for that reason).

## For review

`quillmark info --json` (`crates/bindings/cli/src/commands/info.rs`) builds its nested `metadata` object from the same `HashMap` walk and has the same unstable order. Neither issue names it and it is out of this PR's stated scope, so the canon sentence is scoped to the two surfaces carrying the `metadata` getter rather than claiming every surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_