### PR TITLE
feat(core)!: `---` front matter is CommonMark's, and the message names the fence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,26 @@ Upgrade path: [0.112 → 0.113](docs/migrations/0.112-to-0.113.md).
 
 ### Parsing and the card block
 
+- feat(core)!: **`---` front matter is CommonMark's, and the message names the
+  fence to write instead.** A `---` at document start paired with a later `---`
+  opened the root block. It is a thematic break and a setext underline again,
+  so a document fenced that way has no root block and fails `MissingQuill`. The
+  alias was accept-don't-emit-don't-advertise: no authoring page taught it,
+  `FORMAT_RULES` says the fence is exactly `~~~`, the blueprint emits `~~~`,
+  and `toMarkdown` rewrote a `---`-authored root to `~~~` on first re-emit.
+  What it cost was a rule that only half held — composable cards have no `---`
+  form — and the containment that took: a document-start rule, a matched-fences
+  rule, and a lookahead rejecting a `---` below the root block when a later
+  `---` paired with it over YAML-key-looking content. That lookahead read prose
+  it had no claim on. A thematic break, a paragraph opening `Note:`, and a
+  second break is ordinary markdown, and it was refused outright with a
+  composable-card error. The scanner now reads no `---` at all, so it claims
+  nothing a CommonMark renderer draws, and `missing_block_message` carries what
+  the tolerance was for: a document opening with `---` and declaring `$quill`
+  is told to replace the opening and closing `---` with `~~~`, which is the
+  edit. A `---` document *without* `$quill` keeps the generic message, which
+  names the fence and the key together rather than sending the author back for
+  a second turn. Refs #1698.
 - feat(core)!: **every column-zero `~~~` block is a card, whatever its info
   string.** The opener's info string is no longer read. `~~~card-yaml` and
   `~~~yaml` were accepted aliases and `~~~rust` opened an ordinary code block;

--- a/crates/core/src/document/assemble.rs
+++ b/crates/core/src/document/assemble.rs
@@ -58,6 +58,18 @@ fn missing_block_message(markdown: &str, unclosed_root: Option<&UnclosedRoot>) -
 
     let trimmed = markdown.trim_start();
 
