### PR TITLE
fix(wasm): cross the typed boundary through `tsify::Ts`, not the leaking ABI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- fix(wasm): **a failed conversion at the typed boundary throws instead of
+  stranding the JS handle.** `RenderOptions`, `RenderResult`, `Diagnostic`,
+  `ChangeSet`, `ContentHit` and `FieldRegion` cross as `tsify::Ts<T>`, whose
+  handle the wasm-bindgen shim owns and frees; the deprecated `into_wasm_abi` /
+  `from_wasm_abi` impls they carried leaked it on the way out (tsify#65), and
+  took the module down with a trap rather than a catchable error when
+  serialization failed. The TypeScript surface is byte-identical, and the crate
+  compiles warning-free, so the next deprecation is visible.
 - fix(docs): **the 57 comments and doc claims that contradicted the code now
   state it.** The user-visible ones: the Typst backend never searched system
   fonts, so its docs stop promising `#set text(font: "Arial")` and name what a

--- a/crates/bindings/wasm/src/engine.rs
+++ b/crates/bindings/wasm/src/engine.rs
@@ -6,6 +6,7 @@ use js_sys::{Array, Uint8Array};
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, HashMap};
+use tsify::Ts;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -570,10 +571,10 @@ impl Quillmark {
         &self,
         quill: &Quill,
         doc: &Document,
-        opts: Option<RenderOptions>,
-    ) -> Result<RenderResult, JsValue> {
+        opts: Option<Ts<RenderOptions>>,
+    ) -> Result<Ts<RenderResult>, JsValue> {
         let start = now_ms();
-        let rust_opts: quillmark_core::RenderOptions = opts.unwrap_or_default().into();
+        let rust_opts = render_options_or_throw(opts)?;
         let result = self
             .inner
             .render(&quill.inner, &doc.inner, &rust_opts)
@@ -582,7 +583,7 @@ impl Quillmark {
             doc.parse_warnings.iter().cloned().map(Into::into).collect();
         warnings.extend(result.warnings.into_iter().map(Into::into));
         let kinds: Vec<Option<&str>> = doc.inner.cards().iter().map(|c| c.kind()).collect();
-        Ok(RenderResult {
+        to_ts_or_throw(&RenderResult {
             artifacts: result.artifacts.into_iter().map(Into::into).collect(),
             warnings,
             output_format: result.output_format.into(),
@@ -915,9 +916,9 @@ impl Document {
     /// Render a Diagnostic as the canonical pretty-printed text, so it looks
     /// identical whichever consumer surfaces it.
     #[wasm_bindgen(js_name = formatDiagnostic)]
-    pub fn format_diagnostic(diag: Diagnostic) -> String {
-        let core: quillmark_core::Diagnostic = diag.into();
-        core.fmt_pretty()
+    pub fn format_diagnostic(diag: Ts<Diagnostic>) -> Result<String, JsValue> {
+        let core: quillmark_core::Diagnostic = from_ts_or_throw(&diag)?.into();
+        Ok(core.fmt_pretty())
     }
 
     /// Emit canonical Quillmark Markdown. Round-trip safe: re-parsing the
@@ -2544,6 +2545,37 @@ fn serialize_inner<T: serde::Serialize + ?Sized>(
         .map_err(|e| WasmError::from(format!("{what}: serialization failed: {e}")).to_js_value())
 }
 
+/// [`serialize_or_throw`] for a value crossing as its own declared TypeScript
+/// type, under that type's `tsify` serialization config.
+#[cfg(any(feature = "typst", feature = "pdfform"))]
+fn to_ts_or_throw<T: tsify::Tsify + Serialize>(value: &T) -> Result<Ts<T>, JsValue> {
+    Ts::from_rust(value).map_err(|e| WasmError::from(e.to_string()).to_js_value())
+}
+
+/// The read direction of [`to_ts_or_throw`].
+fn from_ts_or_throw<T: tsify::Tsify + serde::de::DeserializeOwned>(
+    value: &Ts<T>,
+) -> Result<T, JsValue>
+where
+    T::JsType: Clone,
+{
+    value
+        .to_rust()
+        .map_err(|e| WasmError::from(e.to_string()).to_js_value())
+}
+
+/// The render verbs' shared argument read: an absent `options` is the default.
+#[cfg(any(feature = "typst", feature = "pdfform"))]
+fn render_options_or_throw(
+    opts: Option<Ts<RenderOptions>>,
+) -> Result<quillmark_core::RenderOptions, JsValue> {
+    let opts = match opts {
+        Some(ts) => from_ts_or_throw(&ts)?,
+        None => RenderOptions::default(),
+    };
+    Ok(opts.into())
+}
+
 fn json_value_to_js(value: Option<serde_json::Value>) -> Result<JsValue, JsValue> {
     match value {
         Some(v) => serialize_or_throw(&v, "ext value"),
@@ -2800,29 +2832,29 @@ impl LiveSession {
     /// Distinct from [`applyChange`](Document::apply_change), which splices ops
     /// into a document; this recompiles a document the caller already mutated.
     #[wasm_bindgen(js_name = update)]
-    pub fn update(&mut self, doc: &Document) -> Result<ChangeSet, JsValue> {
+    pub fn update(&mut self, doc: &Document) -> Result<Ts<ChangeSet>, JsValue> {
         let cs = self
             .inner
             .update(&doc.inner)
             .map_err(|e| WasmError::from(e).to_js_value())?;
         self.card_kinds = card_kinds_of(&doc.inner);
-        Ok(ChangeSet {
+        to_ts_or_throw(&ChangeSet {
             page_count: cs.page_count,
             dirty_pages: cs.dirty_pages,
         })
     }
 
     #[wasm_bindgen(js_name = render)]
-    pub fn render(&self, opts: Option<RenderOptions>) -> Result<RenderResult, JsValue> {
+    pub fn render(&self, opts: Option<Ts<RenderOptions>>) -> Result<Ts<RenderResult>, JsValue> {
         let start = now_ms();
-        let rust_opts: quillmark_core::RenderOptions = opts.unwrap_or_default().into();
+        let rust_opts = render_options_or_throw(opts)?;
 
         let result = self
             .inner
             .render(&rust_opts)
             .map_err(|e| WasmError::from(e).to_js_value())?;
 
-        Ok(RenderResult {
+        to_ts_or_throw(&RenderResult {
             artifacts: result.artifacts.into_iter().map(Into::into).collect(),
             warnings: result.warnings.into_iter().map(Into::into).collect(),
             output_format: result.output_format.into(),
@@ -2900,13 +2932,14 @@ impl LiveSession {
         x: f32,
         y: f32,
         tol_pt: Option<f32>,
-    ) -> Option<ContentHit> {
+    ) -> Result<Option<Ts<ContentHit>>, JsValue> {
         self.inner
             .position_at(page, x, y, tol_pt.unwrap_or(0.0))
             .map(|mut hit| {
                 hit.field = plate_to_docpath(&hit.field, &self.kinds());
-                hit.into()
+                to_ts_or_throw(&ContentHit::from(hit))
             })
+            .transpose()
     }
 
     /// A content position → **caret rect**, the reverse of `positionAt`: the box
@@ -2914,13 +2947,16 @@ impl LiveSession {
     /// `FieldRegion.rect`, its `span` collapsed to `[pos, pos]`. `undefined` when
     /// the field places no tracked content or the offset maps to no drawn glyph.
     #[wasm_bindgen(js_name = locate)]
-    pub fn locate(&self, field: &str, pos: usize) -> Option<FieldRegion> {
+    pub fn locate(&self, field: &str, pos: usize) -> Result<Option<Ts<FieldRegion>>, JsValue> {
         let kinds = self.kinds();
         let plate = docpath_to_plate(field, &kinds);
-        self.inner.locate(&plate, pos).map(|mut r| {
-            r.field = plate_to_docpath(&r.field, &kinds);
-            r.into()
-        })
+        self.inner
+            .locate(&plate, pos)
+            .map(|mut r| {
+                r.field = plate_to_docpath(&r.field, &kinds);
+                to_ts_or_throw(&FieldRegion::from(r))
+            })
+            .transpose()
     }
 
     /// Page dimensions in points (1 pt = 1/72 inch).

--- a/crates/bindings/wasm/src/types.rs
+++ b/crates/bindings/wasm/src/types.rs
@@ -2,11 +2,15 @@ use serde::{Deserialize, Serialize};
 use tsify::Tsify;
 use wasm_bindgen::prelude::*;
 
+// `Tsify` declares the TypeScript type; values cross through `tsify::Ts<T>`,
+// whose JS handle the wasm-bindgen shim owns and frees. The `into_wasm_abi` /
+// `from_wasm_abi` ABI impls throw mid-conversion while holding that handle,
+// which strands it (tsify#65), so no type here derives them.
+
 /// Output formats supported by backends. Gated behind the engine surface so
 /// tsify omits it from the core bundle, which has no rendering surface.
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "lowercase")]
 pub enum OutputFormat {
     Pdf,
@@ -40,7 +44,6 @@ impl From<quillmark_core::OutputFormat> for OutputFormat {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "lowercase")]
 pub enum Severity {
     Error,
@@ -68,7 +71,6 @@ impl From<Severity> for quillmark_core::Severity {
 
 /// Source location for errors and warnings
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct Location {
     pub file: String,
@@ -94,7 +96,7 @@ impl From<Location> for quillmark_core::Location {
 
 /// Diagnostic message (error or warning)
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
+#[tsify(hashmap_as_object)]
 #[serde(rename_all = "camelCase")]
 pub struct Diagnostic {
     pub severity: Severity,
@@ -158,7 +160,6 @@ impl From<Diagnostic> for quillmark_core::Diagnostic {
 /// Rendered artifact (PDF, SVG, etc.).
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct Artifact {
     pub format: OutputFormat,
@@ -193,7 +194,7 @@ impl From<quillmark_core::Artifact> for Artifact {
 /// Result of a render operation.
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi, hashmap_as_object)]
+#[tsify(hashmap_as_object)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderResult {
     pub artifacts: Vec<Artifact>,
@@ -213,7 +214,6 @@ const _: () = assert!(<RenderResult as tsify::Tsify>::SERIALIZATION_CONFIG.hashm
 /// removed pages are implied by `pageCount`.
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct ChangeSet {
     pub page_count: usize,
@@ -231,7 +231,6 @@ pub struct ChangeSet {
 /// whitespace stays uncovered; `LiveSession.fieldBoxes(field)` owns that union.
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct FieldRegion {
     /// Canonical `DocPath` field address (e.g. `"cards.indorsement[1].from"`):
@@ -264,7 +263,6 @@ impl From<quillmark_core::RenderedRegion> for FieldRegion {
 /// the finest this API offers, `segment` the floor it degrades to.
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub enum HitGranularity {
     /// `pos` is the first content char of the cluster under the point. Place
@@ -293,7 +291,6 @@ impl From<quillmark_core::HitGranularity> for HitGranularity {
 /// `locate`.
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct ContentHit {
     /// Canonical `DocPath` field address (same grammar as `FieldRegion.field`).
@@ -319,7 +316,6 @@ impl From<quillmark_core::ContentHit> for ContentHit {
 /// Options for rendering.
 #[cfg(any(feature = "typst", feature = "pdfform"))]
 #[derive(Debug, Clone, Serialize, Deserialize, Tsify)]
-#[tsify(into_wasm_abi, from_wasm_abi)]
 #[serde(rename_all = "camelCase")]
 pub struct RenderOptions {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/bindings/wasm/tests/wasm_bindings.rs
+++ b/crates/bindings/wasm/tests/wasm_bindings.rs
@@ -2,6 +2,7 @@
 //! `serde_wasm_bindgen` boundary produces the right JS types under a real
 //! browser's instantiation, so the assertions stay at the crossing.
 
+use tsify::{Ts, Tsify};
 use wasm_bindgen_test::*;
 
 use quillmark_wasm::{Document, Quill, Quillmark, RenderOptions};
@@ -9,6 +10,20 @@ use quillmark_wasm::{Document, Quill, Quillmark, RenderOptions};
 mod common;
 
 wasm_bindgen_test::wasm_bindgen_test_configure!(run_in_browser);
+
+// The engine's typed surface crosses as `Ts<T>`, the JS handle itself, so these
+// two conversions are part of what these tests exercise.
+fn default_opts() -> Ts<RenderOptions> {
+    Ts::from_rust(&RenderOptions::default()).expect("RenderOptions crosses")
+}
+
+fn rust_of<T>(value: &Ts<T>) -> T
+where
+    T: Tsify + serde::de::DeserializeOwned,
+    T::JsType: Clone,
+{
+    value.to_rust().expect("value crosses back")
+}
 
 fn small_quill_tree() -> wasm_bindgen::JsValue {
     common::tree(&[
@@ -29,9 +44,11 @@ fn test_render_from_document() {
     let quill = Quill::from_tree(small_quill_tree()).expect("quill failed");
 
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
-    let result = engine
-        .render(&quill, &doc, Some(RenderOptions::default()))
-        .expect("render from Document failed");
+    let result = rust_of(
+        &engine
+            .render(&quill, &doc, Some(default_opts()))
+            .expect("render from Document failed"),
+    );
 
     assert!(
         !result.artifacts.is_empty(),
@@ -48,23 +65,17 @@ fn test_render_from_document() {
 /// serializer reverting to `Array<number>`.
 #[wasm_bindgen_test]
 fn test_artifact_bytes_is_uint8array() {
-    use serde::Serialize;
     use wasm_bindgen::{JsCast, JsValue};
 
     let engine = Quillmark::new();
     let quill = Quill::from_tree(small_quill_tree()).expect("quill failed");
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
     let result = engine
-        .render(&quill, &doc, Some(RenderOptions::default()))
+        .render(&quill, &doc, Some(default_opts()))
         .expect("render failed");
-    assert!(!result.artifacts.is_empty(), "should produce artifacts");
 
-    // The same serializer Tsify uses for `into_wasm_abi`.
-    let serializer = serde_wasm_bindgen::Serializer::new();
-    let js_result = result
-        .serialize(&serializer)
-        .expect("RenderResult serialization");
-    let artifacts = js_sys::Reflect::get(&js_result, &JsValue::from_str("artifacts"))
+    // `js_value()` is the object the boundary handed out, not a re-serialization.
+    let artifacts = js_sys::Reflect::get(&result.js_value(), &JsValue::from_str("artifacts"))
         .expect("artifacts present");
     let arr = js_sys::Array::from(&artifacts);
     assert!(arr.length() > 0, "artifacts array non-empty");
@@ -88,9 +99,11 @@ fn test_open_session_render() {
     let session = engine.open(&quill, &doc).expect("open failed");
     assert!(session.page_count() > 0, "session should expose page count");
 
-    let result = session
-        .render(Some(RenderOptions::default()))
-        .expect("session render failed");
+    let result = rust_of(
+        &session
+            .render(Some(default_opts()))
+            .expect("session render failed"),
+    );
     assert!(!result.artifacts.is_empty(), "should produce artifacts");
 }
 
@@ -138,11 +151,19 @@ fn test_session_region_shapes_cross_the_boundary() {
         rect[0].as_f64().unwrap() as f32 + 5.0,
         rect[3].as_f64().unwrap() as f32 - 3.0,
     );
-    let hit = session
-        .position_at(page, cx, cy, None)
-        .expect("positionAt inside content resolves");
+    let hit = rust_of(
+        &session
+            .position_at(page, cx, cy, None)
+            .expect("positionAt crosses")
+            .expect("positionAt inside content resolves"),
+    );
     assert_eq!(hit.field, "body");
-    let caret = session.locate("body", hit.pos).expect("locate");
+    let caret = rust_of(
+        &session
+            .locate("body", hit.pos)
+            .expect("locate crosses")
+            .expect("locate resolves"),
+    );
     assert_eq!(caret.span, Some([hit.pos, hit.pos]));
 }
 
@@ -184,12 +205,16 @@ fn test_quill_from_object_tree() {
 
     let doc = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
     let doc2 = Document::from_markdown(SIMPLE_MARKDOWN).expect("fromMarkdown failed");
-    let r_map = engine
-        .render(&from_map, &doc, Some(RenderOptions::default()))
-        .expect("render from Map form");
-    let r_obj = engine
-        .render(&from_obj, &doc2, Some(RenderOptions::default()))
-        .expect("render from object form");
+    let r_map = rust_of(
+        &engine
+            .render(&from_map, &doc, Some(default_opts()))
+            .expect("render from Map form"),
+    );
+    let r_obj = rust_of(
+        &engine
+            .render(&from_obj, &doc2, Some(default_opts()))
+            .expect("render from object form"),
+    );
     assert_eq!(r_map.artifacts.len(), r_obj.artifacts.len());
 }
 


### PR DESCRIPTION
`cargo check -p quillmark-wasm` emitted eleven deprecation warnings, the
workspace's only ones, one per `#[tsify(into_wasm_abi, from_wasm_abi)]`.
Those impls take the JS handle before converting: `from_abi` calls
`throw_str` and `into_abi` panics while still holding it, so a value JS
worded wrong strands a table slot, and a serialization failure traps the
module instead of surfacing as a catchable error. A live editor rendering
and hit-testing continuously is the case that accumulates it.

The eleven types keep their `Tsify` derive, which is what declares the
TypeScript type, and drop the ABI attributes. The six signatures that
actually cross — `Quillmark.render`, `LiveSession.{update,render,positionAt,
locate}` and `Document.formatDiagnostic` — take and return `tsify::Ts<T>`,
a `#[repr(transparent)]` JS handle the wasm-bindgen shim owns and frees,
and convert through `to_ts_or_throw` / `from_ts_or_throw`, which throw the
crate's diagnostic-carrying `Error` like every other failure here. The two
readers that returned a bare `Option` now return `Result<Option<_>, _>` so
the throw has somewhere to go.

`Location`, `Severity`, `Artifact`, `OutputFormat` and `HitGranularity`
never crossed as an outermost type; they only ever needed the declaration.

The generated `wasm.d.ts` is byte-identical apart from the low-level
`InitOutput` arities the added `Result`s widen: `formatDiagnostic` still
declares `string`, `locate` still `FieldRegion | undefined`. The 267 vitest
cases, the `runtime.d.ts` drift typecheck, and the workspace suite pass;
`cargo check --workspace --all-targets` is warning-free.

Closes #1633.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WBPod4uP476syXc9DqeTJC