### PR TITLE
docs(canon,ci): the crate compatibility position, and the changelog read that catches a stale entry

### DIFF
--- a/.github/workflows/release-prepare.yml
+++ b/.github/workflows/release-prepare.yml
@@ -170,6 +170,13 @@ jobs:
 
           **Before merging:** review and edit the \`v${VERSION}\` section at the top of \`CHANGELOG.md\` on this branch, seeded from the curated \`## Unreleased\` section when one exists (raw commits ride in an HTML comment as a coverage check), else from the raw commit list. The final section becomes the GitHub Release notes.
 
+          Read that section **as a whole against HEAD**, not entry by entry: later commits in a cycle supersede earlier entries, and only the whole read catches one.
+
+          - An entry asserting a symbol's current state must be true at HEAD. \`grep\` each symbol it names.
+          - Naming a deleted symbol is correct when the entry is the one deleting it. The tense separates the two.
+          - The seed comment checks commits against entries, never entries against HEAD.
+          - Each \`!\` entry reconciles against \`docs/migrations/<prev>-to-<next>.md\`, which carries the same break for an upgrading consumer.
+
           Merging this PR will tag and publish the release.
 
           The checks here come from a dispatched \`CI\` run at the branch head: a PR opened by \`GITHUB_TOKEN\` gets no \`pull_request\` run." \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -931,6 +931,18 @@ Upgrade path: [0.112 → 0.113](docs/migrations/0.112-to-0.113.md).
   recipe. The text-type 2×2 table was in `creating-quills.md` and
   `quill-yaml-reference.md`, with the tutorial already linking at the
   reference; the tutorial keeps the two questions that pick a type.
+- docs(canon): **the crate compatibility position, and the third reading of an
+  unknown content name.** `ARCHITECTURE.md` § "Crate Structure" carries what the
+  withdrawn `COMPATIBILITY.md` left unstated: seven crates publish to crates.io
+  and promise no API stability before 1.0. Cargo reads a `0.x` minor bump as a
+  major and the workspace bumps nearly every release, so there is no compatible
+  release for `#[non_exhaustive]`, a sealed `Backend` or a `semver-checks` gate
+  to hold — all three are the 1.0 tag's decisions, and a removal, a rename or a
+  dependency's type in a public signature escapes all three regardless.
+  `ERROR.md`'s YAML boundary rests on that promise. `DOCUMENT_STORAGE.md`
+  § "Content vocabularies" weighed projecting an unknown name and dropping it,
+  and now weighs carrying it opaquely while refusing only to project it: that
+  holds the bytes and costs totality.
 - test(fixtures): **`classic_resume` and `cmu_letter` leave the fixture tree.**
   2.7 MB of the 4.3 MB was their fonts. No test named `cmu_letter`;
   `classic_resume` was named by one three-line gate that also runs on `taro`

--- a/prose/canon/ARCHITECTURE.md
+++ b/prose/canon/ARCHITECTURE.md
@@ -20,6 +20,23 @@ do the heavy compilation.
 
 ## Crate Structure
 
+Seven crates publish to crates.io: `quillmark-core`, `quillmark`,
+`quillmark-content`, `quillmark-pdf`, `quillmark-typst`, `quillmark-pdfform`
+and `quillmark-cli`. The binding, fixture and fuzz crates are `publish = false`:
+they path-depend on the core beside them and ship as one build.
+
+The published crates carry **no API stability promise before 1.0**. The
+workspace bumps its minor on nearly every release, which Cargo reads as a major
+for a `0.x` crate, so an out-of-crate consumer pins an exact version.
+`#[non_exhaustive]`, a sealed `Backend` and a `cargo semver-checks
+check-release` gate each hold a *compatible-release* promise, and a `0.x`
+cadence makes no compatible release: all three are the 1.0 tag's decisions.
+
+Most of what breaks a consumer is outside all three regardless — a removal, a
+rename, an added method on an unsealed trait, a widened bound, and a public
+signature naming a dependency's own type, which chains this crate's major to
+that dependency's ([ERROR.md](ERROR.md) on the YAML boundary).
+
 ### `quillmark-core`
 
 Foundation types and traits: the render contract (`Backend` / `LiveSession`),

