### PR TITLE
refactor(core)!: an enum's domain rides the type token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -680,6 +680,20 @@ Upgrade path: [0.112 → 0.113](docs/migrations/0.112-to-0.113.md).
 
 ### Schema, validation and the resolved view
 
+- refactor(core)!: **an enum's domain rides the type token.** `FieldType::Enum`
+  carries `values`, and `FieldSchema::enum_values` is gone. The domain and the
+  token had to agree, an agreement the loader enforced and the type could not,
+  so every consumer keyed on the carrier and left a `FieldType::Enum` arm behind
+  as unreachable residue — three of them, each answering "no domain" differently:
+  the transform schema projected `{type: string}`, an open domain contradicting
+  the token; validation skipped the membership check; pdfform refused to bind.
+  One rule replaces them, special-cased nowhere: a domain admits its members and
+  the blank, so an empty one admits only the blank. `FieldSchema::domain()`
+  answers it for the three branches that enter through `variants:` holding no
+  token. No quill loads differently and no stored or wire byte moves: `values:`
+  is still the one spelling, still required non-empty on `type: enum`, still a
+  load error elsewhere, and `Serialize` re-emits it from the payload in the slot
+  it already occupied.
 - feat(core,wasm,python)!: **a quill carries the load's advisory diagnostics,
   so they reach a binding host at last.** `Quill::warnings()` is new, mirrored
   as `quill.warnings` in WASM and Python, and it answers whatever

--- a/crates/backends/pdfform/src/bind.rs
+++ b/crates/backends/pdfform/src/bind.rs
@@ -235,18 +235,13 @@ fn descend<'a>(cur: &'a FieldSchema, seg: &str) -> Option<&'a FieldSchema> {
     }
 }
 
-/// Project a resolved [`FieldSchema`] to its widget kind, keyed on capability
-/// rather than the `type` token: any field carrying `enum_values` is a dropdown.
+/// Project a resolved [`FieldSchema`] to its widget kind: an `enum` is a
+/// dropdown over its domain, and an `object` has no widget shape at all.
 pub fn project_kind(
     field: &FieldSchema,
     name: &str,
     path: &str,
 ) -> Result<WidgetType, BindError> {
-    if let Some(values) = &field.enum_values {
-        return Ok(WidgetType::Choice {
-            options: blank_first(values),
-        });
-    }
     let unbindable = || BindError::Unbindable {
         name: name.to_string(),
         path: path.to_string(),
@@ -270,9 +265,10 @@ pub fn project_kind(
             Some(items) if is_scalar_or_prose(items) => WidgetType::Text { multiline: true },
             _ => return Err(unbindable()),
         },
-        // An `Enum` reaching here carries no `enum_values`, so it has no options
-        // to offer; an `Object` has no widget shape at all.
-        SchemaType::Enum | SchemaType::Object => return Err(unbindable()),
+        SchemaType::Enum { values } => WidgetType::Choice {
+            options: blank_first(values),
+        },
+        SchemaType::Object => return Err(unbindable()),
     })
 }
 