+    if trimmed.starts_with("---")
+        && trimmed
+            .lines()
+            .any(|l| l.trim_start().starts_with("$quill:"))
+    {
+        return "Missing required root card-yaml block. Your document opens with \
+                `---` YAML front matter; card-yaml blocks are fenced with `~~~`. \
+                Replace the opening `---` and its closing `---` with a line \
+                containing exactly `~~~` (three tildes)."
+            .to_string();
+    }
+
     if trimmed.starts_with("$quill:") || trimmed.starts_with("quill:") {
         return "Missing required root card-yaml block. Your document starts with \
                 YAML metadata but is missing the `~~~` fence. Wrap the \

--- a/crates/core/src/document/fences.rs
+++ b/crates/core/src/document/fences.rs
@@ -116,50 +116,6 @@ pub(crate) fn is_card_yaml_opener_line(line: &str) -> bool {
     card_yaml_opener_run(line).is_some()
 }
 
-/// `true` for exactly three dashes at column zero followed only by whitespace.
-///
-/// `---` opens/closes the root block only, never a composable card. Column zero
-/// matches CommonMark's YAML-metadata-block semantics: an indented `---` is a
-/// thematic break.
-fn is_dash_fence_line(line: &str) -> bool {
-    let bytes = line.as_bytes();
-    if bytes.len() < 3 || bytes[0] != b'-' {
-        return false;
-    }
-    let run_len = bytes.iter().take_while(|&&b| b == b'-').count();
-    if run_len != 3 {
-        return false;
-    }
-    line[run_len..].chars().all(|c| c == ' ' || c == '\t')
-}
-
-/// Disambiguates a stray `---` thematic break from a would-be composable card.
-fn looks_like_yaml_key_line(line: &str) -> bool {
-    let trimmed = line.trim_start();
-    if trimmed.is_empty() || trimmed.starts_with('#') {
-        return false;
-    }
-    super::prescan::key_end(trimmed).is_some()
-}
-
-/// A paired `---` block with YAML-key content between the markers, seen after
-/// the root block: almost certainly a misplaced composable card.
-fn has_paired_dash_with_yaml_keys(lines: &Lines<'_>, opener_k: usize) -> bool {
-    let mut saw_yaml_key = false;
-    let mut j = opener_k + 1;
-    while j < lines.len() {
-        let text = lines.line_text(j);
-        if is_dash_fence_line(text) {
-            return saw_yaml_key;
-        }
-        if looks_like_yaml_key_line(text) {
-            saw_yaml_key = true;
-        }
-        j += 1;
-    }
-    false
-}
-
 /// The first line below `opener_k` whose text `closes` accepts as the closer.
 fn closer_below(
     lines: &Lines<'_>,
@@ -293,56 +249,6 @@ pub(super) fn find_metadata_blocks(markdown: &str) -> Result<FenceScan, ParseErr
             )?;
             blocks.push(block);
             k = cj + 1;
-            continue;
-        }
-
-        // `---` is accepted only as the root opener, and only with a `---`
-        // closer. After the root block a paired `---` with YAML keys between is
-        // rejected as a misplaced composable card; anything else falls through
-        // to CommonMark as a thematic break / setext underline.
-        if is_dash_fence_line(text) {
-            let blank_above = k == 0 || lines.is_blank(k - 1);
-
-            if blocks.is_empty() && blank_above {
-                // Document-start only: requiring every line above to be blank
-                // keeps this from racing setext headings and thematic breaks
-                // deeper in a prose preamble.
-                let above_all_blank = (0..k).all(|i| lines.is_blank(i));
-                if above_all_blank {
-                    let Some(cj) = closer_below(&lines, k, is_dash_fence_line) else {
-                        // Per CommonMark a lone leading `---` is a thematic
-                        // break, not frontmatter: no root block, so the document
-                        // surfaces MissingQuill downstream.
-                        k += 1;
-                        continue;
-                    };
-
-                    let block = super::assemble::build_block(
-                        markdown,
-                        lines.line_start(k),
-                        lines.line_end_inclusive(k),
-                        lines.line_start(cj),
-                        lines.line_end_inclusive(cj),
-                        blocks.len(),
-                    )?;
-                    blocks.push(block);
-                    k = cj + 1;
-                    continue;
-                }
-            }
-
-            if !blocks.is_empty() && blank_above && has_paired_dash_with_yaml_keys(&lines, k) {
-                return Err(ParseError::InvalidStructure(
-                    "Composable card block opened with `---` but composable cards \
-                     must use `~~~` fences. Replace the opening `---` and the \
-                     closing `---` with `~~~` (three tildes). The \
-                     `---` style is accepted only for the document's root block."
-                        .to_string(),
-                ));
-            }
-
-            // A lone `---` is CommonMark's, and never a code-fence opener.
-            k += 1;
             continue;
         }
 

--- a/crates/core/src/document/tests/assemble_tests.rs
+++ b/crates/core/src/document/tests/assemble_tests.rs
@@ -55,15 +55,27 @@ fn test_body_prose_inside_the_block_is_told_to_close_the_block() {
     assert!(!hint.contains("block scalar"), "got: {hint}");
 }
 
+/// `---` front matter declaring `$quill` is one fence away from a root block,
+/// so the message names that edit.
 #[test]