--- a/prose/canon/DOCUMENT_STORAGE.md
+++ b/prose/canon/DOCUMENT_STORAGE.md
@@ -215,7 +215,10 @@ decoder, both lanes, so **a row holding one does not open**. Refusing is the
 only reading that keeps the reader honest: projecting an unrecognized `kind` as
 `para` would re-encode the row as `{"kind":"para"}`, moving canonical bytes on a
 read with no edit (§ Byte-stability), and dropping the value loses content on a
-mere open. A malformed discriminator is a different failure and stays
+mere open. Carrying the name opaquely and refusing only to *project* it holds
+the bytes, and costs totality instead: a projection over a container tree is
+total over a `Normalized` body, and a region no projection reads has no defined
+result. A malformed discriminator is a different failure and stays
 `ParseError::Shape`: the closed set answers for names, and a non-string is not a
 name.
 


### PR DESCRIPTION
Two commits out of the #1726 review. Neither changes behaviour; both close a gap in what the repo states about itself.

## `ci(release)`: the changelog review reads the whole section against HEAD

The release PR already asks the merging maintainer to review the version section. Read entry by entry, that misses the class a long cycle produces on its own: a later commit supersedes an earlier entry, which then describes a state the tree no longer holds and ships as the Release notes verbatim. #1727 catalogued 12 such entries and 5 breaks with no entry at all.

The checklist now names the read that catches one.

- An entry asserting a symbol's current state must be true at HEAD.
- Naming a deleted symbol is correct when the entry is the one deleting it; the tense separates the two.
- The seed comment checks commits against entries, never entries against HEAD.
- Each `!` entry reconciles against `docs/migrations/<prev>-to-<next>.md`.

This widens the gate that already existed rather than adding a process. #1727's option (2), a token sweep, stays unbuilt: run against the *repaired* section it reports `getContentAt` (×2), `print_errors`, `non_exhaustive` and `blueprint -o` on the first pass, every one a correct entry. Option (3) stands — the seed comment is the commits→entries check and nothing else does it, though it cannot see the stale class at all, since every superseded entry has a real commit behind it.

Closes #1727.

## `docs(canon)`: the compatibility position, and a third reading of an unknown name

`COMPATIBILITY.md` was withdrawn with the ceremony it described, and its seam table moved to `ARCHITECTURE.md`. The position itself did not move, so nothing stated whether the published crates promise anything — while seven of them still publish to crates.io, and `ERROR.md`'s YAML boundary rests on a crate-major promise no page defined.

`ARCHITECTURE.md` § "Crate Structure" states it: no API stability before 1.0. Cargo reads a `0.x` minor bump as a major and the workspace bumps nearly every release, so no compatible release exists for `#[non_exhaustive]`, a sealed `Backend` or a `semver-checks` gate to hold; all three belong to the 1.0 tag. A removal, a rename, an added method on an unsealed trait, a widened bound and a dependency's type in a public signature escape all three regardless, which is the larger half.

`DOCUMENT_STORAGE.md` § "Content vocabularies" already weighed two readings of a content name outside the closed sets: projecting it moves canonical bytes, dropping it loses content on a mere open. It gains the third, the one #1728 names — carrying it opaquely while refusing only to *project* it holds the bytes and costs totality instead, since a projection over a container tree is total over a `Normalized` body.

Closes #1728. Closes #1729.

## What this branch does not carry

- **#1727's structural decision**, which is recorded on that issue rather than implemented here: `## Unreleased` is a pointer for breaks and a record for everything else. Checking it turned up a prerequisite, now **#1738** — nine of the 35 `!` entries have no section in `docs/migrations/0.112-to-0.113.md`, so trimming blind would delete the only record of nine breaks. #1738 fills the guide; #1686 then trims, re-scoped by the decision (the 35 `!` entries, not all 110, and the seed comment stays).
- **The stored-row scan.** No corpus exists in-repo (`grep -rl '"schema".*quillmark/document@' --include=*.json` returns 0), so the population #1728 flags — a `@0.112.0` row a host authored a vocabulary name into, which stops opening under 0.113 with no tag change and no migration hop — only closes against a host database. A tested `jq` scanner over the five axes is in hand, deliberately not checked in as a one-time pre-release check.
- **#1730** is closed rather than actioned: the dates show every fix predating the entire pruning ledger, so its ordering premise inverts.

## Verification

`scripts/check-canon.mjs` passes. The workflow YAML parses, and the `gh pr create` body string renders with its backtick escapes intact. No Rust changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqvyJA7FRh7qFbub1KSD8K