### PR TITLE
fix(python): OutputFormat and Severity members hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+- fix(python): **`OutputFormat` and `Severity` members are hashable.** The two
+  pyclass mirrors declared `eq` alone, which fills `tp_richcompare` and leaves
+  no `tp_hash`, so CPython stamped `__hash__ = None` and every variant was
+  rejected as a set member or a dict key: `set(engine.supported_formats(quill))`
+  and `Counter(d.severity for d in exc.diagnostics)` raised `TypeError`. Both
+  are now frozen and hash by variant, one slot per member.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/bindings/python/src/enums.rs
+++ b/crates/bindings/python/src/enums.rs
@@ -8,8 +8,8 @@ macro_rules! py_enum {
             $($variant:ident),* $(,)?
         }
     ) => {
-        #[pyclass(name = $py_name, eq, eq_int, from_py_object)]
-        #[derive(Clone, Copy, PartialEq)]
+        #[pyclass(name = $py_name, eq, eq_int, hash, frozen, from_py_object)]
+        #[derive(Clone, Copy, PartialEq, Eq, Hash)]
         $(#[$meta])*
         $vis enum $name {
             $($variant),*

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -16,6 +16,7 @@ from quillmark import (
     Document,
     OutputFormat,
     QuillmarkError,
+    Severity,
 )
 from conftest import QUILLS_PATH, _latest_version, raises_edit_code
 
@@ -82,6 +83,14 @@ def test_quill_properties(engine, taro_quill_dir):
     supported_formats = engine.supported_formats(quill)
     assert isinstance(supported_formats, list)
     assert OutputFormat.PDF in supported_formats
+
+
+def test_enum_members_are_hashable():
+    """Both mirrors key a dict and enter a set, one slot per variant."""
+    mime = {OutputFormat.PDF: "application/pdf", OutputFormat.SVG: "image/svg+xml"}
+    assert mime[OutputFormat.PDF] == "application/pdf"
+    assert len(set(OutputFormat.all())) == len(OutputFormat.all())
+    assert len(set(Severity.all())) == len(Severity.all())
 
 
 def test_registered_backends(engine):


### PR DESCRIPTION
Closes #1515.

## The change

`py_enum!` in `crates/bindings/python/src/enums.rs` declared `#[pyclass(name = .., eq, eq_int, from_py_object)]`. `eq` fills only `tp_richcompare`, so PyO3 emitted no `tp_hash` and CPython stamped `__hash__ = None` on both types: a variant could not be a set member or a dict key. The pyclass attributes gain `hash, frozen` and the derive list gains `Eq, Hash`, the issue's proposed fix. PyO3 0.29.2 requires `frozen` and `eq` for `hash` and accepts it beside `eq_int` on a simple enum; both mirrors are fieldless `Copy` enums whose only `#[pymethods]` take `&self`, so `frozen` costs nothing, and `from_py_object` extraction goes through `PyClassGuard`, which frozen classes support.

`Eq` joins `Hash` so the Rust-side type is a usable map key too; the issue named only `Hash`.

Verified by rebuilding without the fix: the new test fails with the issue's exact `TypeError: unhashable type: 'builtins.OutputFormat'`.

## Docs

None. The stub declares no `__hash__` (`object`'s is correct for it) and stubtest is clean; no canon or README claim covers enum hashability.

## Verification

- `cargo test --workspace`: green.
- `cargo clippy -p quillmark-python`: no warnings from the crate.
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: clean.
- `cd crates/bindings/python && uv venv && source .venv/bin/activate && uv pip install maturin pytest && maturin develop && pytest`: 117 passed.
- `uv pip install mypy && python -m mypy.stubtest --ignore-disjoint-bases quillmark`: "Success: no issues found in 2 modules".
- By hand: `hash(OutputFormat.PDF)`, `{OutputFormat.PDF: ...}[OutputFormat.PDF]`, `set(OutputFormat.all())`, `Counter([Severity.ERROR, Severity.WARNING, Severity.ERROR])` all work; `mypy --strict` accepts `set[OutputFormat]` and `dict[OutputFormat, str]`.

## For review

- `eq_int` makes `OutputFormat.PDF == 0` true while the derived hash is not `hash(0)`, so `{0: "pdf"}[OutputFormat.PDF]` still raises `KeyError`, unlike CPython's `IntEnum`, which hashes as its int. Closing that would mean hand-writing `__hash__ -> isize` instead of the `hash` option. Int comparison is undocumented here (the stub declares neither `__int__` nor int equality), so the pyclass option stays.
- The test asserts the dict-key and set-dedup properties but not `hash(x) == hash(x)`: PyO3 hands back the cached singleton for every simple-enum value, so that comparison cannot fail even with an identity hash, and it would not guard anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_