### PR TITLE
fix(wasm): merge the document's load warnings in the runtime `Engine.render`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+- fix(wasm): **`Engine.render` returns the document's load warnings ahead of
+  the compile's own.** The engine renders a backend-memory clone built by
+  `Document.fromStored`, which carries no warnings, so a `@quillmark/wasm`
+  consumer got compile warnings only and a parse, `conform::*` or
+  `plate::unsupported_construct` diagnostic reached `RenderResult.warnings`
+  from no public surface. `Engine.render` now snapshots `doc.warnings` beside
+  the storage DTO and fronts the result with it, the pipeline order ERROR.md
+  states. `doc.warnings` still carries the same list, and
+  `LiveSession.render` carries the compile half alone.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/bindings/wasm/README.md
+++ b/crates/bindings/wasm/README.md
@@ -352,6 +352,12 @@ A document that compiles to zero pages still produces a valid session
 `pageCount === 0` to render a "no pages to preview" UI rather than relying on
 the throw.
 
+Their `warnings` differ in reach. `engine.render` returns one list for the
+whole pipeline: `doc.warnings` (parse, `conform::*`,
+`plate::unsupported_construct`) ahead of the compile's own. A session outlives
+the document it opened from, so `session.render` and `session.warnings` carry
+the compile half alone — read `doc.warnings` beside them.
+
 ### Canvas Preview
 
 `session.paint(ctx, page, opts?)` rasterizes a page directly into a

--- a/crates/bindings/wasm/runtime.test.js
+++ b/crates/bindings/wasm/runtime.test.js
@@ -68,6 +68,24 @@ function makeRuntimeQuill() {
   return Quill.fromTree(makeQuill({ name: 'test_quill', plate: TEST_PLATE }))
 }
 
+// A quill declaring one construct its plate does not typeset, so `quill.parse`
+// draws a `plate::unsupported_construct` warning off a body holding a rule.
+const DECLINE_QUILL_YAML = `quill:
+  name: decliner
+  version: "1.0"
+  backend: typst
+  description: A quill that typesets no horizontal rule
+
+main:
+  body:
+    unsupported: [rule]
+  fields: {}
+`
+
+const DECLINE_PLATE = `#import "@local/quillmark-helper:0.1.0": data
+
+#data.at("$body")`
+
 const PKG_DIR = path.resolve(import.meta.dirname, '..', '..', '..', 'pkg')
 
 /** Read a field value from a card's payloadItems list by key. */
