### PR TITLE
refactor(core): a quill reference parses its selector token directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+- refactor(core): **a quill reference parses its selector token directly.**
+  `QuillReference::from_str` split `name@selector` and then re-prefixed the
+  half it had just split off — `VersionSelector::from_str(&format!("@{}",
+  part))` — so the selector parser carried a `written` flag to tell the typo
+  `memo@` from the absent selector in `memo`, a distinction only the caller
+  ever had in hand. `VersionSelector::from_token` parses the unprefixed token
+  and refuses the empty one, `from_str` is the written spelling over it, and
+  the allocation per parse goes. Parsed values, `Display` output and error
+  strings are unchanged, which is what the untouched selector tests assert.
+
 Upgrade path: [0.112 → 0.113](docs/migrations/0.112-to-0.113.md).
 
 ### The content model

--- a/crates/core/src/version.rs
+++ b/crates/core/src/version.rs
@@ -95,36 +95,25 @@ impl VersionSelector {
     }
 }
 
-impl FromStr for VersionSelector {
-    type Err = String;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        // An absent selector is `latest`; a written `@` with nothing after it is
-        // a typo, not a spelling of it.
-        let (written, version_str) = match s.strip_prefix('@') {
-            Some(rest) => (true, rest),
-            None => (false, s),
-        };
-
-        if version_str.is_empty() {
-            return if written {
-                Err(format!(
-                    "Invalid version selector '{}': `@` carries no selector; omit it for the latest version, or write one",
-                    s
-                ))
-            } else {
-                Ok(VersionSelector::Latest)
-            };
+impl VersionSelector {
+    /// The selector as written after `@`, unprefixed: `2`, `2.1`, `2.1.0` or
+    /// `latest`. Empty is the typo `name@`, not a spelling of latest.
+    pub(crate) fn from_token(token: &str) -> Result<Self, String> {
+        if token.is_empty() {
+            return Err(
+                "Invalid version selector '@': `@` carries no selector; omit it for the latest version, or write one"
+                    .to_string(),
+            );
         }
-        if version_str == "latest" {
+        if token == "latest" {
             return Ok(VersionSelector::Latest);
         }
 
-        let parts: Vec<&str> = version_str.split('.').collect();
+        let parts: Vec<&str> = token.split('.').collect();
 
         match parts.len() {
             2 | 3 => {
-                let version = Version::from_str(version_str)?;
+                let version = Version::from_str(token)?;
                 Ok(if parts.len() == 3 {
                     VersionSelector::Exact(version)
                 } else {
@@ -132,18 +121,32 @@ impl FromStr for VersionSelector {
                 })
             }
             1 => {
-                let major = parse_segment(version_str, "major").map_err(|_| {
+                let major = parse_segment(token, "major").map_err(|_| {
                     format!(
                         "Invalid version selector '{}': expected number, MAJOR.MINOR, MAJOR.MINOR.PATCH, or 'latest'",
-                        version_str
+                        token
                     )
                 })?;
                 Ok(VersionSelector::Major(major))
             }
             _ => Err(format!(
                 "Invalid version selector '{}': expected number, MAJOR.MINOR, MAJOR.MINOR.PATCH, or 'latest'",
-                version_str
+                token
             )),
+        }
+    }
+}
+
+impl FromStr for VersionSelector {
+    type Err = String;
+
+    /// The written selector, `@` and all. An empty string is an absent
+    /// selector, which is latest.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.strip_prefix('@') {
+            Some(token) => Self::from_token(token),
+            None if s.is_empty() => Ok(VersionSelector::Latest),
+            None => Self::from_token(s),
         }
     }
 }
@@ -223,10 +226,9 @@ impl FromStr for QuillReference {
             ));
         }
 
-        let selector = if let Some(version_part) = version_part_opt {
-            VersionSelector::from_str(&format!("@{}", version_part))?
-        } else {
-            VersionSelector::Latest
+        let selector = match version_part_opt {
+            Some(token) => VersionSelector::from_token(token)?,
+            None => VersionSelector::Latest,
         };
 
         Ok(QuillReference { name, selector })


### PR DESCRIPTION
The salvageable half of the `VersionSelector` row in #1698. **The `@N` / `@latest` cut the issue proposes is rejected** — reasoning below — but the "re-prefix dance" it names alongside is real, and this removes it.

## What changes

`QuillReference::from_str` split `name@selector` and then re-prefixed the half it had just split off:

```rust
VersionSelector::from_str(&format!("@{}", version_part))?
```

That round trip is why the selector parser carried a `written` flag: with the `@` back in hand it had to tell the typo `memo@` from the absent selector in `memo` — a distinction only the caller ever had in hand. `VersionSelector::from_token` parses the unprefixed token and refuses the empty one; `from_str` is the written spelling layered over it.

## Non-breaking, and the tests are the proof

Parsed values, `Display` output and error strings are all unchanged — including the `'@'` in the trailing-`@` message, which the old code produced by formatting the reconstructed string and the new one states directly. **No test was modified**; all 18 selector tests pass as they stand, `a_trailing_at_is_not_a_selector` and `test_version_selector_without_at` included. That is the whole argument for the change being safe.

## Why the `@N` / `@latest` cut is rejected

- **`Latest` is not only a spelling.** It is the value of an *absent* selector (`memo` with no `@`), which is the common case, so the variant cannot go without making `QuillReference.selector` an `Option` — a refactor with no behavior change. Only the written `@latest` is cuttable, and cutting it forces `Display` to write something unparseable for `Latest`, breaking `to_string().parse()`.
- **`@N` is the semver-correct pin.** `VERSIONING.md` defines MINOR as backward-compatible, so `memo@1` means "any compatible 1.x" — which neither `Exact` (breaks on a patch) nor `Minor` (breaks on a minor) can express. Cutting it leaves no selector for the thing a document most wants to say.
- **Both are advertised**, unlike the `---` alias in #1739: `prose/canon/VERSIONING.md:38-39`, the spec's §3.5 table, `docs/quills/versioning.md:38`, `docs/authoring/card-yaml.md:94`. And both are *coherent* — they mean the same thing wherever a selector is read, with no root-only asymmetry. Advertised and coherent is contract.
- Cutting `@N` would also be a `!` on what `set_quill_ref` and `Document.new` accept in **both** bindings.

## Checks

`cargo test --workspace`, `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --workspace`, and `node scripts/check-canon.mjs` all pass. No binding exposes `VersionSelector` or `Version`; `QUILL_REF_HINT`, which `python/tests/test_parse.py:230` reads, is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QLYYzuG5znPb3MroBsobaD

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLYYzuG5znPb3MroBsobaD)_