-fn test_root_dash_frontmatter_without_quill_reports_missing_quill() {
+fn test_dash_frontmatter_with_quill_names_the_fence_edit() {
+    let err = decompose("---\n$quill: usaf_memo\n$kind: main\ntitle: Memo\n---\n\nBody\n")
+        .unwrap_err();
+    let msg = err.to_string();
+    assert!(msg.contains("Replace the opening `---`"), "got: {msg}");
+    assert!(msg.contains("~~~"), "got: {msg}");
+}
+
+/// Without `$quill` the document needs both edits, so the generic shape — which
+/// names the fence *and* the key — beats the fence-only hint.
+#[test]
+fn test_dash_frontmatter_without_quill_reports_the_generic_shape() {
     let err = decompose("---\nquill: usaf_memo\ntitle: Memo\n---\n\nBody\n").unwrap_err();
     let msg = err.to_string();
-    assert!(msg.contains("must declare `$quill: <name>`"), "got: {msg}");
-    assert!(!msg.contains("`---` YAML frontmatter"), "stale hint: {msg}");
+    assert!(msg.contains("$quill: <name>"), "got: {msg}");
     assert!(
         !msg.contains("Replace the opening `---`"),
-        "stale hint: {msg}"
+        "fence-only hint under-reports the missing key: {msg}"
     );
 }
 
@@ -138,64 +150,26 @@ fn test_root_opener_with_foreign_info_string_parses_as_the_bare_form() {
     assert_eq!(foreign_doc, bare_doc);
 }
 
+/// Every `---` below the root block is CommonMark's, whatever it encloses: a
+/// would-be card stays in the body, and paired breaks around a `Word:`
+/// paragraph are prose the parser neither claims nor refuses.
 #[test]
-fn test_dash_root_block_parses_equivalent_to_card_yaml() {
-    let dash_md = "---\n$quill: test_quill\n$kind: main\ntitle: Test\n---\n\nBody.";
-    let canonical_md = "~~~card-yaml\n$quill: test_quill\n$kind: main\ntitle: Test\n~~~\n\nBody.";
-    let dash_doc = decompose(dash_md).expect("--- root block should parse");
-    let canonical_doc = decompose(canonical_md).expect("canonical root block parses");
-    assert_eq!(dash_doc, canonical_doc);
-    assert_eq!(dash_doc.quill_reference().name, "test_quill");
-    assert_eq!(
-        dash_doc
-            .main()
-            .payload()
-            .get("title")
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "Test"
-    );
-    assert_eq!(dash_doc.main().body_markdown(), "Body.");
-}
-
-#[test]
-fn test_dash_root_block_emits_canonical_card_yaml() {
-    let dash_md = "---\n$quill: test_quill\n$kind: main\ntitle: Test\n---\n\nBody.";
-    let doc = decompose(dash_md).unwrap();
-    let emitted = doc.to_markdown();
+fn test_dash_blocks_below_the_root_are_body_prose() {
+    let as_card = "~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\nBody.\n\n\
+                   ---\n$kind: note\nlabel: a\n---\n\nNote body.";
+    let doc = decompose(as_card).expect("a `---` below the root block is CommonMark's");
+    assert!(doc.cards().is_empty(), "no card opens on `---`");
     assert!(
-        emitted.starts_with("~~~\n"),
-        "expected canonical opener, got: {emitted:?}"
+        doc.main().body_markdown().contains("$kind: note"),
+        "the would-be card stays in the body: {:?}",
+        doc.main().body_markdown()
     );
-    assert!(
-        !emitted.contains("---\n"),
-        "stray dash fence in emit: {emitted:?}"
-    );
-}
 
-#[test]
-fn test_dash_root_with_composable_card_yaml_parses() {
-    let markdown = "---\n$quill: test_quill\n$kind: main\ntitle: Test\n---\n\nBody.\n\n\
-                    ~~~card-yaml\n$kind: note\nlabel: a\n~~~\n\nNote body.";
-    let doc = decompose(markdown).expect("mixed shape should parse");
-    assert_eq!(doc.quill_reference().name, "test_quill");
-    assert_eq!(doc.cards().len(), 1);
-    assert_eq!(doc.cards()[0].kind(), Some("note"));
-    assert_eq!(doc.cards()[0].body_markdown(), "Note body.");
-}
-
-#[test]
-fn test_dash_opener_in_composable_card_position_errors() {
-    let markdown = "~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\nBody.\n\n\
-                    ---\n$kind: note\nlabel: a\n---\n\nNote body.";
-    let err = decompose(markdown).unwrap_err();
-    let msg = err.to_string();
-    assert!(
-        msg.contains("composable cards") || msg.contains("Composable card"),
-        "expected composable-card rejection, got: {msg}"
-    );
-    assert!(msg.contains("~~~"), "got: {msg}");
+    let as_prose = "~~~card-yaml\n$quill: test_quill\n$kind: main\n~~~\n\nBody.\n\n\
+                    ---\n\nNote: the second break closes nothing.\n\n---\n\nMore body.";
+    let doc = decompose(as_prose).expect("thematic breaks are CommonMark's");
+    assert!(doc.cards().is_empty());
+    assert!(doc.main().body_markdown().contains("Note: the second break"));
 }
 
 #[test]

--- a/crates/core/src/document/tests/card_fence_tests.rs
+++ b/crates/core/src/document/tests/card_fence_tests.rs
@@ -105,18 +105,6 @@ fn backtick_yaml_fence_stays_an_ordinary_code_block() {
 }
 
 #[test]
-fn dash_yaml_line_is_not_a_fence() {
-    let src = "~~~\n$quill: q\n$kind: main\n~~~\n\n---yaml\nkey: value\n---\n";
-    let doc = Document::parse(src).unwrap().document;
-    assert_eq!(doc.cards().len(), 0);
-    assert!(
-        doc.main().body_markdown().contains("---yaml"),
-        "body: {:?}",
-        doc.main().body_markdown()
-    );
-}
-
-#[test]
 fn longer_tilde_run_still_opens_a_card() {
     let src = "~~~\n$quill: q\n$kind: main\n~~~\n\n~~~~\n$kind: note\nname: Widget\n~~~~\n";
     let doc = Document::parse(src).unwrap().document;

--- a/crates/core/src/document/tests/fence_conformance_tests.rs
+++ b/crates/core/src/document/tests/fence_conformance_tests.rs
@@ -92,14 +92,6 @@ fn scanner_agrees_with_commonmark_on_synthetic_inputs() {
             "~~~\n$quill: q\n$kind: main\n~~~\n\n~~~\n$kind: a\n~~~\n\nfirst\n\n~~~\n$kind: b\n~~~\n\nsecond\n",
         ),
         (
-            "--- root alias",
-            "---\n$quill: q\n$kind: main\n---\n\nBody.\n",
-        ),
-        (
-            "--- root then bare card",
-            "---\n$quill: q\n$kind: main\n---\n\nBody.\n\n~~~\n$kind: note\nx: 1\n~~~\n",
-        ),
-        (
             "shielded fences inside a backtick block",
             "~~~\n$quill: q\n$kind: main\n~~~\n\n```text\n~~~\n$kind: nope\n~~~\n```\n\nBody.\n",
         ),

--- a/docs/migrations/0.112-to-0.113.md
+++ b/docs/migrations/0.112-to-0.113.md
@@ -7,8 +7,11 @@ about rows already written — so it leads the sections below.
 
 **Every column-zero `~~~` block is a card**, whatever its info string. A
 `~~~rust` fence in a document body opened an ordinary code block and now opens
-a card. This is the other break a type checker cannot see, and it is about
-documents already written, so it follows immediately.
+a card. And **`---` front matter no longer opens the root block**: `---` is
+CommonMark's at every position, so a document fenced that way fails with
+`MissingQuill` naming the `~~~` to write instead. These are the other two
+breaks a type checker cannot see, and both are about documents already
+written, so they follow immediately.
 
 Four more changes. `reader.get` **answers in the values form**: a field whose content
 sits inside an array or an object reads as text rather than as stored content
@@ -203,6 +206,44 @@ renamed) rather than a `String`, and `Loss` is the enum `Fidelity` was, so
 name }`, and `LineKind::tag` / `Container::tag` / `MarkKind::tag` return
 `&'static str`. An exhaustive `match` on any of these is a compile error, which
 the `#[non_exhaustive]` withdrawal below makes loud.
+
+## Breaking: `---` front matter no longer opens the root block
+
+A `---` at document start, paired with a later `---`, was accepted as a root
+block. It is not read as a fence any more: `---` is CommonMark's everywhere in
+a document, a thematic break or a setext-heading underline. A document fenced
+that way now fails with `MissingQuill`.
+
+This is a fact about documents already written, which no type checker reaches.
+The alias was never emitted (`toMarkdown` always wrote `~~~`) and never
+documented, so it can only appear in hand- or LLM-authored markdown that has
+not been through a round-trip.
+
+| A document opening with | 0.112 | 0.113 |
+|---|---|---|
+| `~~~` … `~~~` | root block | root block |
+| `---` … `---`, declaring `$quill` | root block | `MissingQuill`, naming the fence edit |
+| `---` … `---`, no `$quill` | `MissingQuill` | `MissingQuill` |
+| a `---` below the root block | composable-card error, or a break | always a break |
+
+**Migrate:** replace the opening and closing `---` of the root block with a
+line containing exactly `~~~`. The error message says so when the block
+declares `$quill`:
+
+```
+Missing required root card-yaml block. Your document opens with `---` YAML
+front matter; card-yaml blocks are fenced with `~~~`. Replace the opening
+`---` and its closing `---` with a line containing exactly `~~~` (three
+tildes).
+```
+
+Grep a corpus for `^---$` on line 1 to find them. Re-emitting each document
+through `toMarkdown` before upgrading also does it, since that already wrote
+the canonical `~~~`.
+
+One document *gains* a parse: a body holding two thematic breaks with a
+paragraph starting `Word:` between them — `---`, `Note: …`, `---` — was
+refused as a misplaced composable card, and is prose again.
 
 ## Breaking: every column-zero `~~~` block is a card, whatever its info string
 

--- a/prose/references/markdown-spec.md
+++ b/prose/references/markdown-spec.md
@@ -15,10 +15,7 @@ Every valid CommonMark 0.31.2 document parses to the same block / inline
 structure under this spec, *except* for the deviations declared in §6.2
 (raw HTML), §3.2 (a column-zero `~~~` block with a blank line above it is a
 card-yaml block, not an ordinary fenced code block, whatever its info string;
-an indented `~~~` is not a card-yaml opener), and §3.2.1
-(root-block `---` alias: a `---` at document start followed by a matching
-`---` is interpreted as a YAML-frontmatter root block, not a thematic
-break / setext underline). Additionally, this spec defines:
+an indented `~~~` is not a card-yaml opener). Additionally, this spec defines:
 
 - **Structured data**: card-yaml blocks (§3).
 - **Extensions**: strikethrough, pipe tables, and `<u>` for underline