@@ -773,6 +791,24 @@ describe('@quillmark/wasm/runtime: Engine (hidden core→backend crossing)', () 
     const formats = await engine.supportedFormats(quill)
     expect(formats).toContain('svg')
     expect(typeof (await engine.supportsCanvas(quill))).toBe('boolean')
+  })
+
+  // ERROR.md § "Warning flow": `RenderResult.warnings` is pipeline order, the
+  // load half ahead of the compile's. Only the runtime layer can merge them —
+  // the document clone it renders comes through `fromStored`, which carries no
+  // warnings, so the backend build's own merge has nothing to prepend.
+  it('render fronts RenderResult.warnings with the load warnings, leaving doc.warnings intact', async () => {
+    const quill = Quill.fromTree(
+      makeQuill({ name: 'decliner', plate: DECLINE_PLATE, quillYaml: DECLINE_QUILL_YAML }),
+    )
+    const doc = quill.parse('~~~card-yaml\n$quill: decliner\n~~~\n\nAlpha\n\n---\n\nBeta\n')
+    const loadCodes = doc.warnings.map((d) => d.code)
+    expect(loadCodes).toContain('plate::unsupported_construct')
+
+    const result = await new Engine().render(quill, doc, { format: 'svg' })
+    expect(result.artifacts.length).toBeGreaterThan(0)
+    expect(result.warnings.slice(0, loadCodes.length)).toEqual(doc.warnings)
+    expect(doc.warnings.map((d) => d.code)).toEqual(loadCodes)
   })
 
   it('manifest-backed capability probes do NOT load the backend', async () => {

--- a/crates/bindings/wasm/runtime/runtime.d.ts
+++ b/crates/bindings/wasm/runtime/runtime.d.ts
@@ -523,6 +523,12 @@ export declare class Engine {
 	 * Render `doc` against `quill` in one shot. Both handles are read
 	 * synchronously before the first await, so the caller may `free()` them as
 	 * soon as this call returns.
+	 *
+	 * This is the surface that merges the two warning halves:
+	 * {@link RenderResult.warnings} carries `doc.warnings` (parse, `conform::*`,
+	 * `plate::unsupported_construct`) ahead of the compile's own. A
+	 * {@link LiveSession} outlives the document it opened from, so
+	 * {@link LiveSession.render} carries the compile half alone.
 	 */
 	render(quill: Quill, doc: Document, options?: RenderOptions): Promise<RenderResult>;
 

--- a/crates/bindings/wasm/runtime/runtime.js
+++ b/crates/bindings/wasm/runtime/runtime.js
@@ -799,11 +799,15 @@ export class Engine {
 	 * memory and run `fn` against the backend engine. Only `render`/`open` call
 	 * this, so `doc` is always present.
 	 *
-	 * OWNERSHIP WINDOW: both caller handles are snapshotted (`doc.toStored()`, and
-	 * `quill.toTree()` on a clone-cache miss) BEFORE the first await. The backend
-	 * load below is a real suspension point, so reading the handles after it
-	 * would race a caller that `free()`s them as soon as this call returns its
-	 * promise ("null pointer passed to rust").
+	 * OWNERSHIP WINDOW: both caller handles are snapshotted (`doc.toStored()` and
+	 * `doc.warnings`, and `quill.toTree()` on a clone-cache miss) BEFORE the first
+	 * await. The backend load below is a real suspension point, so reading the
+	 * handles after it would race a caller that `free()`s them as soon as this
+	 * call returns its promise ("null pointer passed to rust").
+	 *
+	 * `docWarnings` rides the context because the storage DTO does not carry
+	 * them: `fromStored` clears the load's warnings, so the backend clone knows
+	 * nothing of them and `render` splices the snapshot back in.
 	 *
 	 * Clone lifetimes differ by design: the `doc` clone is TRANSIENT, freed in
 	 * the `finally` of every call, while the `quill` clone is CACHED and is not
@@ -813,12 +817,13 @@ export class Engine {
 	 * @param {string} method the caller's name, for the rejection message
 	 * @param {Quill} quill
 	 * @param {Document} doc
-	 * @param {(ctx: { mod: any, engine: any, quill: any, doc: any }) => any} fn
+	 * @param {(ctx: { mod: any, engine: any, quill: any, doc: any, docWarnings: any[] }) => any} fn
 	 */
 	async #withClones(method, quill, doc, fn) {
 		const backendId = this.#backendOf(quill, method);
 		requireLocalDoc(doc, method);
 		const docJson = doc.toStored();
+		const docWarnings = doc.warnings;
 		const quillTree = this.#quillClones.get(backendId)?.has(quill) ? null : quill.toTree();
 		const { mod, engine } = await this.#resolveBackend(backendId);
 		// The doc clone and `fn` share one try so the clone is freed even if a
@@ -828,7 +833,7 @@ export class Engine {
 		let backendDoc = null;
 		try {
 			backendDoc = mod.Document.fromStored(docJson);
-			return fn({ mod, engine, quill: backendQuill, doc: backendDoc });
+			return fn({ mod, engine, quill: backendQuill, doc: backendDoc, docWarnings });
 		} finally {
 			backendDoc?.free();
 		}
@@ -843,8 +848,15 @@ export class Engine {
 	 * @returns {Promise<import('./runtime.js').RenderResult>}
 	 */
 	async render(quill, doc, options) {
-		return this.#withClones('engine.render(quill, doc)', quill, doc, ({ engine, quill: q, doc: d }) =>
-			engine.render(q, d, options ?? undefined)
+		return this.#withClones(
+			'engine.render(quill, doc)',
+			quill,
+			doc,
+			({ engine, quill: q, doc: d, docWarnings }) => {
+				const result = engine.render(q, d, options ?? undefined);
+				result.warnings = docWarnings.concat(result.warnings);
+				return result;
+			}
 		);
 	}
 

--- a/prose/canon/BINDINGS.md
+++ b/prose/canon/BINDINGS.md
@@ -178,6 +178,8 @@ Each backend (Typst and pdfform) is a **private** build with its own linear memo
 
 Backend handles never escape the `Engine`: it clones the quill tree + `doc.toStored()` into the backend's memory as serialized data and frees the clones.
 
+The storage DTO carries no warnings, so the clone the backend renders knows nothing of the load's. `Engine.render` snapshots `doc.warnings` beside the DTO and splices it into `RenderResult.warnings` ahead of the compile's own ([ERROR.md](ERROR.md) § "Warning flow"): the runtime layer, not the backend build, is the surface that merges the two halves. `LiveSession.render` carries the compile half alone, a session outliving the document it opened from.
+
 **Exactly one copy of the package per process.** Two copies are two core builds (two linear memories, two `Quill`/`Document` classes), and no topology legitimately loads a multi-megabyte binary twice and needs handles to cross between the copies. Every seam taking a core handle checks it and throws a `QuillmarkError` naming the duplicate install, including the ones that could cross as data (`Engine`, `LiveSession.update`). Errors are the exception: `isQuillmarkError` stays structural, an error being data rather than a handle.
 
 Beyond the byte-output verbs (`engine.render`, `LiveSession.render`), the canvas-capable backend builds (Typst, and pdfform under its preview seam) expose a **live preview** path on `LiveSession` (`update`, `pageCount`, `pageSize`, `paint`, …). See [PREVIEW.md](PREVIEW.md).

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -77,8 +77,12 @@ families:
 
 - **Parse warnings**: the `warnings` on the `Parsed` that `Document::parse`
   returns (e.g. a `~~~` opener missing its blank line). The CLI render and the
-  WASM one-shot render splice them into `RenderResult.warnings` ahead of any
-  compile warnings.
+  WASM one-shot render splice the whole `Parsed.warnings` carrier — this family
+  plus the two below that `Quill::parse` appends to it — into
+  `RenderResult.warnings` ahead of any compile warnings. In WASM the surface
+  that merges is the runtime `Engine.render`, reading the carrier off the
+  caller's `doc.warnings`: the backend-memory clone it renders is built by
+  `Document.fromStored`, which carries none.
 - **`conform::*`: resting-form warnings.** `Quill::conform` returns one per
   declared content field whose value the strict write refuses, and
   `Quill::parse` appends them to the `Parsed.warnings` the parse produced. Each


### PR DESCRIPTION
Closes #1510.

## The change

The issue's premise held at every cited site. `Quillmark.render` in `crates/bindings/wasm/src/engine.rs` prepends `doc.parse_warnings`, but the public `Engine.render` in `crates/bindings/wasm/runtime/runtime.js` renders a backend-memory clone built by `Document.fromStored`, which clears them by design, so the Rust merge had nothing to prepend and a `@quillmark/wasm` consumer saw compile warnings only.

Takes the first option, honouring ERROR.md. `#withClones` snapshots `doc.warnings` beside `doc.toStored()`, inside the pre-await ownership window, and passes it on the context; `Engine.render` fronts `RenderResult.warnings` with it. That carrier holds exactly what the Rust merge would have added (parse, `conform::*`, and `plate::unsupported_construct`, all produced by `Quill::parse`), and the core render pipeline emits none of them, so nothing duplicates.

`open` is left alone: the Rust `Quillmark.open` and `LiveSession.render` do not merge parse warnings, and a session outlives the document it opened from.

## Docs

ERROR.md § "Warning flow" now says the splice carries the whole `Parsed.warnings` carrier and names the runtime `Engine.render` as the WASM surface that does it, with the `fromStored` reason. BINDINGS.md § WASM states the same at the clone-crossing paragraph where the mechanism lives. `runtime.d.ts` carries the consumer-facing contract on `Engine.render`; the binding README contrasts the two paths' `warnings` reach under "`engine.render` vs. `engine.open`".

## Verification

- `./scripts/build-wasm.sh --ci` then `npx vitest run` in `crates/bindings/wasm`: 265 passed, 6 files.
- `npm run typecheck`: clean.
- `cargo test --workspace`: green (no Rust changed).
- `node scripts/check-canon.mjs`: canon spine OK.
- The new `runtime.test.js` case was confirmed to fail on the pre-fix runtime (`result.warnings` came back `[]`) and pass after.

## For review

The snapshot is read in `#withClones` rather than in `render`, so `open` pays one `doc.warnings` serialization it does not use. That keeps the pre-await ownership rule stated in one place and the read after `requireLocalDoc`, so the duplicate-install rejection still fires first; the cost is an empty-array serialization on the usual path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_