### PR TITLE
fix(wasm): code an unregistered backend `engine::backend_not_found`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(wasm): **an unregistered backend rejects with `engine::backend_not_found`
+  like every other failure.** The four `Engine` verbs threw a bare `Error` for a
+  quill whose declared `backend:` has no loader, so `isQuillmarkError` answered
+  `false` and the README's own `catch` example re-threw it as a foreign
+  failure. The rejection now carries one diagnostic under the code core and the
+  Python binding already raise, hinting the registered backend ids.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -464,6 +464,9 @@ applies to every throw site:
 - `engine.render(quill, parsed)` against a quill whose *name* differs
   (`quill::name_mismatch`) or whose *version* falls outside the document's
   selector (`quill::version_mismatch`): a throw, never a warning.
+- The four `Engine` verbs against a quill whose declared `backend:` is not in
+  the registry: `engine::backend_not_found`, the code core raises for the same
+  condition, hinting the registered ids.
 - Any method taking a `Quill` or `Document`: a handle from a *second* copy of
   `@quillmark/wasm` is refused with `runtime::foreign_handle`, hinting `npm ls
   @quillmark/wasm`. Two copies are two WASM memories and two `Quill`/`Document`

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -1092,7 +1092,7 @@ A single line of body ink.`
     expect(b.artifacts.length).toBeGreaterThan(0)
   })
 
-  it('throws a clear error for an unregistered backend', async () => {
+  it('rejects an unregistered backend with engine::backend_not_found, probes like renders', async () => {
     const engine = new Engine()
     // A quill whose declared backend has no loader.
     const yaml = `quill:
@@ -1108,7 +1108,19 @@ main:
 `
     const quill = Quill.fromTree(new Map([['Quill.yaml', new TextEncoder().encode(yaml)]]))
     const doc = quill.seedDocument()
-    await expect(engine.render(quill, doc)).rejects.toThrow(/no backend registered/)
+    for (const [call, verb] of [
+      [() => engine.render(quill, doc), 'engine.render'],
+      [() => engine.supportedFormats(quill), 'engine.supportedFormats'],
+    ]) {
+      const caught = await call().then(
+        () => expect.unreachable(`${verb} resolved against an unregistered backend`),
+        (e) => e
+      )
+      expect(isQuillmarkError(caught)).toBe(true)
+      expect(caught.diagnostics[0].code).toBe('engine::backend_not_found')
+      expect(caught.message).toContain('doesnotexist')
+      expect(caught.diagnostics[0].hint).toContain('typst')
+    }
   })
 
   it('accepts a custom backend descriptor override', async () => {

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -515,6 +515,10 @@ export interface EngineOptions {
  * `quill.backendId`, lazily loads that backend build, clones the quill and
  * document into the backend's WASM memory on demand, renders, and frees the
  * clones. The cross-memory crossing is invisible to callers.
+ *
+ * A `quill.backendId` outside the registry rejects with
+ * `engine::backend_not_found`, the capability probes included. The diagnostic's
+ * `hint` names the registered ids.
  */
 export declare class Engine {
 	constructor(options?: EngineOptions);

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -710,17 +710,19 @@ export class Engine {
 	}
 
 	/**
-	 * The registered descriptor for `backendId`, or the "no backend registered"
-	 * throw. Touches no binary.
+	 * The registered descriptor for `backendId`, or the
+	 * `engine::backend_not_found` throw core raises for the same condition.
+	 * Touches no binary.
 	 * @param {string} backendId
 	 * @returns {{ load: () => Promise<unknown>, formats: string[], canvas: boolean }}
 	 */
 	#descriptorFor(backendId) {
 		const descriptor = this.#loaders[backendId];
 		if (!descriptor) {
-			throw new Error(
-				`Engine: no backend registered for '${backendId}'. ` +
-					`Known backends: ${Object.keys(this.#loaders).join(', ') || '(none)'}.`
+			throw quillmarkError(
+				'engine::backend_not_found',
+				`Engine: backend '${backendId}' not registered or not enabled.`,
+				`Available backends: ${Object.keys(this.#loaders).join(', ') || '(none)'}`
 			);
 		}
 		return descriptor;


### PR DESCRIPTION
Closes #1511.

## The change

`Engine.#descriptorFor` in `crates/bindings/wasm/runtime/runtime.js` threw a bare `Error` for a quill whose declared `backend:` has no registered loader. It carried no `diagnostics`, so `isQuillmarkError` answered `false` and the README's own `catch` example re-threw it as "not a quillmark failure", from all four `Engine` verbs, since `render`/`open` reach it through `#resolveBackend` and `supportedFormats`/`supportsCanvas` call it directly.

It now throws through the runtime's existing `quillmarkError(code, message, hint)` under `engine::backend_not_found`, the code core (`Quillmark::resolve_backend`) and the Python binding already raise. Message and hint mirror core's vocabulary so the three surfaces read alike: `Engine: backend '<id>' not registered or not enabled.` with `Available backends: <ids>` (`(none)` on an empty registry, which core has no equivalent for). The code carries no args in ERROR.md's table (`engine::*` is off it by the § Scope rule), so nothing to add there.

`validateBackend`'s construction-time throws stay bare, as the issue asks: a malformed descriptor is a programming error at `new Engine(...)`, not a render-path refusal.

## Docs

README § Errors gains the throw-site bullet naming the code beside its `quill::*` and `runtime::*` siblings; the `Engine` class doc in `runtime.d.ts` states the rejection once for all four verbs rather than repeating it per method. No canon change: ERROR.md § "Bindings Error Delegation" and BINDINGS.md § "Capability principle" already promised this, and the code was the thing out of step.

## Verification

- `./scripts/build-wasm.sh --ci`, then `npx vitest run` in `crates/bindings/wasm`: 264 passed, 6 files.
- `npm run typecheck`: clean.
- `cargo test --workspace`: green (no Rust changed).

The existing unregistered-backend case in `runtime.test.js` now asserts the invariant rather than the sentence: `isQuillmarkError`, `diagnostics[0].code === 'engine::backend_not_found'`, the message naming the backend, and the hint naming a registered id, looped over `engine.render` and `engine.supportedFormats` so the probe path is covered alongside the render path.

## For review

The message keeps the runtime's `Engine: ` scope prefix over core's bare `Backend '<id>' …`, matching the sibling `runtime::backend_load_failed` at the same seam. If the preference is byte-identical prose across surfaces, drop the prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_