### PR TITLE
fix(typst)!: a vendored package without `typst.toml` is skipped, with a warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 ## Unreleased
 
+- fix(typst)!: **a vendored package without `typst.toml` is skipped, with the
+  warning its siblings already get.** A `packages/<dir>/` carrying no manifest
+  had one synthesized — `@local/<dir>:0.1.0` — and loaded under it. That spelling
+  was undocumented, unfixtured and untested, and it split one package tree into
+  two behaviors: the synthesized path passed no entrypoint, so it alone skipped
+  the `typst::package_entrypoint_missing` check that the same files with a
+  two-line manifest get. A manifest-less directory now warns under
+  `typst::package_manifest`, the code its malformed-manifest and bad-version
+  siblings already carry, and is skipped. The migration is the file the fallback
+  was standing in for: `parse_package_toml` defaults `namespace` to `local`,
+  `version` to `0.1.0` and `entrypoint` to `lib.typ`, so `[package]` plus
+  `name = "<dir>"` reproduces the old spec exactly. `package_spec` and
+  `entrypoint` stop being `Option` on `load_package_files_from_quill`, whose two
+  call sites always passed one, and the infallible `"0.1.0".parse()` dressed as
+  fallible goes with them. Refs #1698.
+
 Upgrade path: [0.112 → 0.113](docs/migrations/0.112-to-0.113.md).
 
 ### The content model

--- a/crates/backends/typst/src/world.rs
+++ b/crates/backends/typst/src/world.rs
@@ -300,8 +300,8 @@ impl QuillWorld {
                             &package_dir,
                             sources,
                             binaries,
-                            Some(spec),
-                            Some(&package_info.entrypoint),
+                            spec,
+                            &package_info.entrypoint,
                             warnings,
                         )?;
                     }
@@ -322,22 +322,16 @@ impl QuillWorld {
                     }
                 }
             } else {
-                // A package directory with no typst.toml.
-                let spec = PackageSpec {
-                    namespace: "local".into(),
-                    name: package_name.into(),
-                    version: "0.1.0".parse().map_err(|_| "Invalid version format")?,
-                };
-
-                Self::load_package_files_from_quill(
-                    source,
-                    &package_dir,
-                    sources,
-                    binaries,
-                    Some(spec),
-                    None,
-                    warnings,
-                )?;
+                warnings.push(
+                    Diagnostic::new(
+                        Severity::Warning,
+                        format!(
+                            "Skipping package '{package_name}': it has no typst.toml. Add one \
+                             declaring `[package]` with `name`, `version` and `entrypoint`."
+                        ),
+                    )
+                    .with_code("typst::package_manifest".to_string()),
+                );
             }
         }
 
@@ -349,8 +343,8 @@ impl QuillWorld {
         package_dir: &Path,
         sources: &mut HashMap<FileId, Source>,
         binaries: &mut HashMap<FileId, Bytes>,
-        package_spec: Option<PackageSpec>,
-        entrypoint: Option<&str>,
+        package_spec: PackageSpec,
+        entrypoint: &str,
         warnings: &mut Vec<Diagnostic>,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         let package_pattern = format!("{}/*", package_dir.to_string_lossy());
@@ -370,7 +364,7 @@ impl QuillWorld {
                         continue;
                     }
                 };
