### PR TITLE
perf(python): build a render result's artifacts once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- perf(python): **reading `RenderResult.artifacts` copies no bytes.** The
+  getter rebuilt its list on every read, cloning each artifact's buffer, and
+  `Artifact.bytes` cloned that again on the way into a `bytes`, so a `save`
+  followed by one `bytes` read moved a multi-MB PDF three times. The
+  `Artifact` and `Diagnostic` objects are built once, with the result, and
+  every `artifacts` or `warnings` read hands the same objects back; `bytes`
+  makes the one Rust→Python copy and `save` writes without one.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -2,13 +2,14 @@ use pyo3::conversion::IntoPyObjectExt;
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::pycell::{PyRef, PyRefMut};
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyBytes, PyDict, PyList};
 use pyo3::Bound;
 
 use quillmark::{
     quill_from_path, Diagnostic, Document, Location, OutputFormat, Quill, Quillmark, RenderResult,
 };
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Instant;
 
 use crate::enums::{PyOutputFormat, PySeverity};
@@ -64,10 +65,7 @@ impl PyQuillmark {
         result
             .warnings
             .splice(0..0, doc.parse_warnings.iter().cloned());
-        Ok(PyRenderResult {
-            inner: result,
-            render_time_ms: elapsed_ms,
-        })
+        PyRenderResult::new(doc.py(), result, elapsed_ms)
     }
 
     /// The output formats `quill`'s backend can emit. Raises `QuillmarkError`
