### PR TITLE
docs(cli): document exit 2 for a usage error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- docs(cli): **the exit-code table separates a usage error from a refusal.**
+  The CLI reference and the crate README both promised `1` on any error, while
+  `clap` exits `2` on an invocation it cannot parse — an unknown flag, a missing
+  argument, an unknown subcommand — before any command runs. `1` is the command
+  running and refusing: an invalid quill, a missing file, a failed render, an
+  argument value the command itself rejects (`-f docx`). `--help` and
+  `--version` exit `0`. Stated in `prose/canon/CLI.md`, the reference, and the
+  README; a smoke test pins the `2`.
 - change(core)!: **YAML nesting depth is the parser's to bound, and
   `MAX_YAML_DEPTH` is gone.** The constant set `serde_saphyr`'s depth budget
   and doubled as the bound on host values crossing into the document, so one

--- a/crates/bindings/cli/README.md
+++ b/crates/bindings/cli/README.md
@@ -58,7 +58,8 @@ field, `!must_fill` where a value is expected.
 
 Checks the quill's configuration: `Quill.yaml` parse errors, `example:`/`default:`
 literals against their declared types, and referenced files. `-v` adds advisory
-warnings such as missing field descriptions. Exits 1 on any error.
+warnings such as missing field descriptions. Exits 1 where the configuration is
+invalid.
 
 ### `quillmark info <QUILL_PATH> [--json]`
 
@@ -67,7 +68,11 @@ Prints quill metadata — name, version, author, backend, field and card counts.
 
 ## Exit codes
 
-`0` on success, `1` on any error, with diagnostics on stderr.
+`0` on success, `--help`, and `--version`. `2` where argument parsing rejected
+the invocation before any command ran — an unknown flag, a missing argument, an
+unknown subcommand. `1` where the command ran and refused — an invalid quill, a
+missing file, a failed render, an argument value the command itself rejects
+(`-f docx`). Diagnostics go to stderr.
 
 ## Links
 

--- a/crates/bindings/cli/tests/smoke.rs
+++ b/crates/bindings/cli/tests/smoke.rs
@@ -353,6 +353,21 @@ fn absent_quill_exits_one_with_stderr() {
     );
 }
 
+/// Exit 2 rather than 1: a script reading the status can tell an invocation
+/// `clap` rejected from a command that ran and refused.
+#[test]
+fn a_usage_error_exits_two_with_stderr() {
+    let out = run(&["render", "--bogus"]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "expected a usage exit 2, got {:?}\nstderr: {}",
+        out.status,
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(!out.stderr.is_empty(), "usage error wrote nothing to stderr");
+}
+
 /// Every command routes a typo'd path through the loader, which names the path
 /// rather than the `Quill.yaml` a directory that does not exist cannot be
 /// missing.

--- a/docs/cli/reference.md
+++ b/docs/cli/reference.md
@@ -169,5 +169,6 @@ quillmark info ./my-quill --json
 
 ## Exit Codes
 
-- `0`: success
-- `1`: error (invalid arguments, file not found, parse error, compilation error, etc.)
+- `0`: success, `--help`, and `--version`
+- `1`: the command ran and refused — an invalid quill, a file not found, a parse error, a compilation error, or an argument value the command itself rejects (`-f docx`)
+- `2`: usage error — an unknown flag, a missing argument, an unknown subcommand; argument parsing rejected the invocation before any command ran

--- a/prose/canon/CLI.md
+++ b/prose/canon/CLI.md
@@ -30,3 +30,7 @@ them.
 - **Every artifact reaches disk.** `svg` and `png` render one artifact per page,
   and a multi-page render writes `out-1.svg`, `out-2.svg`, …. `--stdout` carries
   one artifact and refuses such a render.
+- **Two failure codes.** `clap` rejects an unparseable invocation — unknown
+  flag, missing argument, unknown subcommand — with `2`, before any command
+  runs. A command that ran and refused exits `1`. Success, `--help`, and
+  `--version` exit `0`.


### PR DESCRIPTION
Closes #1509.

## The change

Verified against the built binary: `quillmark render --bogus`, `quillmark render` (missing `<QUILL_PATH>`), bare `quillmark`, and an unknown subcommand all exit 2; `--help` and `--version` exit 0. Takes the issue's first option (document the clap/POSIX convention, change no behaviour), so `--help`/`--version` keep their 0 and no script keying on the current status breaks.

The exit-code tables in `docs/cli/reference.md` and `crates/bindings/cli/README.md` now read the same three codes: 0 for success plus `--help`/`--version`; 2 where argument parsing rejected the invocation before any command ran; 1 where the command ran and refused. Both tables name the case the old wording made ambiguous: an argument value the command itself rejects (`-f docx`) reaches `CliError::InvalidArgument` and exits 1, not 2. The README's `validate` line, which said "Exits 1 on any error", now says it exits 1 where the configuration is invalid.

`prose/canon/CLI.md` had no exit-code claim, so the two tables had no canonical source; it gains one Contract bullet stating the split, which is what both docs now restate.

A smoke test beside `absent_quill_exits_one_with_stderr`, `a_usage_error_exits_two_with_stderr`, asserts `render --bogus` exits 2 with non-empty stderr. `an_unloadable_quill_is_not_an_invalid_argument` already pinned the 1 side of the split.

## Docs

`docs/cli/reference.md` §Exit Codes, `crates/bindings/cli/README.md` §Exit codes and its `validate` line, `prose/canon/CLI.md` §Contract.

## Verification

- `cargo test --workspace`: green, no failures; `quillmark-cli` 21 passed.
- `node scripts/check-canon.mjs`: canon spine OK.
- `cargo clippy -p quillmark-cli --all-targets`: 5 warnings, all pre-existing in `commands/info.rs` and `output.rs`, none from this change.
- No binding builds (no binding code touched); `cargo doc` not run (no doc comments or `pub` items touched).

## For review

A changelog entry is included as `docs(cli):`, not `fix(cli)!:`. Behaviour is unchanged, only the stated contract was wrong, matching the existing `docs(python): the error contract names both classes the binding raises` precedent. If the project would rather treat a doc-only correction as silent, the entry can be dropped.

The alternative route (`try_parse` + `process::exit(1)`) was not taken: nothing in the code or canon relies on 1 for usage errors, and it would break every script already reading clap's 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU

---
_Generated by [Claude Code](https://claude.ai/code/session_01YGrXeNye87SNSB6ZPSSUNU)_