### PR TITLE
fix(python)!: answer a negative index as an out-of-range index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- fix(python)!: **a negative index is an out-of-range index, not an
+  `OverflowError`.** Every index parameter was a `usize`, so `doc.card(-1)`,
+  `doc.move_card(-1, 0)`, `writer.card(-1).set(..)` and `render(pages=[-1])`
+  died in the boundary conversion with a third exception type, outside the two
+  the binding documents. Indices are signed at the boundary now. A negative one
+  addresses nothing — it is not the last card, and the binding does not index
+  from the end — so it takes the answer its site already gives an index past the
+  end: `edit::index_out_of_range` where the verb raises,
+  `typst::page_index_out_of_bounds` for a page, `None` where `remove_card`
+  answers absence.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/bindings/python/README.md
+++ b/crates/bindings/python/README.md
@@ -204,8 +204,10 @@ Neither axis gates render. Partial documents are accepted, and
 
 ## Error contract
 
-Every failure raises `QuillmarkError`, carrying a non-empty `.diagnostics` list
-of `Diagnostic` objects.
+An engine refusal raises `QuillmarkError`, carrying a non-empty `.diagnostics`
+list of `Diagnostic` objects. An argument the binding cannot read at all — a
+non-finite float, a value with no JSON form, a malformed `path` sequence —
+raises `ValueError` before the engine is called, described by no diagnostic.
 
 ```python
 try:
@@ -220,6 +222,11 @@ Mutator failures (invalid field names, kind names, out-of-range indices) carry a
 namespaced `edit::*` `code` on `diagnostics[0]`: `edit::invalid_field_name`,
 `edit::unknown_field`, `edit::index_out_of_range`, `edit::field_coercion_failed`,
 …. Route on `diagnostics[0].code`, never on message text.
+
+Card and page indices count from the front, so a negative one addresses nothing
+rather than the last card or page: it takes the same answer as an index past the
+end — `edit::index_out_of_range` where the verb raises, `None` where
+`remove_card` answers absence.
 
 ## Changelog
 

--- a/crates/bindings/python/src/errors.rs
+++ b/crates/bindings/python/src/errors.rs
@@ -4,6 +4,10 @@
 //! `QuillmarkError` carrying a non-empty `.diagnostics` list; the
 //! `EditError::<Variant>` prefix lives in the message, not the type.
 //!
+//! A negative index is a refusal of that first kind: addressing nothing is what
+//! an out-of-range index is, so it raises under the code an index past the end
+//! carries.
+//!
 //! An argument the binding cannot convert at all — a non-finite float, an int
 //! past 64 bits, a type with no JSON form, a malformed `path` sequence — raises
 //! `ValueError` before the engine is called. No diagnostic describes it, and
@@ -14,8 +18,46 @@ use pyo3::create_exception;
 use pyo3::exceptions::PyException;
 use pyo3::prelude::*;
 use quillmark_core::{Diagnostic, EditError, RenderError, Severity};
+use std::collections::BTreeMap;
 
 create_exception!(_quillmark, QuillmarkError, PyException);
+
+/// Resolve a card index the caller passed. Indices count from the front, so a
+/// negative one is out of range whatever `len` is; a non-negative index past the
+/// end is the calling verb's own to answer.
+///
+/// Index parameters are signed for this: a `usize` parameter refuses a negative
+/// int in extraction, raising the `OverflowError` no contract here mentions. The
+/// diagnostic is minted rather than taken from [`convert_edit_error`] because
+/// `EditError::IndexOutOfRange` carries a `usize` and cannot hold the index.
+pub fn card_index(index: isize, len: usize) -> PyResult<usize> {
+    usize::try_from(index).map_err(|_| {
+        let mut args = BTreeMap::new();
+        args.insert("index".to_string(), serde_json::json!(index));
+        args.insert("len".to_string(), serde_json::json!(len));
+        let message = format!("index {index} is out of range (len = {len})");
+        let diagnostic = Diagnostic::new(Severity::Error, message.clone())
+            .with_code("edit::index_out_of_range".to_string())
+            .with_args(args);
+        raise_with_diagnostics(vec![diagnostic], message)
+    })
+}
+
+/// Resolve the `pages` selection the caller passed. Page indices are 0-based and
+/// count from the first page, so a negative one selects no page; the refusal
+/// carries the code the backend mints for a page past the last.
+pub fn page_indices(pages: Vec<isize>) -> PyResult<Vec<usize>> {
+    let negative: Vec<isize> = pages.iter().copied().filter(|&p| p < 0).collect();
+    if !negative.is_empty() {
+        return Err(convert_render_error(RenderError::coded(
+            "typst::page_index_out_of_bounds",
+            format!(
+                "Page index out of bounds; offending indices: {negative:?}. Page indices are 0-based and count from the first page."
+            ),
+        )));
+    }
+    Ok(pages.into_iter().map(|p| p as usize).collect())
+}
 
 pub fn convert_edit_error(err: EditError) -> PyErr {
     let diagnostic =

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -13,8 +13,8 @@ use std::time::Instant;
 
 use crate::enums::{PyOutputFormat, PySeverity};
 use crate::errors::{
-    convert_edit_error, convert_edit_errors, convert_edit_errors_at, convert_render_error,
-    raise_with_diagnostics,
+    card_index, convert_edit_error, convert_edit_errors, convert_edit_errors_at,
+    convert_render_error, page_indices, raise_with_diagnostics,
 };
 
 #[pyclass(name = "Quillmark")]
@@ -35,6 +35,9 @@ impl PyQuillmark {
     /// this engine. The default `output_format` falls back to the backend's
     /// first supported format. Raises `QuillmarkError` (`engine::backend_not_found`)
     /// when the backend is not registered.
+    ///
+    /// `pages` selects 0-based page indices counting from the first page; a
+    /// negative one selects no page and raises like an index past the last.
     #[pyo3(signature = (quill, doc, format=None, ppi=None, pages=None, producer=None, regions=false))]
     #[allow(clippy::too_many_arguments)] // kwargs mirror RenderOptions 1:1; the signature IS the Python API
     fn render(
@@ -43,14 +46,14 @@ impl PyQuillmark {
         doc: PyRef<'_, PyDocument>,
         format: Option<PyOutputFormat>,
         ppi: Option<f32>,
-        pages: Option<Vec<usize>>,
+        pages: Option<Vec<isize>>,
         producer: Option<String>,
         regions: bool,
     ) -> PyResult<PyRenderResult> {
         let mut opts = quillmark_core::RenderOptions::default();
         opts.output_format = format.map(OutputFormat::from);
         opts.ppi = ppi;
-        opts.pages = pages;
+        opts.pages = pages.map(page_indices).transpose()?;
         opts.producer = producer;
         opts.regions = regions;
         let start = Instant::now();
@@ -482,9 +485,11 @@ impl PyDocument {
 
     /// One composable card by index, same dict shape as `main`, so reading one
     /// need not project every card via `cards`. An out-of-range `index` raises
-    /// `IndexOutOfRange`.
-    fn card<'py>(&self, py: Python<'py>, index: usize) -> PyResult<Bound<'py, PyDict>> {
+    /// `IndexOutOfRange`; indices count from the front, so a negative one is out
+    /// of range rather than the last card.
+    fn card<'py>(&self, py: Python<'py>, index: isize) -> PyResult<Bound<'py, PyDict>> {
         let len = self.inner.cards().len();
+        let index = card_index(index, len)?;
         let card = self.inner.card(index).ok_or_else(|| {
             convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
         })?;
@@ -509,7 +514,7 @@ impl PyDocument {
         &mut self,
         py: Python<'py>,
         name: &str,
-        card: Option<usize>,
+        card: Option<isize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         match self
             .addr_card_mut(card)?
@@ -527,7 +532,7 @@ impl PyDocument {
     /// output; pass `{}` for an explicit empty `$ext`. Prefer `store_ext_namespace`
     /// to write one slot without clobbering sibling consumers'.
     #[pyo3(signature = (value, card=None))]
-    fn store_ext(&mut self, value: Bound<'_, PyAny>, card: Option<usize>) -> PyResult<()> {
+    fn store_ext(&mut self, value: Bound<'_, PyAny>, card: Option<isize>) -> PyResult<()> {
         let map = py_to_object(&value, "store_ext")?;
         self.addr_card_mut(card)?
             .store_ext(map)
@@ -542,7 +547,7 @@ impl PyDocument {
     fn remove_ext<'py>(
         &mut self,
         py: Python<'py>,
-        card: Option<usize>,
+        card: Option<isize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let prev = self.addr_card_mut(card)?.remove_ext();
         ext_map_to_py(py, prev)
@@ -557,7 +562,7 @@ impl PyDocument {
         &mut self,
         namespace: &str,
         value: Bound<'_, PyAny>,
-        card: Option<usize>,
+        card: Option<isize>,
     ) -> PyResult<()> {
         let json = py_to_json(&value)?;
         self.addr_card_mut(card)?
@@ -575,7 +580,7 @@ impl PyDocument {
         &mut self,
         py: Python<'py>,
         namespace: &str,
-        card: Option<usize>,
+        card: Option<isize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         ext_value_to_py(py, self.addr_card_mut(card)?.remove_ext_namespace(namespace))
     }
@@ -650,12 +655,15 @@ impl PyDocument {
     }
 
     /// Place a composable card. `at` picks the position: `None` appends, `Some(i)`
-    /// inserts at index `i` (`0..=card_count`; out of range raises
-    /// `IndexOutOfRange`). `card` is a `Card` dict, as `make_card`, `cards`,
-    /// `remove_card`, and `seed_card` return.
+    /// inserts at index `i` (`0..=card_count`; out of range, negative included,
+    /// raises `IndexOutOfRange`). `card` is a `Card` dict, as `make_card`,
+    /// `cards`, `remove_card`, and `seed_card` return.
     #[pyo3(signature = (card, at=None))]
-    fn insert_card(&mut self, card: Bound<'_, PyAny>, at: Option<usize>) -> PyResult<()> {
+    fn insert_card(&mut self, card: Bound<'_, PyAny>, at: Option<isize>) -> PyResult<()> {
         let core_card = py_dict_to_card(&card)?;
+        let at = at
+            .map(|at| card_index(at, self.inner.cards().len()))
+            .transpose()?;
         match at {
             None => self.inner.push_card(core_card),
             Some(index) => self.inner.insert_card(index, core_card),
@@ -663,24 +671,33 @@ impl PyDocument {
         .map_err(convert_edit_error)
     }
 
+    /// Remove the composable card at `index`, returning it as a dict or `None`
+    /// when the index addresses no card, a negative one included.
     fn remove_card<'py>(
         &mut self,
         py: Python<'py>,
-        index: usize,
+        index: isize,
     ) -> PyResult<Option<Bound<'py, PyDict>>> {
+        let Ok(index) = usize::try_from(index) else {
+            return Ok(None);
+        };
         match self.inner.remove_card(index) {
             Some(card) => Ok(Some(card_to_pydict(py, &card)?)),
             None => Ok(None),
         }
     }
 
-    fn move_card(&mut self, from_idx: usize, to_idx: usize) -> PyResult<()> {
+    fn move_card(&mut self, from_idx: isize, to_idx: isize) -> PyResult<()> {
+        let len = self.inner.cards().len();
+        let from_idx = card_index(from_idx, len)?;
+        let to_idx = card_index(to_idx, len)?;
         self.inner
             .move_card(from_idx, to_idx)
             .map_err(convert_edit_error)
     }
 
-    fn set_card_kind(&mut self, index: usize, new_kind: &str) -> PyResult<()> {
+    fn set_card_kind(&mut self, index: isize, new_kind: &str) -> PyResult<()> {
+        let index = card_index(index, self.inner.cards().len())?;
         self.inner
             .set_card_kind(index, new_kind)
             .map_err(convert_edit_error)
@@ -689,14 +706,15 @@ impl PyDocument {
 }
 
 impl PyDocument {
-    fn card_mut_or_raise(&mut self, index: usize) -> PyResult<&mut quillmark_core::Card> {
+    fn card_mut_or_raise(&mut self, index: isize) -> PyResult<&mut quillmark_core::Card> {
         let len = self.inner.cards().len();
+        let index = card_index(index, len)?;
         self.inner.card_mut(index).ok_or_else(|| {
             convert_edit_error(quillmark_core::EditError::IndexOutOfRange { index, len })
         })
     }
 
-    fn addr_card_mut(&mut self, card: Option<usize>) -> PyResult<&mut quillmark_core::Card> {
+    fn addr_card_mut(&mut self, card: Option<isize>) -> PyResult<&mut quillmark_core::Card> {
         match card {
             None => Ok(self.inner.main_mut()),
             Some(index) => self.card_mut_or_raise(index),
@@ -816,9 +834,10 @@ impl PyWriter {
 
     /// Build a composable card of `kind`, typed-commit `fields` onto it, set its
     /// body from optional markdown, and place it. `at` picks the position: `None`
-    /// appends, `Some(i)` inserts at index `i`. Transactional: a rejected field
-    /// (raising a per-field diagnostic bundle) or an invalid kind, body, or
-    /// position leaves the document untouched.
+    /// appends, `Some(i)` inserts at index `i`, and a position out of range, a
+    /// negative one included, raises. Transactional: a rejected field (raising a
+    /// per-field diagnostic bundle) or an invalid kind, body, or position leaves
+    /// the document untouched.
     #[pyo3(signature = (kind, fields=None, body=None, at=None))]
     fn add_card(
         &self,
@@ -826,7 +845,7 @@ impl PyWriter {
         kind: &str,
         fields: Option<Bound<'_, PyDict>>,
         body: Option<String>,
-        at: Option<usize>,
+        at: Option<isize>,
     ) -> PyResult<()> {
         let batch = match fields {
             Some(f) => pydict_to_field_batch(&f)?,
@@ -834,6 +853,9 @@ impl PyWriter {
         };
         let quill = self.quill.borrow(py);
         let mut doc = self.doc.borrow_mut(py);
+        let at = at
+            .map(|at| card_index(at, doc.inner.cards().len()))
+            .transpose()?;
         quill
             .inner
             .writer(&mut doc.inner)
@@ -842,12 +864,15 @@ impl PyWriter {
     }
 
     /// Remove the composable card at `index`, returning it as a dict or `None`
-    /// when the index is out of range.
+    /// when the index is out of range, a negative one included.
     fn remove_card<'py>(
         &self,
         py: Python<'py>,
-        index: usize,
+        index: isize,
     ) -> PyResult<Option<Bound<'py, PyDict>>> {
+        let Ok(index) = usize::try_from(index) else {
+            return Ok(None);
+        };
         let mut doc = self.doc.borrow_mut(py);
         match doc.inner.remove_card(index) {
             Some(card) => Ok(Some(card_to_pydict(py, &card)?)),
@@ -859,7 +884,7 @@ impl PyWriter {
     /// lazily at the write, so this never raises. The cursor is ephemeral: a
     /// `remove_card`/`add_card` between binding and writing silently retargets
     /// it; re-resolve the index at write time when cards may move.
-    fn card(&self, py: Python<'_>, index: usize) -> PyCardWriter {
+    fn card(&self, py: Python<'_>, index: isize) -> PyCardWriter {
         PyCardWriter {
             quill: self.quill.clone_ref(py),
             doc: self.doc.clone_ref(py),
@@ -870,19 +895,26 @@ impl PyWriter {
 
 /// A composable card bound to its `Quill` for typed writes, from `Writer.card`.
 /// Same verbs as `Writer`, targeting the card at its bound index; each write
-/// raises `edit::index_out_of_range` if that index is out of range.
+/// raises `edit::index_out_of_range` if that index is out of range, a negative
+/// one included.
 #[pyclass(name = "CardWriter")]
 pub struct PyCardWriter {
     quill: Py<PyQuill>,
     doc: Py<PyDocument>,
-    index: usize,
+    index: isize,
+}
+
+impl PyCardWriter {
+    fn bound_index(&self, doc: &PyDocument) -> PyResult<usize> {
+        card_index(self.index, doc.inner.cards().len())
+    }
 }
 
 #[pymethods]
 impl PyCardWriter {
     /// The bound card index.
     #[getter]
-    fn index(&self) -> usize {
+    fn index(&self) -> isize {
         self.index
     }
 
@@ -892,8 +924,9 @@ impl PyCardWriter {
     fn kind(&self, py: Python<'_>) -> PyResult<Option<String>> {
         let quill = self.quill.borrow(py);
         let mut doc = self.doc.borrow_mut(py);
+        let index = self.bound_index(&doc)?;
         let mut writer = quill.inner.writer(&mut doc.inner);
-        let card = writer.card(self.index).map_err(convert_edit_error)?;
+        let card = writer.card(index).map_err(convert_edit_error)?;
         Ok(card.kind().map(|k| k.to_string()))
     }
 
@@ -904,10 +937,11 @@ impl PyCardWriter {
         let qv = py_to_quillvalue(&value)?;
         let quill = self.quill.borrow(py);
         let mut doc = self.doc.borrow_mut(py);
+        let index = self.bound_index(&doc)?;
         quill
             .inner
             .writer(&mut doc.inner)
-            .card(self.index)
+            .card(index)
             .map_err(convert_edit_error)?
             .set(name, qv)
             .map_err(convert_edit_error)
@@ -919,9 +953,10 @@ impl PyCardWriter {
         let batch = pydict_to_field_batch(&fields)?;
         let quill = self.quill.borrow(py);
         let mut doc = self.doc.borrow_mut(py);
+        let index = self.bound_index(&doc)?;
         let mut writer = quill.inner.writer(&mut doc.inner);
         writer
-            .card(self.index)
+            .card(index)
             .map_err(convert_edit_error)?
             .set_all(batch)
             .map_err(convert_edit_errors)
@@ -932,10 +967,11 @@ impl PyCardWriter {
     fn revise_body(&self, py: Python<'_>, markdown: &str) -> PyResult<()> {
         let quill = self.quill.borrow(py);
         let mut doc = self.doc.borrow_mut(py);
+        let index = self.bound_index(&doc)?;
         quill
             .inner
             .writer(&mut doc.inner)
-            .card(self.index)
+            .card(index)
             .map_err(convert_edit_error)?
             .revise_body(markdown)
             .map(|_| ())
@@ -947,9 +983,10 @@ impl PyCardWriter {
     fn revise_field(&self, py: Python<'_>, name: &str, text: &str) -> PyResult<()> {
         let quill = self.quill.borrow(py);
         let mut doc = self.doc.borrow_mut(py);
+        let index = self.bound_index(&doc)?;
         let mut writer = quill.inner.writer(&mut doc.inner);
         writer
-            .card(self.index)
+            .card(index)
             .map_err(convert_edit_error)?
             .revise_field(name, text)
             .map(|_| ())
@@ -968,9 +1005,10 @@ impl PyCardWriter {
             .map_err(|e| PyValueError::new_err(format!("set_values: invalid values shape: {e}")))?;
         let quill = self.quill.borrow(py);
         let mut doc = self.doc.borrow_mut(py);
+        let index = self.bound_index(&doc)?;
         let mut writer = quill.inner.writer(&mut doc.inner);
         writer
-            .card(self.index)
+            .card(index)
             .map_err(convert_edit_error)?
             .set_values(&values)
             .map_err(convert_edit_errors_at)
@@ -1097,7 +1135,7 @@ impl PyReader {
     /// A `CardReader` for the composable card at `index`. The index is checked
     /// lazily at the read, so this never raises. The cursor is ephemeral: a
     /// `remove_card`/`add_card` between binding and reading silently retargets it.
-    fn card(&self, py: Python<'_>, index: usize) -> PyCardReader {
+    fn card(&self, py: Python<'_>, index: isize) -> PyCardReader {
         PyCardReader {
             quill: self.quill.clone_ref(py),
             doc: self.doc.clone_ref(py),
@@ -1108,19 +1146,26 @@ impl PyReader {
 
 /// A composable card bound to its `Quill` for interpreted reads, from
 /// `Reader.card`. Same verbs as `Reader`, reading the card at its bound index; each
-/// read raises `edit::index_out_of_range` if that index is out of range.
+/// read raises `edit::index_out_of_range` if that index is out of range, a
+/// negative one included.
 #[pyclass(name = "CardReader")]
 pub struct PyCardReader {
     quill: Py<PyQuill>,
     doc: Py<PyDocument>,
-    index: usize,
+    index: isize,
+}
+
+impl PyCardReader {
+    fn bound_index(&self, doc: &PyDocument) -> PyResult<usize> {
+        card_index(self.index, doc.inner.cards().len())
+    }
 }
 
 #[pymethods]
 impl PyCardReader {
     /// The bound card index.
     #[getter]
-    fn index(&self) -> usize {
+    fn index(&self) -> isize {
         self.index
     }
 
@@ -1130,8 +1175,9 @@ impl PyCardReader {
     fn kind(&self, py: Python<'_>) -> PyResult<Option<String>> {
         let quill = self.quill.borrow(py);
         let doc = self.doc.borrow(py);
+        let index = self.bound_index(&doc)?;
         let reader = quill.inner.reader(&doc.inner);
-        let card = reader.card(self.index).map_err(convert_edit_error)?;
+        let card = reader.card(index).map_err(convert_edit_error)?;
         Ok(card.kind().map(|k| k.to_string()))
     }
 
@@ -1141,9 +1187,10 @@ impl PyCardReader {
     fn get<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Option<Bound<'py, PyAny>>> {
         let quill = self.quill.borrow(py);
         let doc = self.doc.borrow(py);
+        let index = self.bound_index(&doc)?;
         let reader = quill.inner.reader(&doc.inner);
         let read = reader
-            .card(self.index)
+            .card(index)
             .map_err(convert_edit_error)?
             .get(name)
             .map_err(convert_edit_error)?;
@@ -1155,9 +1202,10 @@ impl PyCardReader {
     fn get_content<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Option<Bound<'py, PyAny>>> {
         let quill = self.quill.borrow(py);
         let doc = self.doc.borrow(py);
+        let index = self.bound_index(&doc)?;
         let reader = quill.inner.reader(&doc.inner);
         let read = reader
-            .card(self.index)
+            .card(index)
             .map_err(convert_edit_error)?
             .get_content(name)
             .map_err(convert_edit_error)?;
@@ -1175,9 +1223,10 @@ impl PyCardReader {
         let at = path_from_py(path, "get_content_at")?;
         let quill = self.quill.borrow(py);
         let doc = self.doc.borrow(py);
+        let index = self.bound_index(&doc)?;
         let reader = quill.inner.reader(&doc.inner);
         let read = reader
-            .card(self.index)
+            .card(index)
             .map_err(convert_edit_error)?
             .get_content_at(name, &at)
             .map_err(convert_edit_error)?;
@@ -1189,9 +1238,10 @@ impl PyCardReader {
     fn values<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
         let quill = self.quill.borrow(py);
         let doc = self.doc.borrow(py);
+        let index = self.bound_index(&doc)?;
         let reader = quill.inner.reader(&doc.inner);
         let values = reader
-            .card(self.index)
+            .card(index)
             .map_err(convert_edit_error)?
             .values();
         let json = serde_json::to_value(&values)
@@ -1203,12 +1253,13 @@ impl PyCardReader {
     /// for a bad bound index.
     fn body_markdown(&self, py: Python<'_>) -> PyResult<String> {
         let doc = self.doc.borrow(py);
+        let index = self.bound_index(&doc)?;
         let card = doc
             .inner
-            .card(self.index)
+            .card(index)
             .ok_or_else(|| {
                 convert_edit_error(quillmark_core::EditError::IndexOutOfRange {
-                    index: self.index,
+                    index,
                     len: doc.inner.cards().len(),
                 })
             })?;

--- a/crates/bindings/python/tests/test_api_requirements.py
+++ b/crates/bindings/python/tests/test_api_requirements.py
@@ -263,6 +263,39 @@ def test_insert_card_out_of_range():
         doc.insert_card({"kind": "note"}, at=5)
 
 
+def test_negative_index_is_out_of_range():
+    """Indices count from the front, so -1 addresses no card rather than the last
+    one. Every index-taking surface answers it as it answers an index past the
+    end: `edit::index_out_of_range` where the verb raises, `None` where it
+    answers absence."""
+    doc = Document.from_markdown(MD_WITH_CARDS)
+    with raises_edit_code("edit::index_out_of_range") as exc_info:
+        doc.card(-1)
+    assert exc_info.value.diagnostics[0].args["index"] == -1
+    with raises_edit_code("edit::index_out_of_range"):
+        doc.move_card(-1, 0)
+    with raises_edit_code("edit::index_out_of_range"):
+        doc.set_card_kind(-1, "note")
+    with raises_edit_code("edit::index_out_of_range"):
+        doc.insert_card({"kind": "note"}, at=-1)
+    with raises_edit_code("edit::index_out_of_range"):
+        doc.store_ext({}, card=-1)
+    assert doc.remove_card(-1) is None
+    assert doc.remove_card(99) is None
+    assert len(doc.cards) == 2
+
+    quill = _taro_quill()
+    typed = Document("taro@0.1.0")
+    ed = quill.writer(typed)
+    ed.add_card("quotes", {"author": "Basho"})
+    cursor = ed.card(-1)  # a cursor binds any index; the write checks it
+    assert cursor.index == -1
+    with raises_edit_code("edit::index_out_of_range"):
+        cursor.set("author", "Issa")
+    with raises_edit_code("edit::index_out_of_range"):
+        quill.reader(typed).card(-1).get("author")
+
+
 def test_remove_card():
     """remove_card removes and returns the card."""
     doc = Document.from_markdown(MD_WITH_CARDS)

--- a/crates/bindings/python/tests/test_render.py
+++ b/crates/bindings/python/tests/test_render.py
@@ -66,6 +66,18 @@ def test_engine_render_page_selection(engine, taro_quill_dir, taro_md):
     assert subset.format == OutputFormat.SVG
 
 
+def test_engine_render_negative_page_is_out_of_bounds(engine, taro_quill_dir, taro_md):
+    """Page indices count from the first page, so a negative one is refused under
+    the code a page past the last is refused under."""
+    quill = Quill.from_path(str(taro_quill_dir))
+    parsed = Document.from_markdown(taro_md)
+
+    with pytest.raises(QuillmarkError) as exc_info:
+        engine.render(quill, parsed, OutputFormat.SVG, pages=[-1])
+
+    assert exc_info.value.diagnostics[0].code == "typst::page_index_out_of_bounds"
+
+
 def test_engine_render_full_document(engine, taro_quill_dir, taro_md):
     quill = Quill.from_path(str(taro_quill_dir))
 


### PR DESCRIPTION
Closes #1516.

## The change

Verified the premise: every index parameter in `crates/bindings/python/src/types.rs` was `usize`, so `doc.card(-1)`, `doc.move_card(-1, 0)`, `writer.card(-1).set(..)` and `render(pages=[-1])` died in PyO3's extraction with `OverflowError`, a third exception type beside the two `errors.rs` documents.

Index parameters are `isize` at the boundary now, resolved through one helper in `errors.rs` (`card_index(index, len)`), used by `card`, `insert_card(at=)`, `remove_card`, `move_card`, `set_card_kind`, every `card=i` selector, `Writer.add_card(at=)` / `remove_card` / `card`, and `Reader.card`. No site keeps `usize`.

The rule is uniform: indices count from the front, so `-1` addresses nothing, which is what an out-of-range index is. Each surface answers a negative index exactly as it answers an index past the end: `edit::index_out_of_range` where the verb raises, `None` where `remove_card` answers absence, and `typst::page_index_out_of_bounds` (the code the backend mints for a page past the last) for `render(pages=)`. This departs from the issue's suggested test in one place: `remove_card(-1)` returns `None` rather than raising, because `remove_card(99)` already returns `None`, and a negative index that raised where a too-large one does not would be a new inconsistency. Python-style negative indexing is not implemented, and the docstrings and README say so.

`Writer.card` / `Reader.card` still never raise: the cursors hold the signed index and check it at the write, so the documented lazy contract needed no amendment. `EditError::IndexOutOfRange` carries a `usize` and cannot hold the index, so the negative diagnostic is minted in the binding under the same code, message shape, and `index` / `len` args; a caller cannot tell the two apart except by the value.

## Docs

`errors.rs`'s contract comment places a negative index in the first class. The README's error contract named only `QuillmarkError`; it now names `ValueError` too and states the front-counting rule for card and page indices.

## Verification

`cargo test --workspace` green; `cargo clippy -p quillmark-python` clean; `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace` clean. Python: `maturin develop && pytest`, 118 passed, including the two new tests; `python -m mypy.stubtest --ignore-disjoint-bases quillmark`, no issues (the `.pyi` keeps `int`, unchanged). Canon untouched, so `check-canon.mjs` was not run; WASM not built (no WASM code changed).

## For review

- `path_from_py` still raises `ValueError` for a negative step in a `path` sequence, unchanged: that is a value address, not a card index, and the message and the documented argument-error class already cover it.
- An index whose magnitude exceeds a machine word (`doc.card(10**30)`) still raises `OverflowError` from the `isize` extraction. Pre-existing, and outside the issue; covering it would push every signature to `&Bound<PyAny>` or misreport the index in the diagnostic args.
- `typst::page_index_out_of_bounds` is hardcoded in the binding for the negative page. PR #1604 renames it to `backend::page_index_out_of_bounds`; whichever lands second moves this site with it.
- The release carries a `!` and no migration-guide section was added, matching the other `!` entries in this cycle, which `docs/migrations/0.112-to-0.113.md` also does not carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_