### PR TITLE
refactor(core)!: three of the four deferred core refactors from #1697

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- refactor(core): **`QuillValue` holds its JSON, not a mirror of it.**
+  The value carried a private `Node`/`Kind` tree annotating every node with one
+  `fill` bit, plus a seeded `serde_json::Value` cache of the same data — so
+  `from_json` deep-cloned the whole document to record markers almost none of it
+  carries, and `get` cloned a subtree twice to read one child. No consumer wanted
+  the tree: emit, both wire formats, seeding, compose and conform all ask for a
+  flat path list, which is what `Seeded` already wrote by hand and what the DTO's
+  `nested_fills` already stores. `QuillValue` is now that pair — the JSON beside
+  a sorted, duplicate-free `Vec<Vec<PathSegment>>` — so the two node walkers
+  collapse to one `json_at`, and `OnceLock` and the hand-written `Clone` /
+  `PartialEq` go with them. The public surface is unchanged; `set_fill_at` still
+  refuses a path that addresses nothing, which is what keeps a recorded marker
+  from outliving its node.
 - docs(content,core): **the authored lane is `overwrite` and the op wire.**
   Canon and the 0.112 guide also named `install`, gone since 0.102, and
   `CardInput.body`, which has never rejected anything the storage lane takes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+- refactor(core)!: **prescan's cleaned YAML is line-for-line with its source.**
+  A comment line was dropped from the string handed to the parser, so the two
+  numberings diverged and a `PreScan::source_lines` table existed to map a
+  reported position back. The line now passes through — it is a comment to the
+  parser too — and the table, the `Cleaned` pair it rode in, and the
+  fall-back-to-the-last-line lookup go with it. Blanking the line instead, which
+  the same table would have bought, is what this does *not* do: a blank line is
+  content under keep chomping, so `bio: |+` followed by a comment would have
+  gained a newline. One break: a comment indented inside a multi-line plain
+  scalar now ends it, as it does in YAML, so `key: aaa` / `  # c` / `  bbb`
+  raises a located `parse::yaml_error` where it used to fold to `"aaa bbb"` —
+  a value no YAML parser reads out of that document.
 - refactor(core)!: **nested comments hang off the payload, not each item.**
   `PayloadItem::Field` / `Meta` lose `nested_comments`; one list on `Payload`
   carries them, at paths whose head segment names the owning entry. That is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- refactor(core)!: **nested comments hang off the payload, not each item.**
+  `PayloadItem::Field` / `Meta` lose `nested_comments`; one list on `Payload`
+  carries them, at paths whose head segment names the owning entry. That is the
+  form prescan already produced and the storage DTO already stored, so the
+  flat → per-item → flat conversion at both ends is gone. `Payload` gains the
+  public `nested_comments()` and `rename_field`, which carries a field's
+  comments with its key; `items_mut` is withdrawn, having existed only for the
+  rename that now has a verb — which is what kept `normalize_document` from
+  orphaning them. The wire is untouched: `PayloadV0_92_0.nested_comments` was
+  already the flat sidecar.
 - refactor(core): **`QuillValue` holds its JSON, not a mirror of it.**
   The value carried a private `Node`/`Kind` tree annotating every node with one
   `fill` bit, plus a seeded `serde_json::Value` cache of the same data — so

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -130,11 +130,9 @@ pub(super) struct MetadataBlock {
 
 /// The document-absolute, 1-indexed position of a YAML parse failure.
 ///
-/// `parser` is the position the engine reports inside the string it parsed:
-/// the fence content less the comment lines prescan drops
-/// ([`PreScan::source_lines`] maps what survives back) and less the leading
-/// whitespace `trim` removes. With no reported position the block's first
-/// content line is the anchor.
+/// `parser` is the position the engine reports inside the string it parsed: the
+/// fence content, line-for-line, less the leading whitespace `trim` removes.
+/// With no reported position the block's first content line is the anchor.
 fn document_position(
     markdown: &str,
     content_start: usize,
@@ -148,14 +146,7 @@ fn document_position(
 
     let cleaned = &pre.cleaned_yaml;
     let trimmed_prefix = &cleaned[..cleaned.len() - cleaned.trim_start().len()];
-
-    let cleaned_index = trimmed_prefix.matches('\n').count() + rel_line.saturating_sub(1);
-    let source_index = pre
-        .source_lines
-        .get(cleaned_index)
-        .or_else(|| pre.source_lines.last())
-        .copied()
-        .unwrap_or(0);
+    let source_index = trimmed_prefix.matches('\n').count() + rel_line.saturating_sub(1);
 
     // Only the first parsed line lost leading whitespace to `trim`.
     let column = if rel_line <= 1 {

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -500,7 +500,6 @@ fn build_payload(
                         key,
                         value: qv,
                         fill,
-                        nested_comments: Vec::new(),
                     });
                 }
             }
@@ -519,14 +518,10 @@ fn build_payload(
             key,
             value: qv,
             fill: false,
-            nested_comments: Vec::new(),
         });
     }
 
-    Ok(Payload::from_items_with_flat_nested(
-        items,
-        pre_nested_comments,
-    ))
+    Ok(Payload::from_items_with_nested(items, pre_nested_comments))
 }
 
 /// Apply the nested `!must_fill` markers rooted at `key` onto `value`'s tree.