@@ -94,8 +91,7 @@ the next opening fence or EOF.
   fence is exactly three tildes (`~~~`), and `toMarkdown` (§9) always emits
   three. An opener of four or more tildes is accepted (non-canonical) and
   re-emits as `~~~`; its closing fence must be at least as long as the opener,
-  per CommonMark's fenced-code-block rule. (Exception: the root-block `---`
-  alias in §3.2.1.)
+  per CommonMark's fenced-code-block rule.
 - **Info string.** The info string is **not read**. A card-yaml opener is any
   `~~~` satisfying the rules below, whether it is bare, `~~~card-yaml`,
   `~~~yaml`, or `~~~rust`. The canonical form carries no info string, and
@@ -124,33 +120,17 @@ the next opening fence or EOF.
   document. A `~~~` line without a blank line above it is **not** a card-yaml
   opener: it is treated as an ordinary CommonMark fenced code block.
 
-### 3.2.1 Root-Block `---` Alias
+### 3.2.1 `---` Is CommonMark's
 
-The **root block only** may open with `---` and close with `---` instead of
-`~~~` / `~~~`. A `---`-fenced root parses identically to a `~~~`-fenced root
-with the same payload.
+A card-yaml block is fenced with `~~~`, at every position. A `---` line is
+CommonMark's throughout — a thematic break or a setext-heading underline —
+so a document opening with `---` front matter has no root block and fails
+with `MissingQuill` (§10), whose message names the fence to write instead.
 
