### PR TITLE
fix(python): project a card dict through CardWire's serde, not by hand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -506,6 +506,12 @@
   to just past its `>`, which the dict, array and `endobj` scans all inherit.
   The trigger is real: pdf-writer's compact mode, which krilla and typst-pdf
   use, writes a non-ASCII `/Title` or `/Author` exactly this way.
+- fix(python): **a card dict is `CardWire`'s serde projection rather than a hand
+  copy of it.** `card_to_pydict` serializes the wire and adapts the two keys
+  Python's surface owns: snake_case `payload_items`, and an explicit `None`
+  where an absent `$quill` / `$ext` / `$seed` leaves the wire key out. Every key
+  and value is what it was; the dict now iterates in the wire's own order, so
+  `payload_items` follows `ext` and `seed` instead of preceding them.
 
 ## v0.112.0 - 2026-09-01
 

--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -1469,84 +1469,37 @@ fn read_value_to_py<'py>(
     }
 }
 
-/// The dict keeps Python's snake_case `payload_items`; the item entries
-/// themselves match the WASM `Card` shape verbatim.
+/// `CardWire`'s serde shape with the two divergences Python's surface owns: the
+/// top-level key is snake_case `payload_items`, and an absent `quill` / `ext` /
+/// `seed` is an explicit `None` rather than a missing key. Item entries match
+/// the WASM `Card` shape verbatim.
 fn card_to_pydict<'py>(
     py: Python<'py>,
     card: &quillmark_core::Card,
 ) -> PyResult<Bound<'py, PyDict>> {
     let wire = quillmark_core::CardWire::from(card);
+    let json = serde_json::to_value(&wire).map_err(|e| PyValueError::new_err(e.to_string()))?;
+    let serde_json::Value::Object(mut map) = json else {
+        return Err(PyValueError::new_err("card wire is not a JSON object"));
+    };
+
+    // `CardWire` declares the three right after `kind`, so filling them left to
+    // right lands each at its own index and keeps one key order for every card.
+    for (offset, key) in ["quill", "ext", "seed"].into_iter().enumerate() {
+        if !map.contains_key(key) {
+            map.shift_insert(offset + 1, key.to_string(), serde_json::Value::Null);
+        }
+    }
+
     let d = PyDict::new(py);
-    d.set_item("kind", &wire.kind)?;
-    d.set_item("quill", wire.quill.as_deref())?;
-
-    let items = PyList::empty(py);
-    for item in &wire.payload_items {
-        let entry = PyDict::new(py);
-        match item {
-            quillmark_core::PayloadItemWire::Field {
-                key,
-                value,
-                fill,
-                nested_fills,
-            } => {
-                entry.set_item("type", "field")?;
-                entry.set_item("key", key)?;
-                entry.set_item("value", json_to_py(py, value)?)?;
-                entry.set_item("fill", *fill)?;
-                // Paths to `!must_fill` markers nested inside `value`, which is
-                // itself fill-free. Omitted when empty; `py_dict_to_card` reads
-                // it back.
-                if !nested_fills.is_empty() {
-                    let nf = serde_json::to_value(nested_fills)
-                        .map_err(|e| PyValueError::new_err(e.to_string()))?;
-                    entry.set_item("nestedFills", json_to_py(py, &nf)?)?;
-                }
-            }
-            quillmark_core::PayloadItemWire::Comment { text, inline } => {
-                entry.set_item("type", "comment")?;
-                entry.set_item("text", text)?;
-                entry.set_item("inline", *inline)?;
-            }
-            // `#[non_exhaustive]`: raising beats appending an untyped entry the
-            // caller cannot read.
-            _ => {
-                let msg = "this build cannot project one of the card's payload items";
-                return Err(crate::errors::raise_with_diagnostics(
-                    vec![quillmark_core::Diagnostic::new(
-                        quillmark_core::Severity::Error,
-                        msg.to_string(),
-                    )
-                    .with_code("edit::unprojectable_payload_item".to_string())],
-                    msg.to_string(),
-                ));
-            }
-        }
-        items.append(entry)?;
+    for (key, value) in &map {
+        let key = if key == "payloadItems" {
+            "payload_items"
+        } else {
+            key.as_str()
+        };
+        d.set_item(key, json_to_py(py, value)?)?;
     }
-    d.set_item("payload_items", items)?;
-
-    match &wire.ext {
-        Some(ext_map) => {
-            d.set_item(
-                "ext",
-                json_to_py(py, &serde_json::Value::Object(ext_map.clone()))?,
-            )?;
-        }
-        None => d.set_item("ext", py.None())?,
-    }
-
-    match &wire.seed {
-        Some(seed_map) => {
-            d.set_item(
-                "seed",
-                json_to_py(py, &serde_json::Value::Object(seed_map.clone()))?,
-            )?;
-        }
-        None => d.set_item("seed", py.None())?,
-    }
-
-    d.set_item("body", json_to_py(py, &wire.body)?)?;
     Ok(d)
 }
 