--- a/crates/core/src/quill/blueprint.rs
+++ b/crates/core/src/quill/blueprint.rs
@@ -484,10 +484,8 @@ fn push_container_field(
 /// the value cell alone (a concrete value is shippable as-is, a `!must_fill`
 /// marker asks to be filled) so the annotation needs no cell-state tag.
 fn type_expression(field: &FieldSchema) -> String {
-    if let Some(values) = &field.enum_values {
-        return format!("enum<{}>", values.join(" | "));
-    }
-    match field.r#type {
+    match &field.r#type {
+        FieldType::Enum { values } => format!("enum<{}>", values.join(" | ")),
         FieldType::String => "string".into(),
         FieldType::Number => "number".into(),
         FieldType::Integer => "integer".into(),
@@ -502,9 +500,6 @@ fn type_expression(field: &FieldSchema) -> String {
         // markup, distinct from richtext's `<markdown>` surface.
         FieldType::PlainText { inline: false } => "plaintext<plain>".into(),
         FieldType::PlainText { inline: true } => "plaintext(inline)<plain>".into(),
-        // `enum` fields always carry `enum_values`, so the early return above
-        // handles them; this arm is the defensive fallback for a valueless enum.
-        FieldType::Enum => "enum".into(),
         FieldType::Date => "date<YYYY-MM-DD>".into(),
         FieldType::DateTime => "datetime<YYYY-MM-DDThh:mm[:ss]>".into(),
         // The element type comes from `items`; a scalar element gives

--- a/crates/core/src/quill/config.rs
+++ b/crates/core/src/quill/config.rs
@@ -438,7 +438,7 @@ impl QuillConfig {
             }
             // An enum coerces as a string; domain membership is the validation
             // layer's, an out-of-domain string being a value error.
-            FieldType::String | FieldType::Enum => {
+            FieldType::String | FieldType::Enum { .. } => {
                 if json_value.is_string() {
                     return Ok(value.clone());
                 }
@@ -858,7 +858,7 @@ impl QuillConfig {
                     ),
                 );
             }
-            let Some(values) = &schema.enum_values else {
+            let FieldType::Enum { values } = &schema.r#type else {
                 return err(
                     "quill::variants_on_non_enum",
                     format!(
@@ -1039,43 +1039,41 @@ impl QuillConfig {
         owner_label: &str,
         errors: &mut Vec<Diagnostic>,
     ) {
-        if let Some(values) = &field.enum_values {
-            for v in values {
-                if v.is_empty() {
-                    errors.push(
-                        Diagnostic::new(
-                            Severity::Error,
-                            format!(
-                                "{} declares `\"\"` in `values:`. The blank is not a \
-                                 choice: it is supplied by the engine and always \
-                                 accepted.",
-                                owner_label
-                            ),
-                        )
-                        .with_code("quill::enum_blank_member".to_string())
-                        .with_hint(
-                            "Remove `\"\"` from `values:`; every enum accepts the blank \
-                             already. Keep `default: \"\"` to leave the field optional, \
-                             and declare a member such as `undecided` or `n_a` where \
-                             the empty state is itself a choice someone makes."
-                                .to_string(),
+        for v in field.domain() {
+            if v.is_empty() {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        format!(
+                            "{} declares `\"\"` in `values:`. The blank is not a \
+                             choice: it is supplied by the engine and always \
+                             accepted.",
+                            owner_label
                         ),
-                    );
-                }
-                if v.contains('>') || v.contains(';') || v.contains('|') {
-                    errors.push(
-                        Diagnostic::new(
-                            Severity::Error,
-                            format!(
-                                "{} enum value '{}' contains a reserved character \
-                                 ('>', ';', or '|') that conflicts with the \
-                                 blueprint inline annotation grammar.",
-                                owner_label, v
-                            ),
-                        )
-                        .with_code("quill::format_literal_reserved_char".to_string()),
-                    );
-                }
+                    )
+                    .with_code("quill::enum_blank_member".to_string())
+                    .with_hint(
+                        "Remove `\"\"` from `values:`; every enum accepts the blank \
+                         already. Keep `default: \"\"` to leave the field optional, \
+                         and declare a member such as `undecided` or `n_a` where \
+                         the empty state is itself a choice someone makes."
+                            .to_string(),
+                    ),
+                );
+            }
+            if v.contains('>') || v.contains(';') || v.contains('|') {
+                errors.push(
+                    Diagnostic::new(
+                        Severity::Error,
+                        format!(
+                            "{} enum value '{}' contains a reserved character \
+                             ('>', ';', or '|') that conflicts with the \
+                             blueprint inline annotation grammar.",
+                            owner_label, v
+                        ),
+                    )
+                    .with_code("quill::format_literal_reserved_char".to_string()),
+                );
             }
         }
     }
@@ -1289,9 +1287,8 @@ impl QuillConfig {
                     };
                     let hint = if schema.is_variant_bearing() && actual == "object" {
                         let member = schema
-                            .enum_values
-                            .as_ref()
-                            .and_then(|v| v.first())
+                            .domain()
+                            .first()
                             .map(String::as_str)
                             .unwrap_or("<member>");
                         format!(
@@ -2022,7 +2019,7 @@ pub(crate) fn field_contains_content(field: &FieldSchema) -> bool {
         // world is live is a value-time fact and this is a schema question, so
         // the union answers it: a cell that can hold content means the
         // container's companions, resting form and seed must all handle one.
-        FieldType::Enum => field.variants.as_ref().is_some_and(|v| {
+        FieldType::Enum { .. } => field.variants.as_ref().is_some_and(|v| {
             v.values()
                 .flat_map(|set| set.values())
                 .any(|f| field_contains_content(f))

--- a/crates/core/src/quill/fill.rs
+++ b/crates/core/src/quill/fill.rs
@@ -21,12 +21,6 @@ pub fn blank(field: &FieldSchema) -> QuillValue {
         obj.insert(VARIANT_DISCRIMINANT_KEY.to_string(), json!(""));
         return QuillValue::from_json(serde_json::Value::Object(obj));
     }
-    // Keyed on the carrier rather than the `Enum` token, as every consumer of a
-    // finite domain is, so a serde-built schema whose type and carrier disagree
-    // still blanks to the reserved `""`.
-    if field.enum_values.is_some() {
-        return QuillValue::from_json(json!(""));
-    }
     let json = match field.r#type {
         FieldType::Array => json!([]),
         FieldType::Object => match &field.properties {
@@ -47,7 +41,8 @@ pub fn blank(field: &FieldSchema) -> QuillValue {
         FieldType::RichText { .. } | FieldType::PlainText { .. } => {
             quillmark_content::serial::to_canonical_value(&quillmark_content::Normalized::empty())
         }
-        // String, Date and DateTime: a date's `""` lowers to Typst `none`.
+        // String, Date, DateTime and an `enum`, whose blank every domain
+        // admits: a date's `""` lowers to Typst `none`.
         _ => json!(""),
     };
     QuillValue::from_json(json)
@@ -102,14 +97,6 @@ properties:
                 "address": { "city": "", "tags": [] }
             })
         );
-    }
-
-    /// The loader rejects `values:` on a non-enum type; serde builds it anyway.
-    #[test]
-    fn enum_values_on_a_non_enum_type_blanks_to_the_empty_string() {
-        let mut schema = FieldSchema::new("clearance".to_string(), FieldType::Integer, None);
-        schema.enum_values = Some(vec!["1".to_string(), "2".to_string()]);
-        assert_eq!(blank(&schema).into_json(), json!(""));
     }
 
     #[test]

--- a/crates/core/src/quill/schema.rs
+++ b/crates/core/src/quill/schema.rs
@@ -43,7 +43,7 @@ fn discriminant_schema(field: &FieldSchema) -> serde_json::Value {
         "enum".to_string(),
         serde_json::Value::Array(
             std::iter::once(String::new())
-                .chain(field.enum_values.iter().flatten().cloned())
+                .chain(field.domain().iter().cloned())
                 .map(serde_json::Value::String)
                 .collect(),
         ),
@@ -98,10 +98,8 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
             schema.insert("properties".to_string(), properties.into());
             return serde_json::Value::Object(schema);
         }
-        if field.enum_values.is_some() {
-            return discriminant_schema(field);
-        }
         match field.r#type {
+            FieldType::Enum { .. } => return discriminant_schema(field),
             FieldType::String => {
                 schema.insert(
                     "type".to_string(),
@@ -147,14 +145,6 @@ pub fn build_transform_schema(config: &QuillConfig) -> QuillValue {
                         serde_json::Value::Bool(true),
                     );
                 }
-            }
-            // A loaded `enum` always carries `values:`, so the domain branch
-            // above claims it; this arm is the domain-less residue.
-            FieldType::Enum => {
-                schema.insert(
-                    "type".to_string(),
-                    serde_json::Value::String("string".to_string()),
-                );
             }
             FieldType::Number => {
                 schema.insert(

--- a/crates/core/src/quill/tests.rs
+++ b/crates/core/src/quill/tests.rs
@@ -2430,8 +2430,10 @@ fn enum_rejects_a_blank_value_but_accepts_a_blank_default() {
     let field = config.main.fields.get("classification").unwrap();
     assert_eq!(field.default.as_ref().unwrap().as_json(), &serde_json::json!(""));
     assert_eq!(
-        field.enum_values.as_deref(),
-        Some(["UNCLASSIFIED".to_string(), "CUI".to_string()].as_slice()),
+        field.r#type,
+        FieldType::Enum {
+            values: vec!["UNCLASSIFIED".to_string(), "CUI".to_string()]
+        },
         "the declared choices carry no blank"
     );
 }
@@ -2906,11 +2908,17 @@ fn enum_type_projects_to_json_schema_string_enum() {
     )
     .expect("type: enum loads");
     let field = config.main.fields.get("color").unwrap();
-    assert_eq!(field.r#type, FieldType::Enum);
     // The model layer carries the declared choices only: the blank is not one.
     assert_eq!(
-        field.enum_values.as_deref(),
-        Some(["red".to_string(), "green".to_string(), "blue".to_string()].as_slice())
+        field.r#type,
+        FieldType::Enum {
+            values: vec!["red".to_string(), "green".to_string(), "blue".to_string()]
+        }
+    );
+    // The payload is what `values:` re-emits from.
+    assert_eq!(
+        serde_json::to_value(field).unwrap()["values"],
+        serde_json::json!(["red", "green", "blue"])
     );
     let schema = super::schema::build_transform_schema(&config);
     let color = &schema.as_json()["properties"]["color"];

--- a/crates/core/src/quill/types.rs
+++ b/crates/core/src/quill/types.rs
@@ -293,12 +293,15 @@ pub enum FieldType {
         /// A single line, enforced where [`RichText`](Self::RichText)'s is.
         inline: bool,
     },
-    /// A closed finite domain, its members carried in
-    /// [`FieldSchema::enum_values`] and string-valued only.
-    Enum,
+    /// A closed string domain, `values` in declaration order. The blank (`""`)
+    /// is accepted beside them and is never one of them.
+    Enum { values: Vec<String> },
 }
 
 impl FieldType {
+    /// The `type:` token alone. An `enum`'s domain and a prose type's `inline`
+    /// ride sibling keys that [`FieldSchema::from_quill_value`] folds in, so
+    /// both payloads rest at their default here.
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
         match s.trim() {
@@ -312,7 +315,7 @@ impl FieldType {
             "datetime" => Some(FieldType::DateTime),
             "richtext" => Some(FieldType::RichText { inline: false }),
             "plaintext" => Some(FieldType::PlainText { inline: false }),
-            "enum" => Some(FieldType::Enum),
+            "enum" => Some(FieldType::Enum { values: Vec::new() }),
             _ => None,
         }
     }
@@ -329,7 +332,7 @@ impl FieldType {
             FieldType::DateTime => "datetime",
             FieldType::RichText { .. } => "richtext",
             FieldType::PlainText { .. } => "plaintext",
-            FieldType::Enum => "enum",
+            FieldType::Enum { .. } => "enum",
         }
     }
 }
@@ -361,12 +364,12 @@ pub const VARIANT_DISCRIMINANT_KEY: &str = "value";
 /// axis and the obligation one ([`must_fill`](Self::must_fill)); `SCHEMAS.md`
 /// §"Value and obligation: one declaration" is the rule.
 ///
-/// The prose types' single-line constraint has **one** carrier, the
-/// `inline` payload on [`FieldType::RichText`] / [`FieldType::PlainText`]. The
-/// wire's sibling `inline:` key folds into it at deserialize (through
+/// The prose types' single-line constraint and an `enum`'s domain each have
+/// **one** carrier, the [`FieldType`] payload. The wire's sibling `inline:` and
+/// `values:` keys fold into it at deserialize (through
 /// [`from_quill_value`](Self::from_quill_value)) and the hand-written
-/// `Serialize` re-emits it from there, so the flag cannot live in two places
-/// that disagree.
+/// `Serialize` re-emits them from there, so neither can live in two places that
+/// disagree.
 #[derive(Debug, Clone, PartialEq)]
 pub struct FieldSchema {
     /// The map key carries this on the wire; not serialized, to avoid duplication.
@@ -380,13 +383,10 @@ pub struct FieldSchema {
     /// authors want; documents shape only and never renders as the value.
     pub example: Option<QuillValue>,
     pub ui: Option<UiFieldSchema>,
-    /// The members of an `enum` field; no other type accepts them.
-    /// Serializes as `values`.
-    pub enum_values: Option<Vec<String>>,
     /// Per-member field sets on an `enum` field, keyed by member (a subset of
-    /// [`enum_values`](Self::enum_values); the blank owns no set). Declaring it
-    /// is what turns the field into a container (`SCHEMAS.md` §"Enum
-    /// variants").
+    /// the domain the [`FieldType::Enum`] payload carries; the blank owns no
+    /// set). Declaring it is what turns the field into a container
+    /// (`SCHEMAS.md` §"Enum variants").
     pub variants: Option<IndexMap<String, VariantFields>>,
     /// A typed dictionary's properties, in declaration order.
     pub properties: Option<IndexMap<String, Box<FieldSchema>>>,
@@ -415,7 +415,7 @@ struct FieldSchemaDef {
     pub example: Option<QuillValue>,
     pub ui: Option<UiFieldSchema>,
     /// The domain of a `type: enum` field, and the only spelling of one.
-    /// Lands in [`FieldSchema::enum_values`].
+    /// Lands in the [`FieldType::Enum`] payload.
     pub values: Option<Vec<String>>,
     /// Per-member field sets, keyed by member. Lands in
     /// [`FieldSchema::variants`].
@@ -436,12 +436,20 @@ impl FieldSchema {
             default: None,
             example: None,
             ui: None,
-            enum_values: None,
             variants: None,
             properties: None,
             items: None,
             default_content: None,
             example_content: None,
+        }
+    }
+
+    /// An `enum`'s declared choices; empty for every other type. A domain
+    /// admits its members and the blank, so an empty one admits only the blank.
+    pub fn domain(&self) -> &[String] {
+        match &self.r#type {
+            FieldType::Enum { values } => values,
+            _ => &[],
         }
     }
 
@@ -503,10 +511,10 @@ impl FieldSchema {
     pub fn from_quill_value(key: String, value: &QuillValue) -> Result<Self, String> {
         let def: FieldSchemaDef = serde_json::from_value(value.clone().into_json())
             .map_err(|e| format!("Failed to parse field schema: {}", e))?;
-        // The sole inline sync point: past here the variant payload is the
-        // flag's one carrier.
+        // The sole sync point for `inline:` and `values:`: past here the type
+        // payload is each key's one carrier.
         let r#type = Self::resolve_prose_inline(def.r#type, def.inline)?;
-        let enum_values = Self::resolve_enum_values(&r#type, def.values)?;
+        let r#type = Self::resolve_enum_domain(r#type, def.values)?;
         let schema = Self {
             name: key.clone(),
             r#type,
@@ -514,7 +522,6 @@ impl FieldSchema {
             default: def.default,
             example: def.example,
             ui: def.ui,
-            enum_values,
             variants: match def.variants {
                 Some(variants) => {
                     let mut out = IndexMap::new();
@@ -588,26 +595,25 @@ impl FieldSchema {
         }
     }
 
-    /// Resolve the domain into [`FieldSchema::enum_values`]: `type: enum`
-    /// requires a non-empty `values:` list, and `values:` elsewhere is an error.
-    fn resolve_enum_values(
-        r#type: &FieldType,
+    /// Fold the sibling `values:` key into the [`FieldType::Enum`] payload:
+    /// `type: enum` requires a non-empty list, and `values:` elsewhere is an
+    /// error. Every other type rejects it, here and nowhere else.
+    fn resolve_enum_domain(
+        r#type: FieldType,
         values_key: Option<Vec<String>>,
-    ) -> Result<Option<Vec<String>>, String> {
-        match r#type {
-            FieldType::Enum => match values_key {
-                Some(v) if !v.is_empty() => Ok(Some(v)),
-                _ => Err("type: enum requires a non-empty values: list".to_string()),
-            },
-            other => {
-                if values_key.is_some() {
-                    return Err(format!(
-                        "values: is only valid on type: enum, not on type: {}",
-                        other.as_str()
-                    ));
-                }
-                Ok(None)
+    ) -> Result<FieldType, String> {
+        match (r#type, values_key) {
+            (FieldType::Enum { .. }, Some(values)) if !values.is_empty() => {
+                Ok(FieldType::Enum { values })
             }
+            (FieldType::Enum { .. }, _) => {
+                Err("type: enum requires a non-empty values: list".to_string())
+            }
+            (other, Some(_)) => Err(format!(
+                "values: is only valid on type: enum, not on type: {}",
+                other.as_str()
+            )),
+            (other, None) => Ok(other),
         }
     }
 }
@@ -620,18 +626,23 @@ impl Serialize for FieldSchema {
             FieldType::RichText { inline: true } | FieldType::PlainText { inline: true }
         )
         .then_some(true);
+        let values = match &self.r#type {
+            FieldType::Enum { values } => Some(values),
+            _ => None,
+        };
         let len = 1
             + inline.is_some() as usize
             + self.description.is_some() as usize
             + self.default.is_some() as usize
             + self.example.is_some() as usize
             + self.ui.is_some() as usize
-            + self.enum_values.is_some() as usize
+            + values.is_some() as usize
             + self.variants.is_some() as usize
             + self.properties.is_some() as usize
             + self.items.is_some() as usize;
-        // Field order matches the struct declaration (what a derived impl
-        // emits), so `inline` trails the block and golden snapshots hold.
+        // The emission order is what `usaf_memo/0.2.0/__golden__/schema.yaml`
+        // pins: `values` between `ui` and `variants`, `inline` trailing the
+        // block, both read off the type payload.
         let mut map = serializer.serialize_map(Some(len))?;
         map.serialize_entry("type", &self.r#type)?;
         if let Some(v) = &self.description {
@@ -646,7 +657,7 @@ impl Serialize for FieldSchema {
         if let Some(v) = &self.ui {
             map.serialize_entry("ui", v)?;
         }
-        if let Some(v) = &self.enum_values {
+        if let Some(v) = values {
             map.serialize_entry("values", v)?;
         }
         if let Some(v) = &self.variants {

--- a/crates/core/src/quill/validation.rs
+++ b/crates/core/src/quill/validation.rs
@@ -461,7 +461,7 @@ fn validate_value(
     let type_valid = match field.r#type {
         // An enum is type-valid exactly where a string is; the domain check is
         // below.
-        FieldType::String | FieldType::Enum => value.as_str().is_some(),
+        FieldType::String | FieldType::Enum { .. } => value.as_str().is_some(),
         // A conformed value is a canonical content object; an authored
         // `default`/`example` is the codec's string. The shape pass below
         // checks `inline` and `plain`.
@@ -613,12 +613,12 @@ fn validate_value(
         // the call sites so `validate_value` stays context-free: an enum at
         // element position inside an array accepts the blank on the same line
         // as one at the top level.
-        if let (Some(allowed), Some(actual)) = (&field.enum_values, value.as_str()) {
-            if !actual.is_empty() && !allowed.contains(&actual.to_string()) {
+        if let (FieldType::Enum { values }, Some(actual)) = (&field.r#type, value.as_str()) {
+            if !actual.is_empty() && !values.iter().any(|v| v == actual) {
                 errors.push(ValidationError::EnumViolation {
                     path: path.to_string(),
                     value: actual.to_string(),
-                    allowed: allowed.clone(),
+                    allowed: values.clone(),
                 });
             }
         }
@@ -648,14 +648,13 @@ fn validate_variant(
     let json = value.as_json();
 
     let check_member = |member: &str, at: &DocPath, errors: &mut Vec<ValidationError>| {
-        if let Some(allowed) = &field.enum_values {
-            if !member.is_empty() && !allowed.contains(&member.to_string()) {
-                errors.push(ValidationError::EnumViolation {
-                    path: at.to_string(),
-                    value: member.to_string(),
-                    allowed: allowed.clone(),
-                });
-            }
+        let allowed = field.domain();
+        if !member.is_empty() && !allowed.iter().any(|v| v == member) {
+            errors.push(ValidationError::EnumViolation {
+                path: at.to_string(),
+                value: member.to_string(),
+                allowed: allowed.to_vec(),
+            });
         }
     };
 
@@ -1100,5 +1099,30 @@ main:
         let content = quillmark_content::serial::to_canonical_value(&rt);
         let doc = doc_from_fm(&[("tag", content)]);
         assert!(validate_typed_document(&config, &doc).is_ok());
+    }
+
+    /// A domain admits its members and the blank, so an empty one admits the
+    /// blank alone. The loader refuses to build this field — `type: enum`
+    /// requires a non-empty `values:` — so the rule is reachable only from Rust.
+    #[test]
+    fn an_empty_domain_admits_only_the_blank() {
+        let field = FieldSchema::new(
+            "clearance".to_string(),
+            FieldType::Enum { values: Vec::new() },
+            None,
+        );
+        let at = DocPath::main().field("clearance");
+
+        assert!(validate_field(&field, &QuillValue::from(""), &at).is_empty());
+
+        let errors = validate_field(&field, &QuillValue::from("secret"), &at);
+        assert!(
+            matches!(
+                errors.as_slice(),
+                [ValidationError::EnumViolation { value, allowed, .. }]
+                    if value == "secret" && allowed.is_empty()
+            ),
+            "got: {errors:?}"
+        );
     }
 }

--- a/crates/core/src/reader.rs
+++ b/crates/core/src/reader.rs
@@ -279,7 +279,9 @@ fn project_value(
         // worlds: a cell of a dormant world projects at its own codec, as the
         // document carries it. The discriminant declares no cell and rides
         // verbatim.
-        (FieldType::Enum, serde_json::Value::Object(map)) if schema.is_variant_bearing() => {
+        (FieldType::Enum { .. }, serde_json::Value::Object(map))
+            if schema.is_variant_bearing() =>
+        {
             project_map(name, map, at, |key| schema.variant_field(key))
         }
         _ => Ok(value.clone()),
@@ -354,12 +356,14 @@ fn schema_at<'a>(
             // worlds: a dormant cell resolves here and reads absent at
             // `value_at`. The guard holds a variantless enum to a scalar, which
             // `variant_field` alone would answer as an unknown cell.
-            (FieldType::Enum, PathSegment::Key(key)) if cursor.is_variant_bearing() => cursor
-                .variant_field(key)
-                .ok_or_else(|| EditError::UnknownField {
-                    field: name.to_string(),
-                    at: at[..=depth].to_vec(),
-                })?,
+            (FieldType::Enum { .. }, PathSegment::Key(key)) if cursor.is_variant_bearing() => {
+                cursor
+                    .variant_field(key)
+                    .ok_or_else(|| EditError::UnknownField {
+                        field: name.to_string(),
+                        at: at[..=depth].to_vec(),
+                    })?
+            }
             _ => return Err(blocked),
         };
     }

--- a/docs/migrations/0.112-to-0.113.md
+++ b/docs/migrations/0.112-to-0.113.md
@@ -571,6 +571,47 @@ be content.
 **Migrate:** put the comment on its own line at the mapping's indentation, or
 quote the scalar (`key: "aaa bbb"`) if the fold was what you meant.
 
+## Breaking (Rust): an enum's domain rides the type token
+
+`FieldType::Enum` carries its domain, and `FieldSchema::enum_values` is gone:
+
+```rust
+// Before: the token said "enum", a sibling field carried the members.
+FieldSchema { r#type: FieldType::Enum, enum_values: Some(vec!["CUI".into()]), .. }
+if let Some(values) = &field.enum_values { /* … */ }
+
+// After: one carrier.
+FieldSchema { r#type: FieldType::Enum { values: vec!["CUI".into()] }, .. }
+if let FieldType::Enum { values } = &field.r#type { /* … */ }
+```
+
+**Migrate:** match the token where you have it, and call the new
+`FieldSchema::domain() -> &[String]` where you do not — a variant-bearing
+branch, reached through `variants:`, never matched the token. `domain()` answers
+empty for every non-enum type, so read it only where the field is an enum;
+whether a field *is* one is `matches!(field.r#type, FieldType::Enum { .. })`. A
+`FieldType::Enum` pattern needs `{ .. }`, and `FieldType::from_str("enum")`
+yields an empty domain that the sibling `values:` key fills in at
+`FieldSchema::from_quill_value`, exactly as `inline:` fills a prose type's
+payload.
+
+Two equality notes: two `FieldType::Enum`s with different domains are now
+unequal (`FieldSchema` equality already compared domains, so nothing changes
+there), and `FieldType` is no longer a payload-free token for any variant except
+the scalars.
+
+**No quill loads differently, and no stored or wire byte moves.** `values:` is
+still the one spelling of a domain, still required non-empty on `type: enum`
+(`quill::field_parse_error`), and still a load error on any other type; the
+schema projection, blueprint annotation, pdfform widgets and validation all
+behave as before. What changes is only reachable from Rust: a hand-built
+`FieldType::Enum { values: vec![] }` is a real domain of no members, and an
+empty domain admits only the blank — so a non-blank value against one is an
+`enum_violation`, and pdfform binds it as a dropdown offering the blank alone.
+Previously such a field could not be expressed without also setting
+`enum_values`, and the three consumers that met it disagreed about what it
+meant.
+
 ## Breaking (Rust): nested comments hang off the payload, not each item
 
 `PayloadItem::Field` and `PayloadItem::Meta` lose their `nested_comments`

--- a/prose/canon/SCHEMAS.md
+++ b/prose/canon/SCHEMAS.md
@@ -271,7 +271,8 @@ Coercion rules per type:
   caches (`default_content`/`example_content`) and the render-floor blank (the
   empty content) cover `plaintext` exactly as `richtext`: both are content
   leaves (`field_contains_content`)
-- **`enum` domain validation.** An `enum` field coerces as a string; domain membership is a *value* check (`validation::enum_violation`), not a type check, so an out-of-domain string is well-typed but invalid. `type: enum` requires a non-empty `values:` list; `values:` on any other type is a load error (`quill::field_parse_error`), as is `enum:` on any type. The domain rides one carrier (`FieldSchema::enum_values`), and every consumer keys on that carrier rather than on the `Enum` token: the render floor, the pdfform widget kind, the blueprint annotation, and the transform-schema projection to `{type: string, enum: […]}`
+- **`enum` domain validation.** An `enum` field coerces as a string; domain membership is a *value* check (`validation::enum_violation`), not a type check, so an out-of-domain string is well-typed but invalid. `type: enum` requires a non-empty `values:` list; `values:` on any other type is a load error (`quill::field_parse_error`), as is `enum:` on any type
+- **The domain rides the type token.** It is the `FieldType::Enum` payload, so a consumer that has matched the token holds it: the render floor, the pdfform widget kind, the blueprint annotation, and the transform-schema projection to `{type: string, enum: […]}`. A variant-bearing branch enters through `variants:` with no token in hand and reads it through `FieldSchema::domain()`. A domain admits its members and the blank, so an empty one admits only the blank
 - **Null short-circuits coercion.** A null value (`field:`, `field: null`,
   `field: ~`) passes coercion unchanged for *every* type: null ≡ absent, so
   it carries no data to coerce. The value reaches the render floor and


### PR DESCRIPTION
Closes #1697 — the last of its four deferred refactors (ledger row q-12). The other three landed in #1724 and its follow-ups.

## The problem

An enum field's domain had two carriers that had to agree: the `FieldType::Enum` token and `FieldSchema::enum_values`. The loader enforced the agreement (`resolve_enum_values` required a non-empty `values:` on `type: enum` and rejected `values:` elsewhere), but the type could not express it. So every consumer keyed on the carrier — `if field.enum_values.is_some()` — and left a `FieldType::Enum` match arm behind as unreachable residue.

Three of them, each answering "no domain" differently, and each with a comment admitting the arm was dead:

| Consumer | answer to "no domain" |
|---|---|
| `schema.rs` transform projection | `{type: string}` — an open domain, contradicting the token |
| `validation.rs` | skipped the membership check, so any string passed |
| `pdfform/bind.rs` | refused to bind |

## The change

`FieldType::Enum { values }`; `FieldSchema::enum_values` is gone. One rule replaces the three arms, special-cased nowhere: **a domain admits its members and the blank, so an empty one admits only the blank.** `join`, `contains`, `first` and the `iter().chain` in the JSON-Schema projection all fall out of it for `[]` exactly as for `[a, b]`.

`values:` folds into the payload at `from_quill_value` beside `inline:` — the one sync point — so the two sibling keys carry the same way, and `FieldType::from_str("enum")` yields an empty domain the fold fills in. `FieldType`'s own `Serialize`/`Deserialize` are untouched: the token is still the whole `type:` value.

New `FieldSchema::domain() -> &[String]` serves the three branches that enter through `variants:` holding no token (`schema.rs:46`, `validation.rs:651`, `config.rs:1292`). It returns a slice rather than an `Option` deliberately — an `Option` would re-create the "when is it `None`?" question at every call and re-open the exact residue being removed.

`variants` stays on `FieldSchema`. It is on the *children* side of the line the repo already draws (`items` on `Array`, `properties` on `Object`, `variants` on `Enum`, each with an enforced-not-structural load rule), and moving it would push `quill::variants_on_non_enum` — a diagnostic code, contract under `CONTRIBUTING.md`, asserted in `variant_tests.rs` — into `field_parse_error`.

## Behavior

**No quill loads differently, and no stored or wire byte moves.** `values:` is still the one spelling, still required non-empty on `type: enum`, still a load error on any other type; both loader messages are verbatim. `Serialize` re-emits `values` from the payload in the slot it already occupied, so the `usaf_memo` golden schema holds byte-for-byte. No binding surface ever read `enum_values` (zero hits under `crates/bindings`).

**Rust API break**, hence the `!`: `FieldSchema::enum_values` is gone, `FieldType::Enum` patterns need `{ .. }`, and two enums with different domains are now unequal as bare `FieldType`s. `docs/migrations/0.112-to-0.113.md` carries the migration.

One state changes meaning, reachable only from Rust and only via the now-deleted public mutable field: a hand-built valueless enum. `FieldSchema`'s `Deserialize` routes through `from_quill_value`, so serde could never build the disagreement — the only door was mutating `enum_values` after `new()`, which is what the deleted test did. Such a field is now a real domain of no members: validation flags a non-blank value, and pdfform binds a dropdown offering the blank alone. None of the three old answers was useful, and nothing ships either state.

## Tests

- **Deleted** `enum_values_on_a_non_enum_type_blanks_to_the_empty_string` — the state is unrepresentable, and its premise ("serde builds it anyway") was already false.
- **New** `an_empty_domain_admits_only_the_blank` — pins the one rule the three residue arms are traded for.
- **Collapsed** two assertion pairs in `quill/tests.rs` into one each; the enum projection test also now pins parse → payload → `values:` re-emission.

`cargo test --workspace` green (64 targets, 0 failures), `RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --locked --workspace` clean (the repo's standing lint gate), `scripts/check-canon.mjs` clean. `prose/canon/SCHEMAS.md` § enum rewritten — the carrier rule there was stated verbatim and is now inverted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5iqvWiFRuDhAHFgdaEn3z

---
_Generated by [Claude Code](https://claude.ai/code/session_01E5iqvWiFRuDhAHFgdaEn3z)_