--- a/crates/core/src/document/dto.rs
+++ b/crates/core/src/document/dto.rs
@@ -303,10 +303,8 @@ impl From<&Card> for CardV0_112_0 {
 
 impl From<&Payload> for PayloadV0_92_0 {
     fn from(payload: &Payload) -> Self {
-        // The wire format keeps `nested_comments` as a flat payload-level
-        // sidecar; the live model carries them per-item with relative paths.
         let nested_comments = payload
-            .flat_nested_comments()
+            .nested_comments()
             .iter()
             .map(NestedCommentV0_92_0::from)
             .collect();
@@ -574,7 +572,7 @@ impl TryFrom<PayloadV0_92_0> for Payload {
             .into_iter()
             .map(NestedComment::from)
             .collect();
-        Ok(Payload::from_items_with_flat_nested(items, nested))
+        Ok(Payload::from_items_with_nested(items, nested))
     }
 }
 
@@ -596,12 +594,10 @@ impl TryFrom<PayloadItemV0_92_0> for PayloadItem {
             PayloadItemV0_92_0::Ext { value } => PayloadItem::Meta {
                 key: MetaKey::Ext,
                 value: depth_check_meta_map(value, "$ext")?,
-                nested_comments: Vec::new(),
             },
             PayloadItemV0_92_0::Seed { value } => PayloadItem::Meta {
                 key: MetaKey::Seed,
                 value: depth_check_meta_map(value, "$seed")?,
-                nested_comments: Vec::new(),
             },
             PayloadItemV0_92_0::Field {
                 key,
@@ -623,7 +619,6 @@ impl TryFrom<PayloadItemV0_92_0> for PayloadItem {
                     key,
                     value: qv,
                     fill,
-                    nested_comments: Vec::new(),
                 }
             }
             PayloadItemV0_92_0::Comment { text, inline } => PayloadItem::Comment { text, inline },

--- a/crates/core/src/document/emit.rs
+++ b/crates/core/src/document/emit.rs
@@ -13,7 +13,7 @@
 use serde_json::Value as JsonValue;
 use serde_saphyr::{FlowMap, FlowSeq, SerializerOptions};
 
-use super::payload::PayloadItem;
+use super::payload::{Payload, PayloadItem};
 use super::prescan::NestedComment;
 use crate::value::PathSegment;
 use super::{Card, Document};
@@ -180,13 +180,14 @@ impl KeyPos {
 
 fn emit_block(out: &mut String, card: &Card) {
     out.push_str("~~~\n");
-    emit_payload_items(out, card.payload().items());
+    emit_payload_items(out, card.payload());
     out.push_str("~~~\n");
 }
 
 /// Walk the unified item list and emit each entry. An `inline: true` comment
 /// immediately following a non-comment item is consumed as that item's trailer.
-fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
+fn emit_payload_items(out: &mut String, payload: &Payload) {
+    let items = payload.items();
     let mut i = 0;
     while i < items.len() {
         let trailer = items.get(i + 1).and_then(|next| match next {
@@ -202,19 +203,11 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
             PayloadItem::Kind { value } => {
                 emit_meta_line(out, "kind", value, trailer);
             }
-            PayloadItem::Meta {
-                key,
-                value,
-                nested_comments,
-            } => {
-                emit_meta_block(out, key.as_str(), value, trailer, nested_comments);
+            PayloadItem::Meta { key, value } => {
+                let nested = payload.nested_comments_for(key.as_str());
+                emit_meta_block(out, key.as_str(), value, trailer, &nested);
             }
-            PayloadItem::Field {
-                key,
-                value,
-                fill,
-                nested_comments,
-            } => {
+            PayloadItem::Field { key, value, fill } => {
                 // card-yaml is the human-authored surface, so a stored content
                 // object projects back to markdown here. The projection runs
                 // marker or no marker: a seeded `example` on a must-fill content
@@ -236,6 +229,7 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
                 }
                 // Nested fill markers; the top-level one rides on `*fill`.
                 let fills = value.fill_paths();
+                let nested = payload.nested_comments_for(key);
                 emit_field_at(
                     out,
                     key,
@@ -243,7 +237,7 @@ fn emit_payload_items(out: &mut String, items: &[PayloadItem]) {
                     KeyPos::Line(0),
                     *fill,
                     EmitCtx {
-                        nested: nested_comments,
+                        nested: &nested,
                         fills: &fills,
                         ..EmitCtx::EMPTY
                     },

--- a/crates/core/src/document/meta.rs
+++ b/crates/core/src/document/meta.rs
@@ -81,7 +81,6 @@ pub(super) fn extract_meta_items(payload: &mut JsonValue) -> Result<Vec<PayloadI
                     JsonValue::Object(map) => PayloadItem::Meta {
                         key: meta_key,
                         value: map,
-                        nested_comments: Vec::new(),
                     },
                     other => {
                         return Err(ParseError::InvalidStructure(format!(

--- a/crates/core/src/document/mod.rs
+++ b/crates/core/src/document/mod.rs
@@ -181,7 +181,7 @@ pub use dto::{
 pub use edit::EditError;
 pub use meta::{is_valid_kind_name, validate_composable_kind, CardKindError};
 pub use payload::{MetaKey, Payload, PayloadItem};
-// Reachable through `PayloadItem`'s `nested_comments` fields, so nameable from here.
+// Reachable through `Payload::nested_comments`, so nameable from here.
 pub use prescan::NestedComment;
 pub use wire::{CardWire, PayloadItemWire, WireError};
 

--- a/crates/core/src/document/payload.rs
+++ b/crates/core/src/document/payload.rs
@@ -6,9 +6,9 @@
 //! adjacent to a `$` line round-trips through the same mechanism as one
 //! adjacent to a user field.
 //!
-//! Comments inside a structured value live on the [`PayloadItem::Field`] /
-//! [`PayloadItem::Meta`] that owns it, as `nested_comments` with paths relative
-//! to that item's value tree.
+//! Comments inside a structured value live on the [`Payload`] itself, at paths
+//! whose head segment names the entry that owns them — the form prescan
+//! produces and the storage DTO stores, so neither end converts.
 //!
 //! The map-keyed accessors filter to [`PayloadItem::Field`]; `$` entries have
 //! dedicated typed accessors.
@@ -75,24 +75,18 @@ pub enum PayloadItem {
     /// `$kind` system metadata: the card's kind name.
     Kind { value: String },
     /// `$ext` / `$seed` system metadata: an opaque mapping discriminated by
-    /// [`MetaKey`], never emitted into the plate JSON. `nested_comments` carries
-    /// YAML comments inside the mapping, at paths **relative** to the value tree.
+    /// [`MetaKey`], never emitted into the plate JSON.
     Meta {
         key: MetaKey,
         value: JsonMap<String, JsonValue>,
-        nested_comments: Vec<NestedComment>,
     },
     /// A user-defined YAML field, optionally tagged `!must_fill`.
-    ///
-    /// `nested_comments` carries YAML comments inside the field's value, at
-    /// paths **relative** to that value tree.
     Field {
         key: String,
         value: QuillValue,
         /// `true` when the field was written as `key: !must_fill <value>` or
         /// `key: !must_fill` in source.
         fill: bool,
-        nested_comments: Vec<NestedComment>,
     },
     /// A YAML comment. Text excludes the leading `#` and one optional space.
     ///
@@ -102,14 +96,24 @@ pub enum PayloadItem {
 }
 
 impl PayloadItem {
-    /// Shorthand for a plain (non-fill) field entry with no nested comments.
+    /// Shorthand for a plain (non-fill) field entry.
     #[cfg(test)]
     pub(crate) fn field(key: impl Into<String>, value: QuillValue) -> Self {
         PayloadItem::Field {
             key: key.into(),
             value,
             fill: false,
-            nested_comments: Vec::new(),
+        }
+    }
+
+    /// The key a [`Payload`]'s nested comments address this entry by: a field's
+    /// own key, or the literal `$ext` / `$seed`. `None` for the entries that
+    /// carry no structured value to nest inside.
+    fn nested_owner_key(&self) -> Option<&str> {
+        match self {
+            PayloadItem::Field { key, .. } => Some(key),
+            PayloadItem::Meta { key, .. } => Some(key.as_str()),
+            _ => None,
         }
     }
 
@@ -152,11 +156,15 @@ impl PayloadItem {
 #[derive(Debug, Clone, PartialEq)]
 pub struct Payload {
     items: Vec<PayloadItem>,
+    nested_comments: Vec<NestedComment>,
 }
 
 impl Payload {
     pub(crate) fn new() -> Self {
-        Self { items: Vec::new() }
+        Self {
+            items: Vec::new(),
+            nested_comments: Vec::new(),
+        }
     }
 
     /// No `$` entries, no comments, no fill markers.
@@ -167,102 +175,64 @@ impl Payload {
                 key,
                 value,
                 fill: false,
-                nested_comments: Vec::new(),
             })
             .collect();
-        Self { items }
+        Self::from_items(items)
     }
 
     pub(crate) fn from_items(items: Vec<PayloadItem>) -> Self {
-        Self { items }
+        Self {
+            items,
+            nested_comments: Vec::new(),
+        }
     }
 
-    /// Partition a flat absolute-path `nested_comments` Vec onto the matching
-    /// [`PayloadItem::Field`] / [`PayloadItem::Meta`] items: the first path
-    /// segment names the owner and is stripped. Comments matching no item are
-    /// dropped, which can only arise from a hand-crafted storage DTO.
-    pub(crate) fn from_items_with_flat_nested(
-        mut items: Vec<PayloadItem>,
+    /// `nested_comments` addresses its owners by the head path segment, which
+    /// is how prescan produces them and how the storage DTO stores them. An
+    /// entry matching no item is inert: every reader filters by owner.
+    pub(crate) fn from_items_with_nested(
+        items: Vec<PayloadItem>,
         nested_comments: Vec<NestedComment>,
     ) -> Self {
-        for nc in nested_comments {
-            let Some((first, rest)) = nc.container_path.split_first() else {
-                // Empty path can't address any user field; drop.
-                continue;
-            };
-            let target_key = match first {
-                PathSegment::Key(k) => k.clone(),
-                PathSegment::Index(_) => continue,
-            };
-
-            let relative = NestedComment {
-                container_path: rest.to_vec(),
-                position: nc.position,
-                text: nc.text,
-                inline: nc.inline,
-            };
-
-            // `$ext` / `$seed` are encoded with their literal key at the head
-            // of the path; everything else is a user field.
-            let slot = if let Some(meta_key) = MetaKey::from_key_str(&target_key) {
-                items.iter_mut().find_map(|i| match i {
-                    PayloadItem::Meta {
-                        key,
-                        nested_comments,
-                        ..
-                    } if *key == meta_key => Some(nested_comments),
-                    _ => None,
-                })
-            } else {
-                items.iter_mut().find_map(|i| match i {
-                    PayloadItem::Field {
-                        key,
-                        nested_comments,
-                        ..
-                    } if key == &target_key => Some(nested_comments),
-                    _ => None,
-                })
-            };
-            if let Some(slot) = slot {
-                slot.push(relative);
-            }
+        Self {
+            items,
+            nested_comments,
         }
-        Self { items }
     }
 
-    /// The inverse of
-    /// [`from_items_with_flat_nested`](Self::from_items_with_flat_nested):
-    /// re-prefix each nested comment's path with its owning item's key, for the
-    /// storage DTO's payload-level sidecar.
-    pub(crate) fn flat_nested_comments(&self) -> Vec<NestedComment> {
-        let mut out = Vec::new();
-        for item in &self.items {
-            let (prefix, comments) = match item {
-                PayloadItem::Field {
-                    key,
-                    nested_comments,
-                    ..
-                } => (key.clone(), nested_comments),
-                PayloadItem::Meta {
-                    key,
-                    nested_comments,
-                    ..
-                } => (key.as_str().to_string(), nested_comments),
-                _ => continue,
-            };
-            for nc in comments {
-                let mut path = Vec::with_capacity(nc.container_path.len() + 1);
-                path.push(PathSegment::Key(prefix.clone()));
-                path.extend(nc.container_path.iter().cloned());
-                out.push(NestedComment {
-                    container_path: path,
+    /// Comments inside this payload's structured values, at paths whose head
+    /// segment names the owning entry: a field's key, or the literal `$ext` /
+    /// `$seed`. One list for the whole payload, which is how prescan produces
+    /// them and how the storage DTO stores them.
+    pub fn nested_comments(&self) -> &[NestedComment] {
+        &self.nested_comments
+    }
+
+    /// The comments owned by entry `key`, rebased onto that entry's own value.
+    pub(crate) fn nested_comments_for(&self, key: &str) -> Vec<NestedComment> {
+        self.nested_comments
+            .iter()
+            .filter_map(|nc| {
+                let (PathSegment::Key(head), rest) = nc.container_path.split_first()? else {
+                    return None;
+                };
+                (head == key).then(|| NestedComment {
+                    container_path: rest.to_vec(),
                     position: nc.position,
                     text: nc.text.clone(),
                     inline: nc.inline,
-                });
-            }
-        }
-        out
+                })
+            })
+            .collect()
+    }
+
+    /// Drop the comments nested inside entry `key`. Every path that replaces or
+    /// removes an entry runs it: the new value need not carry the positions the
+    /// old one's comments sat at.
+    fn prune_nested(&mut self, key: &str) {
+        self.nested_comments.retain(|nc| {
+            !matches!(nc.container_path.first(), Some(PathSegment::Key(k)) if k == key)
+        });
     }
 
     /// Ordered iterator over raw items (`$` entries, fields, comments).
@@ -270,18 +240,34 @@ impl Payload {
         &self.items
     }
 
-    /// Mutable access to the raw item list for in-place rewrites. The slice
-    /// cannot add or drop items, so the arity invariants survive any use of it;
-    /// a caller that rewrites a `Field` key owns keeping it well-formed and
-    /// distinct.
-    pub(crate) fn items_mut(&mut self) -> &mut [PayloadItem] {
-        &mut self.items
+    /// Rename user field `from` to `to`, carrying the comments nested inside it.
+    /// No-op when no such field exists; the caller owns `to` being a well-formed
+    /// name not already present.
+    pub(crate) fn rename_field(&mut self, from: &str, to: String) {
+        let Some(slot) = self.items.iter_mut().find_map(|i| match i {
+            PayloadItem::Field { key, .. } if key == from => Some(key),
+            _ => None,
+        }) else {
+            return;
+        };
+        *slot = to.clone();
+        for nc in &mut self.nested_comments {
+            if matches!(nc.container_path.first(), Some(PathSegment::Key(k)) if k == from) {
+                nc.container_path[0] = PathSegment::Key(to.clone());
+            }
+        }
     }
 
-    /// Remove and return the first item matching `pred`.
+    /// Remove and return the first item matching `pred`, with the comments
+    /// nested inside it.
     fn take_item(&mut self, pred: impl Fn(&PayloadItem) -> bool) -> Option<PayloadItem> {
         let pos = self.items.iter().position(pred)?;
-        Some(self.items.remove(pos))
+        let item = self.items.remove(pos);
+        if let Some(key) = item.nested_owner_key() {
+            let key = key.to_string();
+            self.prune_nested(&key);
+        }
+        Some(item)
     }
 
     /// The `$quill` reference, if declared.
@@ -331,14 +317,11 @@ impl Payload {
     }
 
     /// Set or replace an out-of-band meta entry at its canonical position.
-    /// Nested comments on a replaced entry are dropped (the new value tree
-    /// may not contain matching positions).
+    /// Nested comments on a replaced entry are dropped (the new value may not
+    /// contain matching positions).
     pub(crate) fn set_meta(&mut self, key: MetaKey, value: JsonMap<String, JsonValue>) {
-        self.upsert_meta(PayloadItem::Meta {
-            key,
-            value,
-            nested_comments: Vec::new(),
-        });
+        self.prune_nested(key.as_str());
+        self.upsert_meta(PayloadItem::Meta { key, value });
     }
 
     /// Set or replace the `$ext` entry, after `$quill` / `$kind` and before any
@@ -488,23 +471,17 @@ impl Payload {
                 key: k,
                 value: v,
                 fill: item_fill,
-                nested_comments,
             } = item
             {
                 if k == &key {
                     let old = std::mem::replace(v, value);
                     *item_fill = fill;
-                    nested_comments.clear();
+                    self.prune_nested(&key);
                     return Some(old);
                 }
             }
         }
-        self.items.push(PayloadItem::Field {
-            key,
-            value,
-            fill,
-            nested_comments: Vec::new(),
-        });
+        self.items.push(PayloadItem::Field { key, value, fill });
         None
     }
 
@@ -646,5 +623,94 @@ mod tests {
             })
             .collect();
         assert_eq!(comments, vec!["header", "mid"]);
+    }
+
+    /// A nested comment addressed to `key`, one segment deep.
+    fn nested(key: &str, text: &str) -> NestedComment {
+        NestedComment {
+            container_path: vec![PathSegment::Key(key.to_string())],
+            position: 0,
+            text: text.to_string(),
+            inline: false,
+        }
+    }
+
+    fn owners(fm: &Payload) -> Vec<&str> {
+        fm.nested_comments()
+            .iter()
+            .map(|nc| match &nc.container_path[0] {
+                PathSegment::Key(k) => k.as_str(),
+                PathSegment::Index(_) => unreachable!("rooted at a key"),
+            })
+            .collect()
+    }
+
+    fn payload_with_nested() -> Payload {
+        Payload::from_items_with_nested(
+            vec![
+                PayloadItem::Meta {
+                    key: MetaKey::Ext,
+                    value: JsonMap::new(),
+                },
+                PayloadItem::field("a", qv("1")),
+                PayloadItem::field("b", qv("2")),
+            ],
+            vec![nested("a", "in a"), nested("b", "in b"), nested("$ext", "in ext")],
+        )
+    }
+
+    /// Comments key off the owning entry, so touching one entry leaves every
+    /// other entry's comments where they were.
+    #[test]
+    fn replacing_an_entry_prunes_only_its_own_nested_comments() {
+        let mut fm = payload_with_nested();
+        fm.insert_unchecked("a", qv("updated"));
+        assert_eq!(owners(&fm), vec!["b", "$ext"]);
+
+        let mut fm = payload_with_nested();
+        fm.set_ext(JsonMap::new());
+        assert_eq!(owners(&fm), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn removing_an_entry_takes_its_nested_comments_with_it() {
+        let mut fm = payload_with_nested();
+        fm.remove("a").expect("a is a field");
+        assert_eq!(owners(&fm), vec!["b", "$ext"]);
+
+        let mut fm = payload_with_nested();
+        fm.take_meta(MetaKey::Ext).expect("$ext is present");
+        assert_eq!(owners(&fm), vec!["a", "b"]);
+    }
+
+    /// Renaming carries them: the key is how a comment finds its value, so a
+    /// rename that left the head behind would orphan every comment inside it.
+    #[test]
+    fn renaming_a_field_carries_its_nested_comments() {
+        let mut fm = payload_with_nested();
+        fm.rename_field("a", "renamed".to_string());
+        assert_eq!(owners(&fm), vec!["renamed", "b", "$ext"]);
+        assert_eq!(fm.nested_comments_for("renamed").len(), 1);
+        assert!(fm.nested_comments_for("a").is_empty());
+    }
+
+    #[test]
+    fn nested_comments_for_rebases_onto_the_entry() {
+        let fm = Payload::from_items_with_nested(
+            vec![PayloadItem::field("a", qv("1"))],
+            vec![NestedComment {
+                container_path: vec![
+                    PathSegment::Key("a".to_string()),
+                    PathSegment::Index(2),
+                ],
+                position: 1,
+                text: "deep".to_string(),
+                inline: false,
+            }],
+        );
+        let got = fm.nested_comments_for("a");
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].container_path, vec![PathSegment::Index(2)]);
+        assert_eq!(got[0].position, 1);
     }
 }

--- a/crates/core/src/document/prescan.rs
+++ b/crates/core/src/document/prescan.rs
@@ -3,9 +3,10 @@
 //!
 //! Top-level comments become [`super::PayloadItem::Comment`]. Comments inside
 //! block mappings/sequences are captured with their structural path and an
-//! ordinal, which the emitter re-injects at (see [`NestedComment`]). A
-//! `!must_fill` tag is stripped from the cleaned YAML, so serde_saphyr sees a
-//! plain scalar, and recorded as a `fill` marker.
+//! ordinal, which the emitter re-injects at (see [`NestedComment`]). The lines
+//! themselves stay in the cleaned YAML, where they are comments to serde_saphyr
+//! too. A `!must_fill` tag is stripped, so serde_saphyr sees a plain scalar, and
+//! recorded as a `fill` marker.
 //!
 //! `!must_fill` is the only recognized fill tag; every other custom tag is
 //! dropped with a `parse::unsupported_yaml_tag` warning, value kept.
@@ -41,13 +42,11 @@ pub struct NestedComment {
 /// Output of [`prescan_fence_content`].
 #[derive(Debug, Clone, Default)]
 pub(crate) struct PreScan {
-    /// YAML with `!must_fill` tags stripped and comment lines removed; fed to serde_saphyr.
+    /// YAML with `!must_fill` tags stripped; fed to serde_saphyr. Line-for-line
+    /// with the fence content — comment lines pass through, being comments to
+    /// the parser too — so a reported position needs no mapping to travel back
+    /// to a document position.
     pub cleaned_yaml: String,
-    /// The 0-indexed line of the fence content each line of
-    /// [`Self::cleaned_yaml`] came from. Own-line comments are dropped rather
-    /// than blanked, so the two numberings diverge and a parse failure needs
-    /// this to travel back to a document position.
-    pub source_lines: Vec<usize>,
     /// Top-level fields and comments in source order.
     pub items: Vec<PreItem>,
     pub nested_comments: Vec<NestedComment>,
@@ -56,20 +55,6 @@ pub(crate) struct PreScan {
     /// value tree by the assembler. Top-level fills ride on `PreItem::Field`.
     pub nested_fills: Vec<Vec<PathSegment>>,
     pub warnings: Vec<Diagnostic>,
-}
-
-/// The emitted YAML lines paired with the source line each came from.
-#[derive(Debug)]
-struct Cleaned {
-    lines: Vec<String>,
-    source_lines: Vec<usize>,
-}
-
-impl Cleaned {
-    fn push(&mut self, source_line: usize, text: String) {
-        self.lines.push(text);
-        self.source_lines.push(source_line);
-    }
 }
 
 #[derive(Debug)]
@@ -83,10 +68,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
     let mut out = PreScan::default();
 
     let lines: Vec<&str> = content.split('\n').collect();
-    let mut cleaned = Cleaned {
-        lines: Vec::with_capacity(lines.len()),
-        source_lines: Vec::with_capacity(lines.len()),
-    };
+    let mut cleaned: Vec<String> = Vec::with_capacity(lines.len());
 
     let mut stack: Vec<Frame> = vec![Frame {
         indent: 0,
@@ -99,7 +81,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
 
     let mut unsupported_fill_tag = false;
 
-    for (source_line, raw_line) in lines.iter().enumerate() {
+    for raw_line in &lines {
         // The split is on `\n`, so a CRLF line ends in `\r`. Dropped once here:
         // every matcher below, and the cleaned YAML, see `\n`-only lines.
         let line = raw_line.strip_suffix('\r').unwrap_or(raw_line);
@@ -107,7 +89,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
         let trimmed = &line[indent..];
 
         if trimmed.is_empty() {
-            cleaned.push(source_line, line.to_string());
+            cleaned.push(line.to_string());
             continue;
         }
 
@@ -116,7 +98,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
         // A line at or below the key's indent ends the scalar.
         if let Some(key_indent) = block_scalar_indent {
             if indent > key_indent {
-                cleaned.push(source_line, line.to_string());
+                cleaned.push(line.to_string());
                 continue;
             }
             block_scalar_indent = None;
@@ -149,6 +131,9 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
                     inline: false,
                 });
             }
+            // Emitted, not dropped: a comment is a comment to the parser too,
+            // and keeping the line keeps the numbering the source's.
+            cleaned.push(line.to_string());
             continue;
         }
 
@@ -223,9 +208,9 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
                     None if after_dash.trim_end().is_empty() => "-".to_string(),
                     None => format!("- {}", after_dash.trim_end()),
                 };
-                cleaned.push(source_line, format!("{}{}", head, body));
+                cleaned.push(format!("{}{}", head, body));
             } else {
-                cleaned.push(source_line, line.to_string());
+                cleaned.push(line.to_string());
             }
 
             // For a `- |-` item the content is indented past the dash, so the
@@ -267,7 +252,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
                     });
                 }
 
-                cleaned.push(source_line, format!("{}:{}", key, value_without_tag));
+                cleaned.push(format!("{}:{}", key, value_without_tag));
 
                 if let Some(c) = trailing_comment {
                     out.items.push(PreItem::Comment {
@@ -318,12 +303,9 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
                     });
                 }
                 let head = format!("{:width$}", "", width = indent);
-                cleaned.push(
-                    source_line,
-                    format!("{}{}:{}", head, source_key, value_without_tag),
-                );
+                cleaned.push(format!("{}{}:{}", head, source_key, value_without_tag));
             } else {
-                cleaned.push(source_line, line.to_string());
+                cleaned.push(line.to_string());
             }
 
             if has_empty_inline_value(&value_without_tag) {
@@ -341,7 +323,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
         }
 
         unsupported_fill_tag |= line_has_unsupported_fill_tag(line);
-        cleaned.push(source_line, line.to_string());
+        cleaned.push(line.to_string());
     }
 
     if unsupported_fill_tag {
@@ -357,8 +339,7 @@ pub(crate) fn prescan_fence_content(content: &str) -> PreScan {
         );
     }
 
-    out.cleaned_yaml = cleaned.lines.join("\n");
-    out.source_lines = cleaned.source_lines;
+    out.cleaned_yaml = cleaned.join("\n");
     out
 }
 
@@ -1023,23 +1004,25 @@ mod tests {
     }
 
     #[test]
-    fn source_lines_map_cleaned_lines_back_over_dropped_comments() {
+    fn cleaned_yaml_is_line_for_line_with_its_source() {
+        // A parse position is a source position only while this holds; comment
+        // lines, a fill tag lifted off a value, and block-scalar content that
+        // looks like structure all have to leave the numbering alone.
         let input = "# lead\ntitle: Doc\n\n# note\nrole: !must_fill\nbio: |\n  # not a comment\nend: x\n";
         let out = prescan_fence_content(input);
 
-        assert_eq!(out.cleaned_yaml.split('\n').count(), out.source_lines.len());
-        let source = |needle: &str| {
-            let i = out
-                .cleaned_yaml
-                .split('\n')
+        let cleaned: Vec<&str> = out.cleaned_yaml.split('\n').collect();
+        assert_eq!(cleaned.len(), input.split('\n').count());
+        let line_of = |needle: &str| {
+            cleaned
+                .iter()
                 .position(|l| l.contains(needle))
-                .expect("cleaned line present");
-            out.source_lines[i]
+                .expect("cleaned line present")
         };
-        assert_eq!(source("title:"), 1);
-        assert_eq!(source("role:"), 4);
-        assert_eq!(source("# not a comment"), 6);
-        assert_eq!(source("end:"), 7);
+        assert_eq!(line_of("title:"), 1);
+        assert_eq!(line_of("role:"), 4);
+        assert_eq!(line_of("# not a comment"), 6);
+        assert_eq!(line_of("end:"), 7);
     }
 
     #[test]

--- a/crates/core/src/document/tests/lossiness_tests.rs
+++ b/crates/core/src/document/tests/lossiness_tests.rs
@@ -1,7 +1,7 @@
 use crate::document::Document;
 
-/// The prescan comment-stripper must not treat `#`-leading lines inside a
-/// literal block as YAML comments.
+/// Prescan must not record `#`-leading lines inside a literal block as YAML
+/// comments: they are the scalar's own text.
 #[test]
 fn block_scalar_with_markdown_headings_round_trips() {
     let src = "~~~card-yaml\n$quill: q\n$kind: main\nbio: |-\n  ## About me\n\n  - first point\n  Plain line.\ntitle: Resume\n~~~\n";
@@ -701,4 +701,43 @@ fn array_element_nested_fill_survives_markdown_and_storage() {
         restored.to_markdown(),
         "markdown must be identical after a storage round-trip"
     );
+}
+
+/// A comment line ends a block scalar; it is not a blank line inside one. Under
+/// keep chomping (`|+` / `>+`) a blank line there would be content, so the
+/// distinction is the value, not just the numbering.
+#[test]
+fn a_comment_after_a_kept_block_scalar_adds_no_line_to_it() {
+    for marker in ["|+", ">+"] {
+        let src = format!(
+            "~~~card-yaml\n$quill: q\n$kind: main\nbio: {marker}\n  text\n# after\nnext: x\n~~~\n"
+        );
+        let doc = Document::parse(&src).unwrap().document;
+        let fm = doc.main().payload();
+        assert_eq!(
+            fm.get("bio").unwrap().as_str(),
+            Some("text\n"),
+            "`{marker}` keeps only the newlines the source held"
+        );
+        assert_eq!(fm.get("next").unwrap().as_str(), Some("x"));
+        assert!(
+            doc.to_markdown().contains("# after"),
+            "the comment survives\nGot:\n{}",
+            doc.to_markdown()
+        );
+    }
+}
+
+/// A comment ends a multi-line plain scalar, as it does in YAML, so what
+/// follows it is a mapping line the parser refuses — rather than a fold that
+/// quietly invents `"aaa bbb"` from a document no YAML parser accepts. The
+/// refusal anchors at the offending source line.
+#[test]
+fn a_comment_inside_a_plain_scalar_is_a_located_refusal() {
+    let src = "~~~card-yaml\n$quill: q\n$kind: main\nkey: aaa\n  # c\n  bbb\n~~~\n";
+    let err = Document::parse(src).expect_err("the continuation is not a mapping entry");
+    let crate::error::ParseError::YamlErrorWithLocation { line, column, .. } = err else {
+        panic!("expected a located YAML error, got {err:?}");
+    };
+    assert_eq!((line, column), (6, 3), "anchored at `  bbb` in the source");
 }

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -286,7 +286,7 @@ mod tests {
     use serde_json::json;
 
     /// Nested `!must_fill` markers inside a field value survive Card → wire →
-    /// Card via the `nestedFills` path list (the JSON projection is fill-free).
+    /// Card via the `nestedFills` path list (the JSON itself is fill-free).
     #[test]
     fn card_wire_round_trips_nested_fill() {
         let mut addr = QuillValue::from_json(json!({"street": null, "city": "Anytown"}));

--- a/crates/core/src/document/wire.rs
+++ b/crates/core/src/document/wire.rs
@@ -228,7 +228,6 @@ impl TryFrom<CardWire> for Card {
                         key,
                         value: qv,
                         fill,
-                        nested_comments: Vec::new(),
                     })
                 }
                 PayloadItemWire::Comment { text, inline } => {
@@ -295,7 +294,6 @@ mod tests {
             key: "addr".to_string(),
             value: addr,
             fill: false,
-            nested_comments: Vec::new(),
         }]);
         let card = Card::from_parts(payload, quillmark_content::Normalized::empty());
 
@@ -329,7 +327,6 @@ mod tests {
             key: "recipients".to_string(),
             value,
             fill: false,
-            nested_comments: Vec::new(),
         }]);
         let wire = CardWire::from(&Card::from_parts(
             payload,
@@ -423,7 +420,6 @@ mod tests {
                 key: "count".to_string(),
                 value: QuillValue::from_json(json!(3)),
                 fill: true,
-                nested_comments: Vec::new(),
             },
         ]);
         payload.set_kind("note");

--- a/crates/core/src/normalize.rs
+++ b/crates/core/src/normalize.rs
@@ -26,13 +26,19 @@ pub fn normalize_document(doc: crate::document::Document) -> crate::document::Do
 fn normalize_card(card: &Card) -> Card {
     use crate::document::PayloadItem;
     let mut payload = card.payload().clone();
-    for item in payload.items_mut() {
-        if let PayloadItem::Field { key, .. } = item {
-            let normalized = normalize_field_name(key);
-            if normalized != *key {
-                *key = normalized;
+    let renames: Vec<(String, String)> = payload
+        .items()
+        .iter()
+        .filter_map(|item| match item {
+            PayloadItem::Field { key, .. } => {
+                let normalized = normalize_field_name(key);
+                (normalized != *key).then(|| (key.clone(), normalized))
             }
-        }
+            _ => None,
+        })
+        .collect();
+    for (from, to) in renames {
+        payload.rename_field(&from, to);
     }
     Card::from_parts(payload, card.body().clone())
 }

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -72,25 +72,56 @@ fn body_placeholder(kind: &str) -> String {
     format!("Write {kind} body here.")
 }
 
+/// A card's payload under construction: entries in source order beside the
+/// comments nested inside their values, which [`Payload`] keys by owner.
+#[derive(Default)]
+struct CardItems {
+    items: Vec<PayloadItem>,
+    nested: Vec<NestedComment>,
+}
+
+impl CardItems {
+    fn push(&mut self, item: PayloadItem) {
+        self.items.push(item);
+    }
+
+    /// Adopt the comments nested inside entry `key`, rebasing each onto the
+    /// payload-absolute path `Payload` addresses them by.
+    fn adopt_nested(&mut self, key: &str, nested: Vec<NestedComment>) {
+        self.nested.extend(nested.into_iter().map(|nc| {
+            let mut path = Vec::with_capacity(nc.container_path.len() + 1);
+            path.push(PathSegment::Key(key.to_string()));
+            path.extend(nc.container_path);
+            NestedComment {
+                container_path: path,
+                ..nc
+            }
+        }));
+    }
+
+    fn into_payload(self) -> Payload {
+        Payload::from_items_with_nested(self.items, self.nested)
+    }
+}
+
 /// Build the root card: `$quill` (with the `# keep verbatim` inline reminder),
 /// `$kind: main`, the optional description own-line comment, then the fields.
 fn build_main_card(card: &CardSchema, quill_ref: &str, description: Option<String>) -> Card {
     let reference = quill_ref
         .parse()
         .expect("quill name@version is always a valid QuillReference");
-    let mut items = vec![
-        PayloadItem::Quill { reference },
-        PayloadItem::comment_inline("keep verbatim"),
-        PayloadItem::Kind {
-            value: "main".into(),
-        },
-    ];
+    let mut items = CardItems::default();
+    items.push(PayloadItem::Quill { reference });
+    items.push(PayloadItem::comment_inline("keep verbatim"));
+    items.push(PayloadItem::Kind {
+        value: "main".into(),
+    });
     if let Some(desc) = description {
         items.push(PayloadItem::comment(desc));
     }
     append_fields(&mut items, card);
     Card::from_parts(
-        Payload::from_items(items),
+        items.into_payload(),
         // The empty-content fallback is defensive: a placeholder or a
         // load-validated example never over-nests.
         crate::document::import_body(&body_text(card, "main"))
@@ -102,26 +133,25 @@ fn build_main_card(card: &CardSchema, quill_ref: &str, description: Option<Strin
 /// comment, a comment naming it a deletable sample, the optional description,
 /// then the fields.
 fn build_card(card: &CardSchema) -> Card {
-    let mut items = vec![
-        PayloadItem::Kind {
-            value: card.name.clone(),
-        },
-        PayloadItem::comment("composable (0..N)"),
-        PayloadItem::comment("sample card; delete if not needed"),
-    ];
+    let mut items = CardItems::default();
+    items.push(PayloadItem::Kind {
+        value: card.name.clone(),
+    });
+    items.push(PayloadItem::comment("composable (0..N)"));
+    items.push(PayloadItem::comment("sample card; delete if not needed"));
     if let Some(desc) = collapse_opt(card.description.as_deref()) {
         items.push(PayloadItem::comment(desc));
     }
     append_fields(&mut items, card);
     Card::from_parts(
-        Payload::from_items(items),
+        items.into_payload(),
         crate::document::import_body(&body_text(card, &card.name))
             .unwrap_or_else(|_| quillmark_content::Normalized::empty()),
     )
 }
 
 /// Append every field of a card as payload items, in [`group_fields`] order.
-fn append_fields(items: &mut Vec<PayloadItem>, card: &CardSchema) {
+fn append_fields(items: &mut CardItems, card: &CardSchema) {
     let registry: Vec<&str> = card
         .ui
         .as_ref()
@@ -166,7 +196,7 @@ fn group_fields<'a, I: IntoIterator<Item = &'a FieldSchema>>(
 /// Append one top-level field. Dispatches typed tables (`array<object>`) and
 /// typed dictionaries (`object` with `properties`) to their per-property
 /// builders; everything else is a scalar/array cell.
-fn append_field(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
+fn append_field(items: &mut CardItems, field: &FieldSchema) {
     if field.is_variant_bearing() {
         append_variant(items, field);
         return;
@@ -215,7 +245,7 @@ fn eg_hinted(field: &FieldSchema) -> bool {
 /// then the `# e.g.` hint. `eg_when` gates the hint: a leaf surfaces it under
 /// `eg_hinted`, while typed containers always surface it (their example never
 /// inlines).
-fn push_leading(items: &mut Vec<PayloadItem>, field: &FieldSchema, eg_when: bool) {
+fn push_leading(items: &mut CardItems, field: &FieldSchema, eg_when: bool) {
     if let Some(desc) = collapse_opt(field.description.as_deref()) {
         items.push(PayloadItem::comment(desc));
     }
@@ -251,14 +281,13 @@ fn scalar_value(field: &FieldSchema) -> JsonValue {
 
 /// Append a scalar / scalar-array / richtext field as a single payload field
 /// plus its trailing inline type annotation.
-fn append_scalar(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
+fn append_scalar(items: &mut CardItems, field: &FieldSchema) {
     push_leading(items, field, eg_hinted(field));
     let (json, fill) = scalar_cell(field);
     items.push(PayloadItem::Field {
         key: field.name.clone(),
         value: QuillValue::from_json(json),
         fill,
-        nested_comments: Vec::new(),
     });
     items.push(PayloadItem::comment_inline(type_expression(field)));
 }
@@ -375,7 +404,7 @@ fn container_cell(
 /// fields of the world that discriminant selects, and a
 /// `# when <MEMBER>: <fields>` line for every other world that owns a field set
 /// (`prose/canon/BLUEPRINT.md` § "Enum variants").
-fn append_variant(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
+fn append_variant(items: &mut CardItems, field: &FieldSchema) {
     push_leading(items, field, field.default.is_some());
     if let Some(variants) = &field.variants {
         for (member, fields) in variants {
@@ -430,7 +459,7 @@ fn append_variant(items: &mut Vec<PayloadItem>, field: &FieldSchema) {
 /// its trailing inline type annotation. The top-level `fill` flag is always
 /// `false`: typed containers are tagged on their leaves, never the container.
 fn push_container_field(
-    items: &mut Vec<PayloadItem>,
+    items: &mut CardItems,
     key: &str,
     value: JsonValue,
     nested_comments: Vec<NestedComment>,
@@ -441,11 +470,11 @@ fn push_container_field(
     for path in &fills {
         quill_value.set_fill_at(path);
     }
+    items.adopt_nested(key, nested_comments);
     items.push(PayloadItem::Field {
         key: key.to_string(),
         value: quill_value,
         fill: false,
-        nested_comments,
     });
     items.push(PayloadItem::comment_inline(type_expression(field)));
 }

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -289,7 +289,7 @@ impl QuillConfig {
 
         // Null ≡ absent, so a present-null passes through at every type.
         // Returning `value` rather than the JSON also preserves a `!must_fill`
-        // marker riding on it: the fill flag is not part of the JSON projection.
+        // marker riding on it: the fill flag is not part of the JSON.
         if json_value.is_null() {
             return Ok(value.clone());
         }

--- a/crates/core/src/quill/seed.rs
+++ b/crates/core/src/quill/seed.rs
@@ -47,7 +47,6 @@ fn seed_parts(schema: &CardSchema, overlay: Option<&SeedOverlay>) -> (Payload, N
             // mapping never carries one: its obligation sits on the leaves
             // inside it, which `fills` addresses by path.
             fill: fills.iter().any(Vec::is_empty),
-            nested_comments: Vec::new(),
         });
     }
 
@@ -214,7 +213,6 @@ fn seed_variant(
         // A mapping never carries the root marker: the obligation sits on the
         // discriminant cell inside it.
         fill: false,
-        nested_comments: Vec::new(),
     })
 }
 

--- a/crates/core/src/value.rs
+++ b/crates/core/src/value.rs
@@ -1,38 +1,25 @@
 //! Value type for unified representation of YAML/JSON values.
 
-use indexmap::IndexMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_json::Value as JsonValue;
 use std::ops::Deref;
-use std::sync::OnceLock;
 
-/// Unified value type: an annotated tree of JSON-shaped data where every
-/// node additionally records whether it was tagged `!must_fill`.
+/// Unified value type: JSON-shaped data beside the paths of the nodes tagged
+/// `!must_fill`.
 ///
-/// The tree is authoritative; the data API (`as_json`, `Deref`, …) reads a
-/// lazily materialized, **fill-free** [`serde_json::Value`] projection of it.
-/// Construction leaves `fill = false`; the document layer applies the markers.
-/// No data-mutating method exists (only `set_fill_at`, which the projection
-/// ignores), so the cache never goes stale.
+/// The JSON is the data in full, fill-free, and every reader of it (`as_json`,
+/// `Deref`, `Serialize`, …) hands it out directly. Construction records no
+/// marker; the document layer applies them with
+/// [`set_fill_at`](Self::set_fill_at), which is the only mutator — the data
+/// itself is never edited in place, so a recorded path cannot come to address a
+/// node that has gone.
+///
+/// `fills` is kept sorted and duplicate-free, so equality over it is set
+/// equality and the order a caller marks in is not observable.
+#[derive(Clone, PartialEq)]
 pub struct QuillValue {
-    node: Node,
-    json: OnceLock<JsonValue>,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-struct Node {
-    fill: bool,
-    kind: Kind,
-}
-
-#[derive(Debug, Clone, PartialEq)]
-enum Kind {
-    Null,
-    Bool(bool),
-    Number(serde_json::Number),
-    String(String),
-    Array(Vec<Node>),
-    Object(IndexMap<String, Node>),
+    json: JsonValue,
+    fills: Vec<Vec<PathSegment>>,
 }
 
 /// One step of a path into a value tree: an object key or an array index. The
@@ -42,95 +29,23 @@ enum Kind {
 /// Serializes **untagged** (a key as a JSON string, an index as a JSON number),
 /// so a path crosses the binding wire as a plain JS array like
 /// `["addr", "street"]` or `["recipients", 0, "name"]`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum PathSegment {
     Key(String),
     Index(usize),
 }
 
-fn collect_fill_paths(node: &Node, prefix: &mut Vec<PathSegment>, out: &mut Vec<Vec<PathSegment>>) {
-    if node.fill {
-        out.push(prefix.clone());
-    }
-    match &node.kind {
-        Kind::Array(items) => {
-            for (i, child) in items.iter().enumerate() {
-                prefix.push(PathSegment::Index(i));
-                collect_fill_paths(child, prefix, out);
-                prefix.pop();
-            }
-        }
-        Kind::Object(entries) => {
-            for (k, child) in entries {
-                prefix.push(PathSegment::Key(k.clone()));
-                collect_fill_paths(child, prefix, out);
-                prefix.pop();
-            }
-        }
-        _ => {}
-    }
-}
-
-fn node_at_mut<'a>(node: &'a mut Node, path: &[PathSegment]) -> Option<&'a mut Node> {
-    let mut cur = node;
+fn json_at<'a>(value: &'a JsonValue, path: &[PathSegment]) -> Option<&'a JsonValue> {
+    let mut cur = value;
     for seg in path {
-        cur = match (&mut cur.kind, seg) {
-            (Kind::Object(entries), PathSegment::Key(k)) => entries.get_mut(k)?,
-            (Kind::Array(items), PathSegment::Index(i)) => items.get_mut(*i)?,
+        cur = match (cur, seg) {
+            (JsonValue::Object(map), PathSegment::Key(k)) => map.get(k)?,
+            (JsonValue::Array(items), PathSegment::Index(i)) => items.get(*i)?,
             _ => return None,
         };
     }
     Some(cur)
-}
-
-fn node_is_object(node: &Node, path: &[PathSegment]) -> bool {
-    fn at<'a>(node: &'a Node, path: &[PathSegment]) -> Option<&'a Node> {
-        let mut cur = node;
-        for seg in path {
-            cur = match (&cur.kind, seg) {
-                (Kind::Object(entries), PathSegment::Key(k)) => entries.get(k)?,
-                (Kind::Array(items), PathSegment::Index(i)) => items.get(*i)?,
-                _ => return None,
-            };
-        }
-        Some(cur)
-    }
-    matches!(at(node, path).map(|n| &n.kind), Some(Kind::Object(_)))
-}
-
-impl Node {
-    fn from_json(value: &JsonValue) -> Node {
-        let kind = match value {
-            JsonValue::Null => Kind::Null,
-            JsonValue::Bool(b) => Kind::Bool(*b),
-            JsonValue::Number(n) => Kind::Number(n.clone()),
-            JsonValue::String(s) => Kind::String(s.clone()),
-            JsonValue::Array(items) => Kind::Array(items.iter().map(Node::from_json).collect()),
-            JsonValue::Object(map) => Kind::Object(
-                map.iter()
-                    .map(|(k, v)| (k.clone(), Node::from_json(v)))
-                    .collect(),
-            ),
-        };
-        Node { fill: false, kind }
-    }
-
-    fn to_json(&self) -> JsonValue {
-        match &self.kind {
-            Kind::Null => JsonValue::Null,
-            Kind::Bool(b) => JsonValue::Bool(*b),
-            Kind::Number(n) => JsonValue::Number(n.clone()),
-            Kind::String(s) => JsonValue::String(s.clone()),
-            Kind::Array(items) => JsonValue::Array(items.iter().map(Node::to_json).collect()),
-            Kind::Object(entries) => JsonValue::Object(
-                entries
-                    .iter()
-                    .map(|(k, n)| (k.clone(), n.to_json()))
-                    .collect(),
-            ),
-        }
-    }
 }
 
 /// `true` when a value nests deeper than `max_depth` container levels: the
@@ -165,13 +80,6 @@ pub(crate) fn depth_check_meta_map<E>(
 }
 
 impl QuillValue {
-    fn from_node(node: Node) -> Self {
-        QuillValue {
-            node,
-            json: OnceLock::new(),
-        }
-    }
-
     /// Parse a YAML string under the parser's own budget, so an over-deep
     /// document errors rather than overflowing its stack.
     pub fn from_yaml_str(yaml_str: &str) -> Result<Self, crate::error::YamlError> {
@@ -180,44 +88,35 @@ impl QuillValue {
         Ok(Self::from_json(json_val))
     }
 
-    /// The value's JSON projection, materialized on first use and cached.
-    /// Data only: `!must_fill` markers are not represented in JSON.
+    /// The value's data. `!must_fill` markers are not represented in JSON.
     pub fn as_json(&self) -> &serde_json::Value {
-        self.json.get_or_init(|| self.node.to_json())
+        &self.json
     }
 
     /// Convert into the underlying JSON value, dropping fill markers.
     pub fn into_json(self) -> serde_json::Value {
-        match self.json.into_inner() {
-            Some(json) => json,
-            None => self.node.to_json(),
+        self.json
+    }
+
+    /// Create a QuillValue from a JSON value, carrying no fill marker.
+    pub fn from_json(json_val: serde_json::Value) -> Self {
+        QuillValue {
+            json: json_val,
+            fills: Vec::new(),
         }
     }
 
-    /// Create a QuillValue from a JSON value, with every node `fill = false`.
-    pub fn from_json(json_val: serde_json::Value) -> Self {
-        let node = Node::from_json(&json_val);
-        let json = OnceLock::new();
-        // Seed the projection so the render path doesn't re-lower it, at the
-        // cost of holding the data twice.
-        let _ = json.set(json_val);
-        QuillValue { node, json }
-    }
-
-    /// Whether this value's root node carries the `!must_fill` marker.
+    /// Whether this value's root carries the `!must_fill` marker.
     pub fn fill(&self) -> bool {
-        self.node.fill
+        self.fills.iter().any(Vec::is_empty)
     }
 
     /// Paths (relative to this value's root) of every node carrying the
     /// `!must_fill` marker. The root, if filled, is reported as the empty
-    /// path. The JSON projection carries no fill, so this is the only way to
-    /// observe nested fill markers.
+    /// path. The JSON carries no fill, so this is the only way to observe
+    /// nested fill markers.
     pub fn fill_paths(&self) -> Vec<Vec<PathSegment>> {
-        let mut out = Vec::new();
-        let mut prefix = Vec::new();
-        collect_fill_paths(&self.node, &mut prefix, &mut out);
-        out
+        self.fills.clone()
     }
 
     /// Every [`fill_paths`](Self::fill_paths) entry except the empty (root)
@@ -227,29 +126,30 @@ impl QuillValue {
         self.fill_paths().into_iter().filter(|p| !p.is_empty())
     }
 
-    /// Set `fill = true` on the node at `path` (relative to the root).
-    /// Returns `false` if the path does not resolve to a node.
+    /// Mark the node at `path` (relative to the root) `!must_fill`. Returns
+    /// `false`, recording nothing, if the path does not resolve to a node: a
+    /// marker never outlives what it addresses.
     pub fn set_fill_at(&mut self, path: &[PathSegment]) -> bool {
-        match node_at_mut(&mut self.node, path) {
-            Some(n) => {
-                n.fill = true;
-                true
-            }
-            None => false,
+        if json_at(&self.json, path).is_none() {
+            return false;
         }
+        if let Err(i) = self.fills.binary_search_by(|p| p.as_slice().cmp(path)) {
+            self.fills.insert(i, path.to_vec());
+        }
+        true
     }
 
-    /// Clear `fill` on the root node. A stored field's root marker rides the
-    /// owning [`PayloadItem`](crate::PayloadItem)'s flag, so the tree beneath
-    /// it carries the nested markers alone.
+    /// Clear the root marker. A stored field's root marker rides the owning
+    /// [`PayloadItem`](crate::PayloadItem)'s flag, so the value beneath it
+    /// carries the nested markers alone.
     pub(crate) fn clear_root_fill(&mut self) {
-        self.node.fill = false;
+        self.fills.retain(|p| !p.is_empty());
     }
 
     /// Whether the node at `path` (relative to the root) is a mapping.
     /// Used to reject `!must_fill` on object-valued nodes.
     pub fn is_object_at(&self, path: &[PathSegment]) -> bool {
-        node_is_object(&self.node, path)
+        json_at(&self.json, path).is_some_and(JsonValue::is_object)
     }
 }
 
@@ -280,33 +180,12 @@ impl Deref for QuillValue {
     }
 }
 
-impl PartialEq for QuillValue {
-    /// Two values are equal when their annotated trees (data **and** fill)
-    /// are equal. The cached JSON projection is derived and not compared.
-    fn eq(&self, other: &Self) -> bool {
-        self.node == other.node
-    }
-}
-
-impl Clone for QuillValue {
-    fn clone(&self) -> Self {
-        let json = OnceLock::new();
-        if let Some(cached) = self.json.get() {
-            let _ = json.set(cached.clone());
-        }
-        QuillValue {
-            node: self.node.clone(),
-            json,
-        }
-    }
-}
-
 impl std::fmt::Debug for QuillValue {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.node.fill {
-            write!(f, "QuillValue(!must_fill {:?})", self.as_json())
+        if self.fill() {
+            write!(f, "QuillValue(!must_fill {:?})", self.json)
         } else {
-            write!(f, "QuillValue({:?})", self.as_json())
+            write!(f, "QuillValue({:?})", self.json)
         }
     }
 }
@@ -329,10 +208,20 @@ impl QuillValue {
     /// The scalar reads come from the [`Deref`] target instead, where fill is
     /// not observable anyway.
     pub fn get(&self, key: &str) -> Option<QuillValue> {
-        match &self.node.kind {
-            Kind::Object(entries) => entries.get(key).map(|n| QuillValue::from_node(n.clone())),
-            _ => None,
-        }
+        let child = self.json.as_object()?.get(key)?;
+        let head = PathSegment::Key(key.to_string());
+        Some(QuillValue {
+            json: child.clone(),
+            // Stripping a shared head preserves the sort, so the child's list
+            // is normalized by the parent's being so.
+            fills: self
+                .fills
+                .iter()
+                .filter_map(|p| p.split_first())
+                .filter(|(first, _)| **first == head)
+                .map(|(_, rest)| rest.to_vec())
+                .collect(),
+        })
     }
 }
 
@@ -380,7 +269,7 @@ mod tests {
     }
 
     #[test]
-    fn json_round_trips_through_the_tree() {
+    fn json_round_trips_declaration_order_included() {
         // Identity, object key order (serde_json `preserve_order`) included.
         let original = serde_json::json!({
             "z": 1,
@@ -389,10 +278,7 @@ mod tests {
         });
         let qv = QuillValue::from_json(original.clone());
         assert_eq!(qv.as_json(), &original);
-
-        // Re-lowered from the tree rather than read off the seeded cache.
-        let relowered = QuillValue::from_node(qv.node.clone()).into_json();
-        assert_eq!(relowered, original);
+        assert_eq!(qv.into_json(), original);
     }
 
     #[test]
@@ -443,7 +329,7 @@ mod tests {
     }
 
     #[test]
-    fn fill_marker_rides_on_the_node_not_the_json() {
+    fn fill_marker_rides_beside_the_json_not_in_it() {
         let filled = || {
             let mut qv = QuillValue::from("draft");
             assert!(qv.set_fill_at(&[]));
@@ -454,5 +340,61 @@ mod tests {
         assert_eq!(qv.as_json(), &serde_json::json!("draft"));
         assert_ne!(qv, QuillValue::from("draft"), "equality is fill-sensitive");
         assert_eq!(qv, filled());
+    }
+
+    /// The marking order and repetition a caller happens to use are not
+    /// observable: the same set of markers is the same value.
+    #[test]
+    fn fill_markers_normalize_to_a_set() {
+        let key = |k: &str| vec![PathSegment::Key(k.to_string())];
+        let mark = |order: [&str; 3]| {
+            let mut qv = QuillValue::from_json(serde_json::json!({"a": 1, "b": 2, "c": 3}));
+            for k in order {
+                assert!(qv.set_fill_at(&key(k)));
+            }
+            qv
+        };
+        let forward = mark(["a", "b", "c"]);
+        assert_eq!(forward, mark(["c", "a", "b"]));
+        assert_eq!(forward.fill_paths().len(), 3);
+
+        let mut twice = mark(["a", "b", "c"]);
+        assert!(twice.set_fill_at(&key("a")));
+        assert_eq!(twice, forward, "re-marking a node changes nothing");
+    }
+
+    /// A marker addresses a node or is refused, so the recorded paths always
+    /// resolve against the data beside them.
+    #[test]
+    fn fill_marker_on_an_absent_node_is_refused() {
+        let mut qv = QuillValue::from_json(serde_json::json!({"a": [1]}));
+        assert!(!qv.set_fill_at(&[PathSegment::Key("nope".to_string())]));
+        assert!(!qv.set_fill_at(&[
+            PathSegment::Key("a".to_string()),
+            PathSegment::Index(9),
+        ]));
+        assert!(qv.fill_paths().is_empty());
+    }
+
+    #[test]
+    fn get_carries_the_child_markers_and_drops_its_siblings() {
+        let mut qv = QuillValue::from_json(serde_json::json!({
+            "addr": { "street": "", "city": "" },
+            "name": "",
+        }));
+        let street = vec![
+            PathSegment::Key("addr".to_string()),
+            PathSegment::Key("street".to_string()),
+        ];
+        assert!(qv.set_fill_at(&street));
+        assert!(qv.set_fill_at(&[PathSegment::Key("name".to_string())]));
+
+        let addr = qv.get("addr").expect("addr is a member");
+        assert_eq!(
+            addr.fill_paths(),
+            vec![vec![PathSegment::Key("street".to_string())]],
+            "rebased onto the child, and `name` left behind"
+        );
+        assert!(!addr.fill(), "the child root carries no marker of its own");
     }
 }

--- a/docs/migrations/0.112-to-0.113.md
+++ b/docs/migrations/0.112-to-0.113.md
@@ -17,7 +17,8 @@ implicit `ui.group` becomes a load error, a quill carries the load's warnings
 retires, three CLI flags go, a block-only island takes its own line in the
 model rather than on the way out, fifteen Rust items with no caller leave
 `quillmark-core` and `quillmark-content`, a payload's nested comments move off
-its items and onto the payload, the crate-compatibility ceremony
+its items and onto the payload, a comment indented inside a multi-line plain
+scalar ends it rather than folding away, the crate-compatibility ceremony
 — `#[non_exhaustive]`, the `Backend` seal, public `register_backend` — is
 withdrawn, the pre-session `supportsCanvas` probe is deleted at every layer,
 pdfform drops its SVG and PNG output formats, the `$ext` namespace verbs
@@ -377,6 +378,32 @@ and the Typst backend each carried a copy of.
 **Migrate:** the table's right column is the whole of it. A consumer matching
 exhaustively on `PathStepWire` matches `PathSegment` instead — the same two
 variants, with the same payloads.
+
+## Breaking: a comment inside a multi-line plain scalar ends it
+
+Prescan used to delete comment lines from the YAML it hands the parser. It now
+leaves them in place — they are comments to the parser too — which makes the
+parsed string line-for-line with the fence content. One document shape changes
+verdict:
+
+```yaml
+key: aaa
+  # c
+  bbb
+```
+
+This folded to `key: "aaa bbb"`, a value no YAML parser reads out of that
+document (a comment ends a plain scalar, so `  bbb` is a mapping line with no
+key). It is now a located `parse::yaml_error` anchored at `  bbb`.
+
+Every other comment position is unchanged, block scalars included: a comment
+line **inside** a literal or folded block is the scalar's own text and always
+was, and a comment line **after** one ends it without adding to it — including
+under keep chomping (`|+` / `>+`), where a blank line in that position would
+be content.
+
+**Migrate:** put the comment on its own line at the mapping's indentation, or
+quote the scalar (`key: "aaa bbb"`) if the fold was what you meant.
 
 ## Breaking (Rust): nested comments hang off the payload, not each item
 

--- a/docs/migrations/0.112-to-0.113.md
+++ b/docs/migrations/0.112-to-0.113.md
@@ -16,7 +16,8 @@ implicit `ui.group` becomes a load error, a quill carries the load's warnings
 (and the two loader doors that returned them go), `pdfform::form_schema_version`
 retires, three CLI flags go, a block-only island takes its own line in the
 model rather than on the way out, fifteen Rust items with no caller leave
-`quillmark-core` and `quillmark-content`, the crate-compatibility ceremony
+`quillmark-core` and `quillmark-content`, a payload's nested comments move off
+its items and onto the payload, the crate-compatibility ceremony
 — `#[non_exhaustive]`, the `Backend` seal, public `register_backend` — is
 withdrawn, the pre-session `supportsCanvas` probe is deleted at every layer,
 pdfform drops its SVG and PNG output formats, the `$ext` namespace verbs
@@ -376,6 +377,40 @@ and the Typst backend each carried a copy of.
 **Migrate:** the table's right column is the whole of it. A consumer matching
 exhaustively on `PathStepWire` matches `PathSegment` instead — the same two
 variants, with the same payloads.
+
+## Breaking (Rust): nested comments hang off the payload, not each item
+
+`PayloadItem::Field` and `PayloadItem::Meta` lose their `nested_comments`
+field. The comments inside a structured value now live in one list on the
+`Payload`, at paths whose **head segment names the owning entry** — a field's
+key, or the literal `$ext` / `$seed`:
+
+```rust
+// Before: relative to the item's own value, one Vec per item.
+for item in card.payload().items() {
+    if let PayloadItem::Field { key, nested_comments, .. } = item {
+        for nc in nested_comments { /* nc.container_path is relative to `key` */ }
+    }
+}
+
+// After: one list, each path rooted at the entry that owns it.
+for nc in card.payload().nested_comments() {
+    // nc.container_path[0] is PathSegment::Key(<field key or "$ext"/"$seed">)
+}
+```
+
+This is the shape both ends already spoke — prescan produces it and the storage
+DTO stores it — so the two converters between them are gone. `Payload` gains
+`nested_comments()` for reading, and `rename_field`, which carries a field's
+comments with its key; `items_mut` is withdrawn, having existed only for the
+rename that now has a verb.
+
+**The wire is unchanged.** `PayloadV0_92_0.nested_comments` was already a flat
+payload-level sidecar with absolute paths, so no stored blob moves a byte, and
+nothing on the WASM, Python or CLI surface reads these at all.
+
+**Migrate:** read from `payload.nested_comments()` and match the head segment
+instead of iterating items; rename a field with `payload.rename_field(from, to)`.
 
 ## Breaking (Rust): `register_backend` becomes private, and the `Backend` seal and `#[non_exhaustive]` go
 

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -582,7 +582,7 @@ different bytes for the same document.
 `0.92.0` is a unified payload-item list (typed `$` entries living alongside
 user fields and comments in a single `Vec<PayloadItem>`), a per-field
 `nested_fills` list so `!must_fill` markers nested inside a field value
-survive a storage round-trip (the JSON `value` projection is fill-free), and
+survive a storage round-trip (the JSON `value` itself is fill-free), and
 the `seed` payload-item variant (the `$seed` per-card-kind overlay map).
 `0.93.0` leaves the payload model unchanged and instead embeds the card
 `body` as the **canonical content**: structurally, as a nested object, not a

--- a/prose/canon/ERROR.md
+++ b/prose/canon/ERROR.md
@@ -36,7 +36,7 @@ Two surfaces return one directly (`QuillValue::from_yaml_str`, `QuillConfig::sch
 
 Its `line`/`column` are document coordinates, not block-relative ones:
 
-- The engine reports a position inside the string it parsed: the fence content minus the comment lines prescan drops (`PreScan::source_lines` maps what survives back) and minus the whitespace `trim` takes off the front. The assembler translates that position onto the document.
+- The engine reports a position inside the string it parsed: the fence content, line-for-line (prescan strips `!must_fill` tags but leaves every line standing, comment lines included), minus the whitespace `trim` takes off the front. The assembler translates that position onto the document.
 - `to_diagnostic()` renders it as a `Location` against `DOCUMENT_FILE` (`input.md`). Markdown reaches the engine as a string, so the anchor names the input rather than a path on disk.
 - The message names the block instead of repeating a number (`YAML error in the root card-yaml block: …`, `… in card-yaml block 2: …`). The engine's own snippet inside it stays block-relative, as the engine rendered it.
 


### PR DESCRIPTION
Refs #1697 (ledger rows d-11, d-12, k-03). Three of its four bullets land here; `Enum { values }` (q-12) does not, for the reason below.

Sequenced by value ÷ cost rather than by the issue's order: the `value.rs` cut first (largest win, no public break), then the two that break the Rust API.

## `QuillValue` holds its JSON, not a mirror of it — `cf9c426`

The issue frames this as ~120 lines and "holds the data twice". The stronger fact is that **no consumer wanted the tree**. Every reader asks for one of two things:

| site | asks for |
|---|---|
| `as_json` / `Deref` / `Serialize` | fill-free JSON |
| `emit.rs` → `EmitCtx.fills: &[Vec<PathSegment>]`, `is_fill` linear scan | a path list |
| `dto.rs` / `wire.rs` → `nested_fills` on both wire formats | a path list |
| `seed.rs` → `struct Seeded { value, fills }` | the proposed representation, written by hand |
| `compose.rs`, `edit.rs`, `conform.rs` | a path list |

So the `Node`/`Kind` tree was a private intermediate built from a path list at 5 sites and torn back into one at 6, paid for in deep copies: `from_json` cloned every string and number into `Node` *and* kept the original; `get` cloned a subtree then re-lowered it, two deep copies to read one child; `conform`'s "any fills?" walked the whole tree.

`QuillValue` is now `serde_json::Value` beside a `Vec<Vec<PathSegment>>`. Two node walkers collapse to one `json_at`; `OnceLock`, the hand-written `Clone` and the hand-written `PartialEq` go with them. **Public surface unchanged** — `PathSegment` gains `Ord` for the sort, which is additive.

Two properties the tree gave for free and a path list does not, so they are now explicit and tested:

- **Normalization.** `fills` is kept sorted and duplicate-free through `binary_search`, so equality over it is set equality and a caller's marking order is not observable. Without this, `set_fill_at(p)` twice — or two documents reaching the same fill set by different routes — would compare unequal.
- **No dangling marker.** `set_fill_at` resolves against the JSON and refuses, recording nothing, a path that addresses no node. What makes that sufficient is that `QuillValue` has no data mutator at all: values are rebuilt wholesale, never edited in place. That was true before and is now written down.

## Nested comments hang off the payload, not each item — `f028ee3`

`PayloadItem::Field` / `Meta` lose `nested_comments`; one list on `Payload` carries them, keyed by head path segment.

This is the shape **both ends already spoke**: prescan produces flat absolute paths, and `PayloadV0_92_0.nested_comments` stores them. Only the middle held per-item relative ones, so `from_items_with_flat_nested` and `flat_nested_comments` existed purely to convert in and back out. Both are gone; emit filters by owner where it used to read a field.

Flattening moves an invariant off the type, so the entry verbs take it back rather than leaving it to convention:

- replace, remove and `take_meta` prune through one private `prune_nested`;
- **`items_mut` is withdrawn** for `Payload::rename_field`. Its one caller was `normalize_document`, which renames field keys — flat, that would have silently orphaned every comment inside a renamed field. This was the concrete regression risk in the refactor as filed.

Four tests pin those paths (prune-only-its-own on replace and on remove, rename-carries, rebase-onto-the-entry). `Payload::nested_comments()` is public so `NestedComment` stays reachable from the crate API, as it was through the item fields.

**The wire is unchanged** — no stored blob moves a byte, and nothing on the WASM, Python or CLI surface reads these.

## Prescan's cleaned YAML is line-for-line with its source — `0beb124`

The issue proposes emitting `""` for a dropped comment line. **I did not do that, because a blank line is not a nothing in YAML.** Measured before deciding:

| input | today (drop) | issue's `""` | PyYAML |
|---|---|---|---|
| `body: \|+` / `  text` / `# c` | `"text\n"` | `"text\n\n"` | **`"text\n"`** |
| `body: >+` / `  text` / `# c` | `"text\n"` | `"text\n\n"` | **`"text\n"`** |
| `body: \|` / `  text` / `# c` | `"text\n"` | `"text\n"` | `"text\n"` |

Under keep chomping the blank line is content, so blanking would move the value *away* from spec. The issue's safety argument ("block-scalar lines already pass through untouched") covers a comment *inside* a block scalar; the risk is the comment that **ends** one.

Passing the line through **verbatim** buys the same deletions with none of that drift — it is a comment to the parser too, so the numbering is the source's. Gone: `PreScan::source_lines`, the `Cleaned` pair it rode in, and `document_position`'s fall-back-to-the-last-line lookup. The comment-only fence needed no guard after all: `extract_meta_items` returns empty for a non-object and `build_payload` already treats `Some(Null)` exactly as `None`.

One document shape changes verdict, and it is the reason this commit is marked `!`:

```yaml
key: aaa
  # c
  bbb
```

folded to `"aaa bbb"` — a value no YAML parser reads out of that document, since a comment ends a plain scalar. It is now a located `parse::yaml_error` anchored at `  bbb` (line 6, column 3). PyYAML raises `ParserError` on the same input.

## On the suite, and why the tests came first

Worth stating plainly: **the existing suite passes under the issue's blank-line variant too.** I applied it and ran the full workspace — 0 failures. It also passes under the pass-through variant. The suite could not tell the two behaviors apart, so the prescan commit leads with the tests that pin them: the block scalar that must not move, and the plain scalar that does. That is also why this was not "medium risk" as filed but *unmeasured* risk.

## Not done: `FieldType::Enum { values }`

Declined, and #1697 should be amended rather than left as filed. Its premise — "every consumer keys on the carrier, leaving the token arm as residue" — does not hold:

- **Carrier (`enum_values`):** `fill.rs:27`, `blueprint.rs:458`, `schema.rs:101`, `validation.rs:616,651`, `config.rs:861,1042,1292`, `pdfform/bind.rs:245`.
- **Token, load-bearing:** `validation.rs:464` and `config.rs:441` group `String | Enum` (enum is string-valued — nothing to do with the domain); `reader.rs:282,357` and `config.rs:2026` key on `Enum` + `is_variant_bearing()`; `types.rs:598` is the loader rule itself.

Genuine residue is two arms, both already commented as unreachable. And `FieldType` has a standalone `Deserialize` that parses a bare string, with `FieldSchemaDef.r#type` deserialized before `values` is in hand — so `from_str("enum")` would have to yield `Enum { values: vec[] }`, exactly as `from_str("richtext")` yields `RichText { inline: false }`. The invalid state is not eliminated, it is respelled from `None` to `is_empty()`. Against that: a public break in both `FieldType` and `FieldSchema`, a heap payload on a token type whose `PartialEq` would start comparing domains, and a model that contradicts `schema.rs`'s own JSON-Schema output (`enum` is a constraint on a string, not a type). The cheap version — delete `schema.rs:153` and `blueprint.rs:476`, assert the biconditional once at the loader exit — is available with no break at all.

## Verification

- `cargo test --workspace`: **1438 passed / 0 failed** (+10 new).
- `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --locked --workspace`: clean — the repo's standing lint gate.
- `cargo build -p quillmark-wasm -p quillmark-python -p quillmark-cli`: clean. No binding code is touched; PR CI runs both surfaces.
- `node scripts/check-canon.mjs`: canon spine OK.

## Docs

Both `!` breaks have CHANGELOG entries and sections in `docs/migrations/0.112-to-0.113.md` (plus rows in that guide's summary paragraph). Two canon docs were stale on these changes and are corrected: `ERROR.md` described `PreScan::source_lines` mapping a position back over dropped lines, and `DOCUMENT_STORAGE.md` called the stored JSON a "projection", naming the cache `QuillValue` no longer keeps.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014kSZEXEmPFgTF6DLR4dkRM

---
_Generated by [Claude Code](https://claude.ai/code/session_014kSZEXEmPFgTF6DLR4dkRM)_