-- **Accept, don't emit, don't advertise.** Parsers accept the `---` form so
-  that LLMs trained on broader-internet YAML-frontmatter conventions are
-  not penalised on a stylistic mismatch. `toMarkdown` (§9) always emits the
-  canonical bare `~~~` shape; a `---`-authored document round-trips to the
-  canonical form on first re-emit. Authoring surfaces (blueprints,
-  FORMAT_RULES, examples) document only the canonical form.
-- **Root only.** A `---` opener is recognised only when every line above
-  it is blank (i.e. document start, modulo leading blank lines) and no
-  prior block has been parsed. Any other `---` line is delegated to
-  CommonMark as a thematic break or setext-heading underline.
-- **Matched fences.** Within a single block, opener and closer must agree:
-  a `---` opener requires a `---` closer, and a `~~~` opener requires a
-  `~~~` closer. Mixed forms (`---` … `~~~`, `~~~` … `---`) leave the opener
-  unclosed, so it falls through to CommonMark
-  (code block to EOF, or a thematic break for a lone `---`) rather than being
-  recognised as a block.
-- **Composable position.** A `---` line after the root block: when it
-  pairs with a later `---` and has YAML-key content between: is a
-  misplaced composable card and is rejected with a diagnostic that names
-  the canonical `~~~` replacement (§10). Composable cards have no `---`
-  alias.
+`---` front matter is what broader-internet YAML conventions train an author
+(or an LLM) to reach for, so the miss is worth one specific diagnostic rather
+than a parse rule: a tolerance would be root-only, since composable cards can
+have no `---` form, and half a rule is harder to learn than none.
 
 ### 3.3 System Metadata (`$`)
 
