### PR TITLE
refactor(pdfform): a checkbox reads a bool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 ## Unreleased
 
+- refactor(pdfform): **a checkbox reads a bool.** `is_truthy` accepted
+  `"yes"`, `"on"`, `"y"`, `"checked"`, `"1"` and any nonzero number beside
+  `true`. Nothing reaches it: a `checkbox` widget binds only to a `boolean`
+  schema field, and `resolve` runs against `compile_data`, where
+  `conform_value` has already turned a bool, a `"true"`/`"false"` spelling and
+  a number into a JSON bool — and refused everything else as
+  `CoercionError::uncoercible` before any widget resolves. So the vocabulary
+  was not a tolerance but a second, *wider* one behind a door the first never
+  opens: `"yes"` checks the box here and fails the compile upstream. The module
+  binds against `compile_data` precisely so coercion is inherited rather than
+  re-implemented, which is the line `is_truthy` crossed. `matches!(raw,
+  Value::Bool(true))` is the whole rule now. No reachable behavior changes.
+
 Upgrade path: [0.112 → 0.113](docs/migrations/0.112-to-0.113.md).
 
 ### The content model

--- a/crates/backends/pdfform/src/resolve.rs
+++ b/crates/backends/pdfform/src/resolve.rs
@@ -32,7 +32,9 @@ fn resolve_value(field_type: &FieldType, schema_field: Option<&str>, data: &Valu
     let raw = lookup(data, schema_field?)?;
     match field_type {
         FieldType::Text { .. } => coerce_text(raw),
-        FieldType::Checkbox => is_truthy(raw).then(|| CHECKBOX_ON_STATE.to_string()),
+        FieldType::Checkbox => {
+            matches!(raw, Value::Bool(true)).then(|| CHECKBOX_ON_STATE.to_string())
+        }
         FieldType::Choice { options } => coerce_choice(raw, options),
         FieldType::Signature => None,
     }
@@ -122,20 +124,6 @@ fn richtext_plaintext(v: &Value) -> Option<String> {
     let rt = quillmark_content::serial::from_canonical_value(v).ok()?;
     let text = quillmark_content::export::to_plaintext(&rt);
     (!text.is_empty()).then_some(text)
-}
-
-/// A boolean schema field arrives as a JSON bool; strings and numbers are
-/// handled defensively.
-fn is_truthy(v: &Value) -> bool {
-    match v {
-        Value::Bool(b) => *b,
-        Value::Number(n) => n.as_f64().map(|f| f != 0.0).unwrap_or(false),
-        Value::String(s) => matches!(
-            s.trim().to_ascii_lowercase().as_str(),
-            "true" | "yes" | "on" | "1" | "y" | "checked"
-        ),
-        _ => false,
-    }
 }
 
 /// A choice value binds only if it matches one of the declared options exactly.
@@ -246,7 +234,7 @@ mod tests {
     }
 
     #[test]
-    fn checkbox_truthiness() {
+    fn checkbox_reads_a_bool() {
         let on = |f| resolve_value(&FieldType::Checkbox, Some(f), &data());
         assert_eq!(on("agree"), Some(CHECKBOX_ON_STATE.to_string()));
         assert_eq!(on("decline"), None);
@@ -317,22 +305,6 @@ mod tests {
         assert_eq!(card_text("$cards.indorsement.0.missing"), None);
         // `$cards.0.from` reads `0` as a kind, matching no card.
         assert_eq!(card_text("$cards.0.from"), None);
-    }
-
-    #[test]
-    fn is_truthy_string_and_number_variants() {
-        for s in ["true", "Yes", " ON ", "1", "y", "Checked"] {
-            assert!(is_truthy(&json!(s)), "{s:?} should be truthy");
-        }
-        for s in ["false", "no", "0", "", "maybe", "off"] {
-            assert!(!is_truthy(&json!(s)), "{s:?} should be falsy");
-        }
-        assert!(is_truthy(&json!(42)));
-        assert!(is_truthy(&json!(-1)));
-        assert!(!is_truthy(&json!(0)));
-        assert!(!is_truthy(&json!(null)));
-        assert!(!is_truthy(&json!([true])));
-        assert!(!is_truthy(&json!({"a": 1})));
     }
 
     #[test]

--- a/docs/quills/pdfform-backend.md
+++ b/docs/quills/pdfform-backend.md
@@ -198,7 +198,7 @@ Each field's value comes from the **resolver**: for every bound field, the backe
 | Type | Binding |
 |---|---|
 | `text` | String value; numbers/bools stringify; an **array joins with newlines** (one element per line: the multiline fill). Empty → blank. |
-| `checkbox` | Truthy value → checked; otherwise unchecked. |
+| `checkbox` | `true` → checked; otherwise unchecked. Binds a `boolean` field, which reaches here already coerced. |
 | `choice` | The value must match one of `options` exactly, else the field is left blank. |
 | `signature` | Never bound: always an empty, signer-fillable widget. |
 


### PR DESCRIPTION
The `is_truthy` row from #1698.

## What changes

`FieldType::Checkbox => matches!(raw, Value::Bool(true))`. `is_truthy` and its test go.

## Why: not merely unused, but contradictory

`is_truthy` accepted `"yes"`, `"on"`, `"y"`, `"checked"`, `"1"` and any nonzero number beside `true`. The issue calls it unreachable; it is, and I traced every path to confirm:

- A `checkbox` widget binds only to a `boolean` schema field (`bind.rs:256`) or is unbound, in which case `resolve_value` returns before the lookup.
- Every door into the backend carries `compile_checked` / `compile_data` output — `orchestration/engine.rs:73,88`, `session.rs:297`, and the WASM/Python/CLI entries that delegate to them.
- `conform_value` for `Boolean` at `Leniency::Render` (`config.rs:328-360`) turns a bool, a `"true"`/`"false"` spelling and a number into a JSON bool, and **refuses everything else** as `CoercionError::uncoercible` — the compile fails before any widget resolves.
- Every address shape is coerced, not just top-level: array items, object properties, variant cells, and `$cards` via `coerce_card`.

The sharper point is what the vocabulary *was*, given that: not a tolerance but a **second, wider one behind a door the first never opens**. `"yes"` checks the box here and fails the compile upstream. The two disagree, and only the unreachable one is permissive — so if a path ever did reach it, it would silently accept what the schema had just rejected.

`resolve.rs`'s own module doc states the contract it crossed: binding is against `compile_data` "so blank-fill, validation, defaults and scalar coercion are inherited rather than re-implemented."

## Tests

`checkbox_reads_a_bool` (renamed from `checkbox_truthiness`, which promised a vocabulary) already asserts the property, as does `card_coercion_runs_per_widget_type`. The deleted test only pinned the dead vocabulary.

## Not breaking

No reachable behavior changes, so no `!`. `docs/quills/pdfform-backend.md`'s "Truthy value → checked" row is tightened to `true` → checked.

## Note on adjacent dead arms

`coerce_choice`'s `Number` / `Bool` arms look equally unreachable (a Choice binds through `enum_values`, and an `Enum` at `Render` is stringified by `lenient_string`). Left alone — out of scope for this row, and worth its own look. `element_text`'s `Bool` arm **is** live (an `array<boolean>` projects to multiline Text) and is untouched.

## Checks

`cargo test --workspace`, `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`, and `node scripts/check-canon.mjs` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLYYzuG5znPb3MroBsobaD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLYYzuG5znPb3MroBsobaD)_