### PR DESCRIPTION
Closes #1543.

## The change

`card_to_pydict` (`crates/bindings/python/src/types.rs`) serializes `CardWire` with `serde_json::to_value` and adapts only the two keys Python's surface owns: snake_case `payload_items`, and an explicit `None` where an absent `$quill` / `$ext` / `$seed` leaves the wire key out. Item entries (`type` / `key` / `value` / `fill` / `nestedFills` / `text` / `inline`) are serde's, so they match the WASM `Card` shape by construction and the `py_dict_to_card` direction, which already reads through `serde_json::from_value::<CardWire>`. 68 lines out, 27 in.

The `_ =>` arm and its runtime `edit::unprojectable_payload_item` are gone; a new `#[non_exhaustive]` `PayloadItemWire` variant now reaches Python by being declared in core. That code was unreachable in any build (the enum has two variants) and appeared in no doc: grep over `prose/`, `docs/`, READMEs and the whole tree finds it nowhere else, so nothing to delete.

The three `None` fills use `Map::shift_insert` at their declaration index rather than appending, so every card dict keeps one key order instead of one that varies with which `$` entries are present.

## Verification

Before deleting the old code the extension was built on both implementations and their output diffed over a 30-entry corpus: `doc.main`, `doc.cards`, `doc.card(i)` and a storage round-trip for seven documents (fields, top-level and nested `!must_fill` including an array-index path, standalone/empty/consecutive/inline comments, `$ext`, `$seed`, every JSON scalar and container shape, unicode, no-`$kind`, empty card), plus `remove_card`, three `make_card` shapes, `Quill.seed_main` / `seed_card`, and a card inserted from a dict carrying `nestedFills`. **Zero value and zero key-set differences.** The one difference is the top-level key order, uniform across all 30: `kind, quill, payload_items, ext, seed, body` becomes `kind, quill, ext, seed, payload_items, body`, the wire's own declaration order, which is also the order WASM's card object carries. Values, key sets, and every nested order are byte-identical. Recorded as a `fix(python)` changelog entry.

Ran: `cargo test --workspace` (green), `cargo clippy -p quillmark-python` (clean; the 5 warnings are pre-existing in `quillmark-typst`), `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace` (clean), `maturin develop && pytest` (116 passed), `python -m mypy.stubtest quillmark._quillmark` (no issues).

## For review

No test added: `test_nested_fill_exposed_as_nested_fills`, `test_remove_card_then_insert_card_round_trips_fields` (the explicit-`None` assertion), `test_store_ext_adds_map`, `test_seed_overlay_reads_one_kind_off_the_main_card` and the `field()` helpers already pin every key of the shape, and compile-time variant drift is not testable from Python. The corpus comparison was scratch tooling, not committed.

`shift_insert` is available only under serde_json's `preserve_order`, which the workspace dependency turns on unconditionally; dropping it would be a compile error, not a silent reorder. No canon claim pins the Python dict's key order, so no canon edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_