@@ -1218,36 +1216,58 @@ impl PyCardReader {
 
 #[pyclass(name = "RenderResult")]
 pub struct PyRenderResult {
-    pub(crate) inner: RenderResult,
-    pub(crate) render_time_ms: f64,
+    artifacts: Vec<Py<PyArtifact>>,
+    warnings: Vec<Py<PyDiagnostic>>,
+    output_format: OutputFormat,
+    regions: Vec<quillmark_core::RenderedRegion>,
+    render_time_ms: f64,
+}
+
+impl PyRenderResult {
+    fn new(py: Python<'_>, result: RenderResult, render_time_ms: f64) -> PyResult<Self> {
+        Ok(Self {
+            artifacts: result
+                .artifacts
+                .into_iter()
+                .map(|a| {
+                    Py::new(
+                        py,
+                        PyArtifact {
+                            inner: Arc::from(a.bytes),
+                            format: a.output_format,
+                        },
+                    )
+                })
+                .collect::<PyResult<_>>()?,
+            warnings: result
+                .warnings
+                .into_iter()
+                .map(|inner| Py::new(py, PyDiagnostic { inner }))
+                .collect::<PyResult<_>>()?,
+            output_format: result.output_format,
+            regions: result.regions,
+            render_time_ms,
+        })
+    }
 }
 
 #[pymethods]
 impl PyRenderResult {
+    /// Every read hands back the same `Artifact` objects in a new list,
+    /// copying no artifact bytes.
     #[getter]
-    fn artifacts(&self) -> Vec<PyArtifact> {
-        self.inner
-            .artifacts
-            .iter()
-            .map(|a| PyArtifact {
-                inner: a.bytes.clone(),
-                format: a.output_format,
-            })
-            .collect()
+    fn artifacts(&self, py: Python<'_>) -> Vec<Py<PyArtifact>> {
+        self.artifacts.iter().map(|a| a.clone_ref(py)).collect()
     }
 
     #[getter]
-    fn warnings(&self) -> Vec<PyDiagnostic> {
-        self.inner
-            .warnings
-            .iter()
-            .map(|d| PyDiagnostic { inner: d.clone() })
-            .collect()
+    fn warnings(&self, py: Python<'_>) -> Vec<Py<PyDiagnostic>> {
+        self.warnings.iter().map(|d| d.clone_ref(py)).collect()
     }
 
     #[getter]
     fn format(&self) -> PyOutputFormat {
-        self.inner.output_format.into()
+        self.output_format.into()
     }
 
     /// Wall-clock time spent inside `render`, in milliseconds.
@@ -1266,8 +1286,7 @@ impl PyRenderResult {
     /// `field` and union the segment rects for the whole-field box.
     #[getter]
     fn regions<'py>(&self, py: Python<'py>) -> PyResult<Vec<Bound<'py, PyDict>>> {
-        self.inner
-            .regions
+        self.regions
             .iter()
             .map(|r| {
                 let d = PyDict::new(py);
@@ -1284,15 +1303,17 @@ impl PyRenderResult {
 #[pyclass(name = "Artifact", from_py_object)]
 #[derive(Clone)]
 pub struct PyArtifact {
-    pub(crate) inner: Vec<u8>,
+    pub(crate) inner: Arc<[u8]>,
     pub(crate) format: OutputFormat,
 }
 
 #[pymethods]
 impl PyArtifact {
+    /// Copies the rendered buffer into a new `bytes` on each read; `save`
+    /// writes it without a copy.
     #[getter]
-    fn bytes(&self) -> Vec<u8> {
-        self.inner.clone()
+    fn bytes<'py>(&self, py: Python<'py>) -> Bound<'py, PyBytes> {
+        PyBytes::new(py, &self.inner)
     }
 
     #[getter]

--- a/crates/bindings/python/tests/test_render.py
+++ b/crates/bindings/python/tests/test_render.py
@@ -5,17 +5,21 @@ import pytest
 from quillmark import OutputFormat, Document, Quill, QuillmarkError
 
 
-def test_save_artifact(engine, taro_quill_dir, taro_md, tmp_path):
+def test_artifact_reads_share_one_buffer(engine, taro_quill_dir, taro_md, tmp_path):
+    """Re-reading `artifacts` hands back the same objects, and `bytes` is what `save` wrote."""
     quill = Quill.from_path(str(taro_quill_dir))
 
     parsed = Document.from_markdown(taro_md)
     result = engine.render(quill, parsed, OutputFormat.PDF)
 
-    output_path = tmp_path / "output.pdf"
-    result.artifacts[0].save(str(output_path))
+    artifact = result.artifacts[0]
+    assert result.artifacts[0] is artifact
 
-    assert output_path.exists()
-    assert output_path.stat().st_size > 0
+    output_path = tmp_path / "output.pdf"
+    artifact.save(str(output_path))
+
+    assert artifact.bytes
+    assert output_path.read_bytes() == artifact.bytes
 
 
 def test_engine_render_with_explicit_format(engine, taro_quill_dir, taro_md):


### PR DESCRIPTION
Closes #1542.

## The change

`RenderResult` now owns the `Artifact` and `Diagnostic` objects it hands out, built once when `render` returns. `artifacts` and `warnings` return a new list over those same objects rather than rebuilding them and cloning each artifact's byte buffer, and `PyArtifact` keeps its bytes in an `Arc<[u8]>` so `bytes` performs the single unavoidable Rust→Python copy (`PyBytes::new`) and `save` writes straight from the shared buffer. `format`, `render_time_ms`, and `regions` read from the destructured fields, so no `RenderResult` copy of the artifact bytes survives construction.

The issue's premise held at the current code (the sites had drifted only slightly). The proposed fix is followed, choosing `Vec<Py<PyArtifact>>` over a cached `Py<PyList>`: each read still yields a fresh, freely mutable list (a cached list would let one caller's `pop()` corrupt the next read), while the elements are the same objects, which is where the bytes live.

Visible types are unchanged: the stub still declares `artifacts: list[Artifact]` and `bytes: bytes`, and the README's `RenderResult` / `Artifact` block still holds. What is new is object identity across reads, stated on the `artifacts` getter's docstring, and that `bytes` copies per read while `save` does not, stated on `bytes`.

## Verification

- `cargo test --workspace`: green.
- `cargo clippy -p quillmark-python`: no new warnings (the pre-existing `collapsible_if` warnings are in `quillmark-typst`).
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`: green.
- Python (`uv venv`, `uv pip install maturin pytest`, `maturin develop`, `pytest`): 116 passed.
- `python -m mypy.stubtest --ignore-disjoint-bases quillmark`: no issues in 2 modules.

## For review

`test_save_artifact` is replaced by `test_artifact_reads_share_one_buffer`, which guards the invariant the change can break: re-reading `artifacts` yields the same object, and `bytes` equals what `save` wrote. It subsumes the old file-exists/non-empty assertions. Identity of the two `warnings` objects is not separately tested: a clean taro render carries no warnings, and it is the same code path as `artifacts`.

`Arc::from(Vec<u8>)` costs one memcpy per artifact at construction, replacing one per property read; `Arc<Vec<u8>>` would avoid even that, at the cost of a less idiomatic type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_