@@ -301,14 +281,6 @@ A `~~~` line that fails D0 (an indented opener) or D1 is **not** a card-yaml
 opener; it is delegated to CommonMark, where an indented `~~~` is still a
 valid fenced code block.
 
-A `---` line opens the **root block** instead **iff** all of the following
-hold (see §3.2.1):
-
-**R1: Document start.** No prior block has been parsed and every line above
-the `---` line is blank.
-
-**R2: Closing `---`.** A matching `---` line appears later in the document.
-
 YAML content between recognised fence markers is opaque to detection: a
 `~~~` line inside an open block is part of that block's payload, not a new
 opener (though the canonical payload never produces such a line). In
@@ -316,15 +288,12 @@ particular, an *indented* `~~~` inside the payload; e.g. a tilde code fence
 embedded in a `|` block-scalar value: is payload by the column-zero closer
 rule (D2). A *column-zero* `~~~` can never be block-scalar content (YAML
 requires scalar content to be indented past its key), so the closer is
-unambiguous. The same opacity applies to `---` lines inside an open
-`---`-fenced root block.
+unambiguous.
 
 Failure of D0, D1, or D2 delegates the `~~~` line to CommonMark (an unclosed
 `~~~` opener becomes a code block to EOF, with a non-fatal unclosed-fence
 warning). A document with no closed root block fails with `MissingQuill`
-(§10). A `---` that fails R1 falls through to CommonMark unless it forms a
-paired block with YAML content, which is rejected as a misplaced composable
-card (§10).
+(§10).
 
 ### 4.1 Worked Example
 
@@ -480,8 +449,8 @@ order), and a `~~~` closer. The root block must declare `$quill`;
 canonical emission also writes `$kind: main` on the root, synthesising
 it when the input omitted the line (see §3.3). Composable cards must
 declare `$kind: <kind>`. A document round-trips to this canonical
-shape: fence markers and YAML quoting are normalised; an opener's info string
-and the `---`-fenced root alias (§3.2.1) both re-emit as bare `~~~`.
+shape: fence markers and YAML quoting are normalised, and an opener's info
+string re-emits as bare `~~~`.
 `!must_fill` tags and YAML comments
 (own-line and inline, including those adjacent to `$` lines) survive the
 round-trip.
@@ -526,15 +495,14 @@ or compare for equality.
 Parse errors include:
 
 - The document has no recognised root block (`MissingQuill`). This covers an