-                let id = file_id(package_spec.clone(), virtual_path);
+                let id = file_id(Some(package_spec.clone()), virtual_path);
 
                 if let Some(ext) = file_path.extension() {
                     if ext == "typ" {
@@ -386,29 +380,26 @@ impl QuillWorld {
             }
         }
 
-        if let (Some(spec), Some(entrypoint_name)) = (&package_spec, entrypoint) {
-            let entrypoint_path = match VirtualPath::new(entrypoint_name) {
-                Ok(vpath) => vpath,
-                Err(e) => {
-                    warnings.push(skipped_path(Path::new(entrypoint_name), e));
-                    return Ok(());
-                }
-            };
-            let entrypoint_file_id = file_id(Some(spec.clone()), entrypoint_path);
-
-            if !sources.contains_key(&entrypoint_file_id) {
-                warnings.push(
-                    Diagnostic::new(
-                        Severity::Warning,
-                        format!(
-                            "Package '{}' declares entrypoint '{entrypoint_name}', which it does \
-                             not ship",
-                            spec.name
-                        ),
-                    )
-                    .with_code("typst::package_entrypoint_missing".to_string()),
-                );
+        let entrypoint_path = match VirtualPath::new(entrypoint) {
+            Ok(vpath) => vpath,
+            Err(e) => {
+                warnings.push(skipped_path(Path::new(entrypoint), e));
+                return Ok(());
             }
+        };
+        let entrypoint_file_id = file_id(Some(package_spec.clone()), entrypoint_path);
+
+        if !sources.contains_key(&entrypoint_file_id) {
+            warnings.push(
+                Diagnostic::new(
+                    Severity::Warning,
+                    format!(
+                        "Package '{}' declares entrypoint '{entrypoint}', which it does not ship",
+                        package_spec.name
+                    ),
+                )
+                .with_code("typst::package_entrypoint_missing".to_string()),
+            );
         }
 
         Ok(())
@@ -617,6 +608,23 @@ name = "minimal-package"
         assert!(
             warning.message.contains("brokenpkg"),
             "warning must name the package: {}",
+            warning.message
+        );
+    }
+
+    #[test]
+    fn a_package_without_a_manifest_is_skipped_with_a_warning() {
+        let quill = quill_with(&[("packages/bare/lib.typ", "#let x = 1\n")]);
+        let world = QuillWorld::new(&quill, "// probe").expect("world builds anyway");
+
+        let warning = world
+            .load_warnings()
+            .iter()
+            .find(|d| d.code.as_deref() == Some("typst::package_manifest"))
+            .expect("a manifest-less package warns");
+        assert!(
+            warning.message.contains("bare") && warning.message.contains("typst.toml"),
+            "the warning names the package and the file it wants: {}",
             warning.message
         );
     }

--- a/docs/migrations/0.112-to-0.113.md
+++ b/docs/migrations/0.112-to-0.113.md
@@ -24,7 +24,8 @@ A **pruning sweep** lands alongside them, each break listed in its own section
 below: five retired `Quill.yaml` keys lose their tailored migration message, an
 implicit `ui.group` becomes a load error, a quill carries the load's warnings
 (and the two loader doors that returned them go), `pdfform::form_schema_version`
-retires, three CLI flags go, a block-only island takes its own line in the
+retires, a vendored Typst package without `typst.toml` is skipped rather than
+given a synthesized spec, three CLI flags go, a block-only island takes its own line in the
 model rather than on the way out, fifteen Rust items with no caller leave
 `quillmark-core` and `quillmark-content`, a payload's nested comments move off
 its items and onto the payload, a comment indented inside a multi-line plain
@@ -410,6 +411,33 @@ tuple destructuring becomes one binding. A host that never wanted the warnings
 changes nothing. The channel's output is `quill::implicit_group` (an error from
 this release, so no longer seen here) and `quill::body_example_unused`, and any
 advisory added later arrives the same way.
+
+## Breaking: a vendored Typst package needs its `typst.toml`
+
+A `packages/<dir>/` inside a quill with no `typst.toml` was loaded under a
+synthesized `@local/<dir>:0.1.0`. It is skipped now, with a
+`typst::package_manifest` warning naming the directory — the same code the
+malformed-manifest and bad-version cases already raise.
+
+The synthesized spelling was never documented, so a quill relying on it was
+relying on read source. It also behaved differently from an identical package
+*with* a manifest: passing no entrypoint, it skipped the
+`typst::package_entrypoint_missing` check.
+
+**Migrate:** add the file the fallback stood in for. The manifest parser
+defaults `namespace` to `local`, `version` to `0.1.0` and `entrypoint` to
+`lib.typ`, so this reproduces the old spec byte for byte:
+
+```toml
+# packages/<dir>/typst.toml
+[package]
+name = "<dir>"
+```
+
+Spell out `version` and `entrypoint` too if the package ships something other
+than a `lib.typ` at `0.1.0`. Without the file, the plate's
+`#import "@local/<dir>:0.1.0"` fails as an unresolved file, and the load
+warning above says why.
 
 ## Breaking: `pdfform::form_schema_version` retires
 

--- a/docs/quills/typst-backend.md
+++ b/docs/quills/typst-backend.md
@@ -98,6 +98,20 @@ typst:
 
 Browse the full catalog at [Typst Universe](https://typst.app/universe/).
 
+A package vendored into the quill under `packages/<dir>/` carries its own
+`typst.toml`, which names the spec the plate imports:
+
+```toml
+[package]
+name = "my-helper"
+version = "0.1.0"
+entrypoint = "lib.typ"
+```
+
+A `packages/<dir>/` without one is skipped at load with a
+`typst::package_manifest` warning, and the plate's `#import` for it then fails
+as an unresolved file.
+
 ## Fonts
 
 A Quill carries its own fonts. The backend loads every `.ttf` and `.otf` under `assets/fonts/` and inside vendored `packages/`, an asset font winning a family a package also ships. A Quill bundling none renders in the embedded Figtree faces. The host's installed fonts are not among them, so `#set text(font: "Arial")` names a family the compile cannot find.


### PR DESCRIPTION
The `typst.toml` fallback row from #1698.

## What changes

A `packages/<dir>/` inside a quill carrying no manifest had one synthesized — `@local/<dir>:0.1.0` — and loaded under it. It is skipped now, with a `typst::package_manifest` warning naming the directory.

## Why reshape rather than plain-cut

The issue proposes deleting the fallback. Deleting it silently would leave a package directory loading nothing with no explanation, so the deletion is paired with the diagnostic its siblings already raise — the same `typst::package_manifest` code the malformed-manifest (`world.rs:316`) and bad-version (`world.rs:287`) branches use. Skip plus warning is what the neighbouring code already does for "this directory claims to be a package and isn't one".

The fallback was also **incoherent**, which is the part the issue does not mention: it passed `entrypoint: None`, so a manifest-less package skipped the `typst::package_entrypoint_missing` check that the *same files* with a two-line manifest get. One package tree, two behaviors, decided by a file's absence.

And it was cheap to lose: `parse_package_toml` defaults `namespace` to `local`, `version` to `0.1.0` and `entrypoint` to `lib.typ`, so the migration is

```toml
[package]
name = "<dir>"
```

which reproduces the synthesized spec byte for byte.

## Fallout the cut cleans up

- `package_spec: Option<PackageSpec>` and `entrypoint: Option<&str>` on `load_package_files_from_quill` become `PackageSpec` and `&str` — both call sites always passed a concrete value, and the `if let (Some, Some)` entrypoint guard becomes straight-line.
- `"0.1.0".parse().map_err(|_| "Invalid version format")?` — an infallible parse dressed as fallible — goes with the branch.

## Tests

The branch had **no test at all**: every package test in `world.rs` (`:601,628,648,666,686`) constructs a `typst.toml`, and the one fixture quill with a `packages/` dir carries a manifest. `a_package_without_a_manifest_is_skipped_with_a_warning` covers the skip.

## Breaking

Marked `!` conservatively. The affected population is a quill that vendored a package directory without a manifest and imported it at the synthesized spelling — undocumented, so anyone doing it read it out of `world.rs`. Recorded in `CHANGELOG.md`, in a section of `docs/migrations/0.112-to-0.113.md` with the migration TOML, and `docs/quills/typst-backend.md` now states the manifest requirement, which it never did.

## Checks

`cargo test --workspace`, `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`, and `node scripts/check-canon.mjs` all pass. Typst-only — no binding, CLI, or canon change; `ERROR.md` already lists `typst::package_manifest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLYYzuG5znPb3MroBsobaD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLYYzuG5znPb3MroBsobaD)_