### PR TITLE
docs(core): ERROR.md's args table covers the validation::seed_* codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+- docs(core): **`ERROR.md`'s args table covers the three `validation::seed_*`
+  codes it claimed.** The table is the `code` + `args` consumer contract, and
+  `diagnostic_args_match_canon` holds it to the minted set — but
+  `seed_unknown_kind`, `seed_overlay_shape` and `seed_unknown_field` were missing
+  from both, so the two agreed by omitting the same three and a consumer reading
+  the table saw a family it covered less of than it said. The rows are now minted
+  from the overlay walk itself, on a document that trips all three, so each row
+  and its construction site check each other.
 - docs: **two copies that were copies, not two ends of a subject.**
   `prose/README.md` divides canon and `docs/` by audience and says neither
   restates the other. § "Addressing cards for re-render" was in both, code block

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -761,6 +761,51 @@ mod args_canon {
             "validation::out_of_variant",
             crate::quill::compose::out_of_variant_warning(&path, "CUI", "UNCLASSIFIED").args,
         );
+        // The `$seed` checks are minted at the overlay walk, so the sample is a
+        // document that trips them: two overlays, three codes.
+        let seed_quill = crate::quill::quill_from_yaml(
+            r#"
+quill:
+  name: seed_probe
+  version: "0.1.0"
+  backend: typst
+  description: Seed overlay probe
+
+typst:
+  plate_file: plate.typ
+
+main:
+  fields:
+    title: { type: string, default: "" }
+card_kinds:
+  sig:
+    fields:
+      label: { type: string }
+"#,
+        );
+        let seed_diags: Vec<crate::Diagnostic> = ["  ghost: {}\n  sig: nope\n", "  sig:\n    nope: 1\n"]
+            .iter()
+            .flat_map(|overlay| {
+                let markdown = format!(
+                    "~~~\n$quill: seed_probe@0.1.0\n$kind: main\n$seed:\n{overlay}~~~\n"
+                );
+                let doc = crate::document::Document::parse(&markdown)
+                    .expect("seed probe parses")
+                    .document;
+                seed_quill.validate(&doc)
+            })
+            .collect();
+        for code in [
+            "validation::seed_unknown_kind",
+            "validation::seed_overlay_shape",
+            "validation::seed_unknown_field",
+        ] {
+            let sample = seed_diags
+                .iter()
+                .find(|d| d.code.as_deref() == Some(code))
+                .unwrap_or_else(|| panic!("no `{code}` sample from the seed probe"));
+            add(code, sample.args.clone());
+        }
         add("plate::unsupported_construct", {
             let mut args = BTreeMap::new();
             args.insert("construct".to_string(), "rule".into());

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -378,6 +378,9 @@ Three outcomes, and the wire tells them apart only with this table in hand, sinc
 | `validation::coercion_failed` | `value`, `target` | structured, coarser |
 | `validation::must_fill` | `trigger` | structured |
 | `validation::out_of_variant` | `variant`, `selected` | structured |
+| `validation::seed_unknown_kind` | — | code-determined |
+| `validation::seed_overlay_shape` | — | code-determined |
+| `validation::seed_unknown_field` | — | code-determined |
 | `validation::not_inline` | — | code-determined |
 | `validation::not_plain` | — | code-determined |
 | `edit::invalid_field_name` | `field` | structured |


### PR DESCRIPTION
`ERROR.md` § "Diagnostic args" is the `code` + `args` consumer contract, and § "Coverage" says it is tested like one: `diagnostic_args_match_canon` compares the table against the minted set.

`validation::seed_unknown_kind`, `validation::seed_overlay_shape` and `validation::seed_unknown_field` were missing from **both** sides of that comparison, so it passed by having the table and the minted set omit the same three codes. A consumer reading the table saw a `validation::*` family it covered less of than it claimed.

## What changed

- Three rows added to the args table, all `—` / code-determined: none of the seed diagnostics carries an arg.
- The samples are minted from the overlay walk itself — two `$seed` overlays on a probe quill that trip all three codes — rather than declared argless by hand. Hardcoding empty maps would have restored the row without exercising the construction site, which is the gap that let this through. Now an arg added to any seed diagnostic fails the test until the table follows.

No behavior change: no diagnostic's code, severity, path, message, or args differ.

## Verification

- `cargo test --workspace`: 1428 passed, 0 failed.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --workspace`: clean (the repo's standing lint gate).

## Context

Noted in passing in #1378, which is closed as not planned — the diagnostic that issue proposed is not part of this. This is only the documentation defect it happened to name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNiN8CrJWPThzpzwJF7z6u

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNiN8CrJWPThzpzwJF7z6u)_