### PR TITLE
fix(python): read the quill version from config, and import quillmark plainly in test_validate

### DIFF
--- a/crates/bindings/python/src/types.rs
+++ b/crates/bindings/python/src/types.rs
@@ -131,13 +131,7 @@ impl PyQuill {
 
     #[getter]
     fn quill_ref(&self) -> String {
-        let source = &self.inner;
-        let version = source
-            .metadata()
-            .get("version")
-            .and_then(|v| v.as_str())
-            .unwrap_or("0.0.0");
-        format!("{}@{}", source.name(), version)
+        format!("{}@{}", self.inner.name(), self.inner.config().version)
     }
 
     /// Identity snapshot mirroring the `quill:` section of `Quill.yaml`. A pure

--- a/crates/bindings/python/tests/test_validate.py
+++ b/crates/bindings/python/tests/test_validate.py
@@ -4,27 +4,12 @@ The diagnostic set and the seed layering rules are core's: `validate`'s
 decision matrix lives in `crates/quillmark/tests/validate_test.rs`, the seed
 semantics in `core/src/quill/seed/tests.rs`. What is pyo3's is the crossing:
 each verb returns the right Python shape, and an error keeps its `code`.
-
-NOTE: These tests cannot run in the devcontainer because the Python binding
-is not built with `maturin develop` in this environment.  They are written
-to run in CI where `maturin develop` (or `pip install -e .`) is available.
-
-Expected environment: `quillmark` importable from a maturin-built wheel.
 """
 
 import json
 import pytest
 
-try:
-    from quillmark import Document, Quill
-    QUILLMARK_AVAILABLE = True
-except ImportError:
-    QUILLMARK_AVAILABLE = False
-
-pytestmark = pytest.mark.skipif(
-    not QUILLMARK_AVAILABLE,
-    reason="quillmark native module not available in this environment",
-)
+from quillmark import Document, Quill
 
 # ---------------------------------------------------------------------------
 # Helpers


### PR DESCRIPTION
Closes #1544.

## The change

`Quill.quill_ref` formats `name@version` from `self.inner.config().version`, the same source the adjacent `metadata` getter reads, instead of looking `"version"` up in the metadata map behind an `as_str` and a `"0.0.0"` fallback.

`crates/bindings/python/tests/test_validate.py` imports `Document, Quill` at module scope like every sibling test file. The `try/except ImportError` guard, the `pytestmark = skipif(...)`, and the devcontainer note are gone.

Both claims hold against current code. `Quill`'s fields are `pub(crate)` and the struct is built at exactly one site, `Quill::from_config` (`crates/core/src/quill/load.rs`), which inserts `config.version` into `metadata["version"]` as a JSON string; the backend-config keys it adds afterward are all prefixed `<backend>_`, so nothing else can occupy or overwrite that key. `version` is a required field parsed as a `Version` (`quill::missing_version` / `quill::invalid_version`), so it is non-empty for any quill that loads. The lookup, the `as_str`, and the fallback therefore all resolved to `config.version` already. `conftest.py` imports `quillmark` at module scope, so a missing extension fails collection of the whole directory before a per-file skip can run; the guard could never skip.

## Docs

None. No canon doc, guide page, or README mentions the `"0.0.0"` fallback.

## Verification

- `cargo test --workspace`: green, no failures.
- `cargo clippy -p quillmark-python`: clean, no new warnings (the pre-existing `collapsible_if` warnings are in `quillmark-typst`).
- Python binding, the CLAUDE.md flow (`uv venv`, `source .venv/bin/activate`, `uv pip install maturin pytest`, `maturin develop`, `pytest`): 116 passed, including the 10 in `test_validate.py`, which run rather than skip.

No changelog entry: `quill_ref`'s output cannot differ for any loadable quill, per the reasoning above, so nothing observable shifts.

## For review

The `# ---- Helpers ----` banner below the imports is left in place: it is the convention across `test_api_requirements.py` and `test_schema.py`, and changing it here alone would be scope the issue did not ask for.

The edit in `types.rs` is confined to `quill_ref`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_