-  unclosed root fence: an unclosed `~~~` opener or a `---` opener with no
-  matching `---` closer is delegated to CommonMark (§4) rather than erroring
-  on its own, but with no closed root block the document still fails here.
-  When the document *does* open with a `~~~` declaring `$quill`, the message
-  names that opener's line and the missing closer (and the failed closer
-  line, for a `~~` run or an indented `~~~`) rather than the generic shape.
-- A `---` line in composable position (after the root block) that pairs
-  with a later `---` and holds YAML-key content between: composable
-  cards must use `~~~` fences (§3.2.1).
+  unclosed root fence: an unclosed `~~~` opener is delegated to CommonMark
+  (§4) rather than erroring on its own, but with no closed root block the
+  document still fails here. When the document *does* open with a `~~~`
+  declaring `$quill`, the message names that opener's line and the missing
+  closer (and the failed closer line, for a `~~` run or an indented `~~~`)
+  rather than the generic shape. When it opens with `---` front matter
+  declaring `$quill`, the message names the `~~~` fence to write instead
+  (§3.2.1).
 - The root block missing its `$quill` entry.
 - The root block declaring a non-`main` `$kind` (an omitted `$kind` on
   the root is accepted and synthesised; only an explicit non-`main`


### PR DESCRIPTION
Cuts the `---` root-block alias — the first of the seven rows in #1698 that is still live after 34bf2bd took the `~~~card-yaml` half.

## What changes

A `---` at document start paired with a later `---` opened the root block. It is a thematic break and a setext underline again, so a document fenced that way has no root block and fails `MissingQuill`.

`missing_block_message` carries what the tolerance was for: a document opening with `---` and declaring `$quill` is told to replace the opening and closing `---` with `~~~`, which is the edit. A `---` document without `$quill` keeps the generic message, which names the fence and the key together rather than sending the author back for a second turn.

## Why cut rather than keep

The alias was accept-don't-emit-don't-advertise: no authoring page taught it, `FORMAT_RULES` says the fence is exactly `~~~`, the blueprint emits `~~~`, and `toMarkdown` rewrote a `---`-authored root to `~~~` on first re-emit. What it cost was a rule that only half held — composable cards have no `---` form — and the containment that took: a document-start rule, a matched-fences rule, and a lookahead rejecting a `---` below the root block when a later `---` paired with it over YAML-key-looking content.

**That lookahead read prose it had no claim on.** A thematic break, a paragraph opening `Note:`, and a second break is ordinary markdown, and it was refused outright:

```
~~~
$quill: q
$kind: main
~~~

Body.

---

Note: this paragraph starts with a word and a colon.

---

More body.
```

→ `Composable card block opened with '---' but composable cards must use '~~~' fences.`

A `Word:` opener is all `looks_like_yaml_key_line` needed, so any prose paragraph shaped that way between two thematic breaks lost the whole document. That case is a test in this PR, and it is the one document that *gains* a parse here.

The scanner reads no `---` at all now, so it claims nothing a CommonMark renderer draws — the spec moves one declared deviation closer to CommonMark rather than further away.

## Tests

- `test_dash_frontmatter_with_quill_names_the_fence_edit` — the new hint.
- `test_dash_frontmatter_without_quill_reports_the_generic_shape` — the fence-only hint does not under-report a missing `$quill`.
- `test_dash_blocks_below_the_root_are_body_prose` — a would-be `---` card stays in the body, and paired breaks around a `Word:` paragraph parse.
- The two `fence_conformance_tests` dash cases go: the cross-check is one-directional (⊆), so a document the scanner finds no block in passes vacuously.
- `dash_yaml_line_is_not_a_fence` goes: with no dash handling left it restates the absence of code.

## Breaking

Yes. A document that parsed stops parsing (`MissingQuill`). Stored documents are unaffected — the DTO carries no fences — so this reaches only markdown that was hand- or LLM-authored and never round-tripped. Recorded in `CHANGELOG.md` and in a section of `docs/migrations/0.112-to-0.113.md` with the before/after table and the grep to find affected documents.

## Checks

`cargo test --workspace`, `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`, and `node scripts/check-canon.mjs` all pass. No binding code touched — no WASM, Python, or CLI source or test contains a `---` document.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLYYzuG5znPb3MroBsobaD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLYYzuG5znPb3MroBsobaD)_