### PR TITLE
Epic #1777: the 0.102→0.113 review findings — checkbox parity, multiline from the value, mapPos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,15 @@
   `\n`, reading the same string the raster draws. An array's widget stays
   multiline unconditionally, value or none, since a signer types its elements
   one per line. Closes #1781.
+- fix(content): **`Delta::map_pos` saturates its base cursor.** `mapPos` is the
+  one `Delta` door no `try_apply` bounds, and it summed a wire delta's
+  `retain`/`delete` counts with a plain `+`: on wasm32, where `usize` is
+  32-bit, `{ops:[{retain:3000000000},{retain:3000000000}]}` wrapped to a wrong
+  caret position in the published build and aborted the instance in the
+  checked one. `map_pos`, `is_deleted` and `inserted_spans` now walk the ops
+  with `saturating_add`, as `expected_base_len` already did: a run past
+  `usize::MAX` describes a base longer than any content, and a position lands
+  inside it as it would in a bounded one. Closes #1782.
 - refactor(pdfform)!: **`quillmark-pdfform` is `quillmark-acroform`, backend id
   included.** `quillmark-pdf` and `quillmark-pdfform` differed by four
   characters and read as prefix-and-specialization, the reading #1749 records:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@
   `FieldSpec::value` the contract excludes — `value` is public — stamped
   `/V /Yes` on a widget the raster drew blank. `FieldSpec::is_checked` is the
   one reading, the strict one, and both paths call it. Closes #1780.
+- fix(acroform): **a value carrying a newline binds to a multiline widget.**
+  `bind` decided `MULTILINE` from the schema type, so a richtext of two
+  paragraphs, a `String` block scalar, or any value whose projection keeps a
+  `\n` reached the stamped widget single-line unless `ui.multiline` said
+  otherwise, while the flattened raster stacked the lines: the author saw the
+  value in the preview and one line of it in the file. `resolve::field_spec`
+  now promotes a `Text` widget to multiline when the value it resolved holds a
+  `\n`, reading the same string the raster draws. An array's widget stays
+  multiline unconditionally, value or none, since a signer types its elements
+  one per line. Closes #1781.
 - refactor(pdfform)!: **`quillmark-pdfform` is `quillmark-acroform`, backend id
   included.** `quillmark-pdf` and `quillmark-pdfform` differed by four
   characters and read as prefix-and-specialization, the reading #1749 records:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## Unreleased
 
+- fix(pdf): **a stamped checkbox's `/DA` names ZapfDingbats.** `stamp` wrote a
+  checkbox's `/MK /CA (4)` caption and no `/DA`, so the widget inherited the
+  form-level `/Helv 0 Tf 0 g` and nothing registered the face the glyph lives
+  in: a viewer synthesizing the appearance under `/NeedAppearances` drew the
+  digit `4`, while the canvas raster drew the check mark through a real
+  ZapfDingbats resource. The widget now carries `/DA (/ZaDb 0 Tf 0 g)`, and
+  `/DR /Font` registers `/ZaDb` whenever a checkbox is present; `spec.font`
+  stays inert on a checkbox. The face, its resource name and the glyph are
+  `quillmark_pdf::{CHECK_FONT, CHECK_FONT_RESOURCE, CHECK_GLYPH}`, which the
+  acroform flatten path now reads rather than restating. Closes #1779.
+- fix(pdf): **one predicate for the checkbox on-state.** `stamp` read any
+  `Some` value as checked and `flatten` only `Some("Yes")`, so a
+  `FieldSpec::value` the contract excludes — `value` is public — stamped
+  `/V /Yes` on a widget the raster drew blank. `FieldSpec::is_checked` is the
+  one reading, the strict one, and both paths call it. Closes #1780.
 - refactor(pdfform)!: **`quillmark-pdfform` is `quillmark-acroform`, backend id
   included.** `quillmark-pdf` and `quillmark-pdfform` differed by four
   characters and read as prefix-and-specialization, the reading #1749 records:

--- a/crates/backends/acroform/src/bind.rs
+++ b/crates/backends/acroform/src/bind.rs
@@ -258,9 +258,9 @@ pub fn project_kind(
         | SchemaType::PlainText { .. } => WidgetType::Text {
             multiline: is_multiline(field),
         },
-        // `resolve::coerce_text` joins an array's elements with newlines, so the
-        // widget is multiline whatever `ui` says: a single-line one collapses
-        // the value the flattened raster stacks.
+        // An array's elements are one per line, in the value `resolve` joins and
+        // in what a signer types into the blank widget, so it is multiline
+        // whatever `ui` says.
         SchemaType::Array => match field.items.as_deref() {
             Some(items) if is_scalar_or_prose(items) => WidgetType::Text { multiline: true },
             _ => return Err(unbindable()),

--- a/crates/backends/acroform/src/flatten.rs
+++ b/crates/backends/acroform/src/flatten.rs
@@ -21,7 +21,7 @@ use quillmark_pdf::{
         alloc_id, append_refs_to_array_key, content_stream_object, dict_object, pdf_escape,
         type1_font_object, winansi_encode, OnNonArray,
     },
-    FieldSpec, FieldType, PdfError, PdfUpdate, CHECKBOX_ON_STATE,
+    FieldSpec, FieldType, PdfError, PdfUpdate, CHECK_GLYPH,
 };
 
 use crate::typography;
@@ -107,7 +107,7 @@ pub fn flatten(base: Vec<u8>, fields: &[FieldSpec]) -> Result<Vec<u8>, PdfError>
 fn has_drawable_value(spec: &FieldSpec) -> bool {
     match &spec.field_type {
         FieldType::Signature => false,
-        FieldType::Checkbox => spec.value.as_deref() == Some(CHECKBOX_ON_STATE),
+        FieldType::Checkbox => spec.is_checked(),
         _ => spec.value.is_some(),
     }
 }
@@ -238,8 +238,6 @@ fn write_text_block(
     out.extend_from_slice(b"ET\nQ\n");
 }
 
-/// Draw ZapfDingbats glyph 0x34 (`'4'`), the filled check mark — the same glyph
-/// the AcroForm stamp path declares via `/MK /CA (4)`.
 fn write_check_char(out: &mut Vec<u8>, font: &str, x: f32, y: f32, size: f32) {
     out.extend_from_slice(b"q\n");
     out.extend_from_slice(STATE_RESET);
@@ -249,7 +247,9 @@ fn write_check_char(out: &mut Vec<u8>, font: &str, x: f32, y: f32, size: f32) {
     push_f32(out, x);
     out.push(b' ');
     push_f32(out, y);
-    out.extend_from_slice(b" Td\n(4) Tj\nET\nQ\n");
+    out.extend_from_slice(b" Td\n(");
+    out.extend_from_slice(CHECK_GLYPH);
+    out.extend_from_slice(b") Tj\nET\nQ\n");
 }
 
 fn rewrite_page_for_flatten(

--- a/crates/backends/acroform/src/resolve.rs
+++ b/crates/backends/acroform/src/resolve.rs
@@ -1,6 +1,7 @@
 //! The value step: turn a value-free [`BoundWidget`] plus the document's
-//! `compile_data` JSON into a stamp-spine [`FieldSpec`]. Kind, options,
-//! multiline, tooltip and geometry are already resolved by [`crate::bind`].
+//! `compile_data` JSON into a stamp-spine [`FieldSpec`]. Kind, options, tooltip
+//! and geometry are already resolved by [`crate::bind`]; so is multiline, which
+//! the value can only widen.
 //!
 //! Binding is against `compile_data` — the same validated, blank-filled object
 //! the Typst plate reads as `data.*` — so blank-fill, validation, defaults and
@@ -13,6 +14,11 @@ use serde_json::Value;
 use crate::bind::BoundWidget;
 
 /// Build a [`FieldSpec`] for `widget`, resolving its bound value from `data`.
+///
+/// A text value holding a newline makes its widget multiline whatever the
+/// schema said: a richtext of two paragraphs, an array, a block scalar. The
+/// flattened raster stacks the lines, and a single-line widget shows a viewer
+/// one, so the rule reads the string the raster draws.
 pub fn field_spec(widget: &BoundWidget, data: &Value) -> FieldSpec {
     let mut spec = FieldSpec::new(
         widget.name.clone(),
@@ -21,6 +27,11 @@ pub fn field_spec(widget: &BoundWidget, data: &Value) -> FieldSpec {
         widget.field_type.clone(),
     );
     spec.value = resolve_value(&widget.field_type, widget.schema_field.as_deref(), data);
+    if let (FieldType::Text { multiline }, Some(value)) = (&mut spec.field_type, &spec.value)
+        && value.contains('\n')
+    {
+        *multiline = true;
+    }
     spec.schema_field = widget.schema_field.clone();
     spec.tooltip = widget.tooltip.clone();
     spec
@@ -305,6 +316,36 @@ mod tests {
         assert_eq!(card_text("$cards.indorsement.0.missing"), None);
         // `$cards.0.from` reads `0` as a kind, matching no card.
         assert_eq!(card_text("$cards.0.from"), None);
+    }
+
+    fn text_widget(schema_field: &str) -> BoundWidget {
+        BoundWidget {
+            name: schema_field.to_uppercase(),
+            schema_field: Some(schema_field.to_string()),
+            page: 0,
+            rect: [72.0, 700.0, 300.0, 720.0],
+            field_type: FieldType::Text { multiline: false },
+            tooltip: None,
+        }
+    }
+
+    #[test]
+    fn a_value_carrying_a_newline_reaches_the_stamp_multiline() {
+        let two_paragraphs = quillmark_content::serial::to_canonical_value(
+            &quillmark_content::import::from_markdown("One.\n\nTwo.").unwrap(),
+        );
+        let data = json!({
+            "bio": two_paragraphs,
+            "address": "1 Main St\nSpringfield",
+            "full_name": "Ada Lovelace",
+        });
+        let multiline = |field: &str| match field_spec(&text_widget(field), &data).field_type {
+            FieldType::Text { multiline } => multiline,
+            other => panic!("{field}: {other:?}"),
+        };
+        assert!(multiline("bio"), "richtext of two paragraphs");
+        assert!(multiline("address"), "block scalar");
+        assert!(!multiline("full_name"), "one line keeps the schema's answer");
     }
 
     #[test]

--- a/crates/backends/acroform/src/typography.rs
+++ b/crates/backends/acroform/src/typography.rs
@@ -6,16 +6,15 @@
 /// Base-14 Helvetica `/BaseFont`, for text and choice values.
 pub(crate) const TEXT_FONT: &[u8] = b"Helvetica";
 
-/// Base-14 ZapfDingbats `/BaseFont`, for the checkbox check glyph.
-pub(crate) const CHECK_FONT: &[u8] = b"ZapfDingbats";
+/// The face the stamped checkbox `/DA` names, for the check glyph.
+pub(crate) const CHECK_FONT: &[u8] = quillmark_pdf::CHECK_FONT;
 
 /// Preferred `/Font` resource name for [`TEXT_FONT`], shared with the `/DA` the
 /// stamp path writes. A page already binding it gets a derived name instead.
 pub(crate) const TEXT_FONT_RESOURCE: &str = quillmark_pdf::FormFont::Helvetica.resource_name();
 
-/// Preferred `/Font` resource name for [`CHECK_FONT`], the AcroForm spelling for
-/// ZapfDingbats.
-pub(crate) const CHECK_FONT_RESOURCE: &str = "ZaDb";
+/// Preferred `/Font` resource name for [`CHECK_FONT`], shared the same way.
+pub(crate) const CHECK_FONT_RESOURCE: &str = quillmark_pdf::CHECK_FONT_RESOURCE;
 
 pub(crate) const MIN_SIZE: f32 = 4.0;
 pub(crate) const MAX_SIZE: f32 = 12.0;

--- a/crates/content/src/delta.rs
+++ b/crates/content/src/delta.rs
@@ -122,6 +122,12 @@ impl Delta {
 
     /// Map a base char position to its new position. `assoc` decides the side of
     /// a same-position insertion (`After` moves past it).
+    ///
+    /// The base cursor saturates, as [`expected_base_len`](Self::expected_base_len)
+    /// does: this is the one door a wire delta reaches without `try_apply`
+    /// having bounded it, and an op run summing past `usize` describes a base
+    /// longer than any content, so a position lands inside it as it would in a
+    /// bounded one.
     pub fn map_pos(&self, pos: usize, assoc: Assoc) -> usize {
         let mut old = 0usize;
         let mut new = 0usize;
@@ -131,34 +137,34 @@ impl Delta {
                     // Strictly inside the retain resolves here; the right
                     // boundary (pos == old + n) falls through, so a following
                     // Insert can apply its `assoc`.
-                    if pos < old + n {
-                        return new + (pos - old);
+                    if pos < old.saturating_add(*n) {
+                        return new.saturating_add(pos - old);
                     }
-                    old += n;
-                    new += n;
+                    old = old.saturating_add(*n);
+                    new = new.saturating_add(*n);
                 }
                 Op::Delete(n) => {
-                    if pos < old + n {
+                    if pos < old.saturating_add(*n) {
                         // Inside (or at the start of) the deletion: collapse to
                         // the deletion point.
                         return new;
                     }
-                    old += n;
+                    old = old.saturating_add(*n);
                 }
                 Op::Insert(s) => {
                     let len = s.chars().count();
                     if pos == old {
                         match assoc {
                             Assoc::Before => return new,
-                            Assoc::After => new += len, // fall through past insert
+                            Assoc::After => new = new.saturating_add(len), // fall through past insert
                         }
                     } else {
-                        new += len;
+                        new = new.saturating_add(len);
                     }
                 }
             }
         }
-        new + pos.saturating_sub(old)
+        new.saturating_add(pos.saturating_sub(old))
     }
 
     /// Whether base position `pos` sits strictly inside a deleted span. The
@@ -168,12 +174,12 @@ impl Delta {
         let mut old = 0usize;
         for op in &self.ops {
             match op {
-                Op::Retain(n) => old += n,
+                Op::Retain(n) => old = old.saturating_add(*n),
                 Op::Delete(n) => {
-                    if pos > old && pos < old + n {
+                    if pos > old && pos < old.saturating_add(*n) {
                         return true;
                     }
-                    old += n;
+                    old = old.saturating_add(*n);
                 }
                 Op::Insert(_) => {}
             }
@@ -189,13 +195,13 @@ impl Delta {
         let mut new = 0usize;
         for op in &self.ops {
             match op {
-                Op::Retain(n) => new += n,
+                Op::Retain(n) => new = new.saturating_add(*n),
                 Op::Insert(s) => {
                     let len = s.chars().count();
                     if len > 0 {
-                        spans.push((new, new + len));
+                        spans.push((new, new.saturating_add(len)));
                     }
-                    new += len;
+                    new = new.saturating_add(len);
                 }
                 Op::Delete(_) => {}
             }
@@ -504,6 +510,30 @@ mod tests {
                 actual: 5,
             })
         );
+    }
+
+    /// `mapPos` hands a wire delta here with no length check ahead of it, and
+    /// `usize` is 32-bit on wasm32, where a release build wraps and a checked
+    /// one aborts the instance. Spelled against `usize::MAX` so the same run
+    /// overflows on every width.
+    #[test]
+    fn map_pos_saturates_on_counts_past_usize() {
+        let over = Delta {
+            ops: vec![
+                Op::Retain(usize::MAX),
+                Op::Retain(2),
+                Op::Insert("x".into()),
+                Op::Delete(3),
+            ],
+        };
+        // A position the first retain covers maps through it.
+        assert_eq!(over.map_pos(5, Assoc::After), 5);
+        // One at the saturated cursor walks the rest of the run without
+        // overflowing, on either side of the insertion.
+        assert_eq!(over.map_pos(usize::MAX, Assoc::Before), usize::MAX);
+        assert_eq!(over.map_pos(usize::MAX, Assoc::After), usize::MAX);
+        assert!(!over.is_deleted(usize::MAX));
+        assert_eq!(over.inserted_spans(), vec![(usize::MAX, usize::MAX)]);
     }
 
     #[test]

--- a/crates/quillmark-pdf/src/lib.rs
+++ b/crates/quillmark-pdf/src/lib.rs
@@ -23,7 +23,10 @@ pub mod writer;
 
 pub use error::PdfError;
 pub use reader::ObjectIndex;
-pub use stamp::{regions_of, stamp, StampOptions, CHECKBOX_ON_STATE};
+pub use stamp::{
+    regions_of, stamp, StampOptions, CHECKBOX_ON_STATE, CHECK_FONT, CHECK_FONT_RESOURCE,
+    CHECK_GLYPH,
+};
 pub use update::PdfUpdate;
 
 const CODE_BAD_RECT: &str = "pdf::bad_rect";
@@ -61,7 +64,8 @@ pub struct FieldSpec {
     /// `[x0, y0, x1, y1]` in PDF points, bottom-left origin.
     pub rect: [f32; 4],
     pub field_type: FieldType,
-    /// `None` is blank; for a checkbox, `Some` (the on-state name) is checked.
+    /// `None` is blank; for a checkbox, [`CHECKBOX_ON_STATE`] is checked and
+    /// anything else is not ([`is_checked`](Self::is_checked)).
     pub value: Option<String>,
     /// Optional `/TU` tooltip / accessible name.
     pub tooltip: Option<String>,
@@ -90,6 +94,15 @@ impl FieldSpec {
             font_size: None,
             align: TextAlign::default(),
         }
+    }
+
+    /// Whether this is a checkbox carrying [`CHECKBOX_ON_STATE`]. The one
+    /// reading of the on-state, shared by the stamped widget and a drawn
+    /// raster: `value` is public, so a spelling the contract excludes reaches
+    /// both, and both read it as unchecked.
+    pub fn is_checked(&self) -> bool {
+        matches!(self.field_type, FieldType::Checkbox)
+            && self.value.as_deref() == Some(CHECKBOX_ON_STATE)
     }
 
     /// `Err` with code `pdf::bad_rect` unless every [`rect`](Self::rect)

--- a/crates/quillmark-pdf/src/stamp.rs
+++ b/crates/quillmark-pdf/src/stamp.rs
@@ -30,6 +30,17 @@ const CODE_EXISTING_ACROFORM: &str = "pdf::existing_acroform";
 /// this as its `value` when checked, `None` when not.
 pub const CHECKBOX_ON_STATE: &str = "Yes";
 
+/// The standard-14 face a check mark is set in, never embedded.
+pub const CHECK_FONT: &[u8] = b"ZapfDingbats";
+
+/// The `/DR` `/Font` key [`CHECK_FONT`] is registered under: the name a
+/// checkbox `/DA` selects it by, and a drawn content stream too.
+pub const CHECK_FONT_RESOURCE: &str = "ZaDb";
+
+/// The [`CHECK_FONT`] glyph a checked box shows, 0x34, the filled check mark:
+/// the widget's `/MK /CA` caption, and what a drawn raster shows in its place.
+pub const CHECK_GLYPH: &[u8] = b"4";
+
 /// House-style default appearance: Helvetica, `0 Tf` (auto-size), black fill.
 /// `Helv` is registered in the form `/DR` `/Font`.
 ///
@@ -37,38 +48,44 @@ pub const CHECKBOX_ON_STATE: &str = "Yes";
 /// [`field_appearance`].
 const DEFAULT_APPEARANCE: &[u8] = b"/Helv 0 Tf 0 g";
 
-/// One widget's `/DA`: its face and size over the house black fill. `f32`'s
-/// `Display` drops the trailing `.0`, so a whole-point size writes `12`. An
-/// absent size — or one not positive and finite, `font_size` being public and
-/// `NaN`/`inf` being tokens no PDF number grammar admits — writes the `0 Tf`
-/// that defers to the viewer's auto-size.
+/// A `/DA` selecting `resource` at `size` over the house black fill. `f32`'s
+/// `Display` drops the trailing `.0`, so a whole-point size writes `12` and
+/// `0.0` writes the `0 Tf` that defers to the viewer's auto-size.
+fn appearance(resource: &str, size: f32) -> Vec<u8> {
+    format!("/{resource} {size} Tf 0 g").into_bytes()
+}
+
+/// A variable-text widget's `/DA`: its own face and size. An absent size — or
+/// one not positive and finite, `font_size` being public and `NaN`/`inf` being
+/// tokens no PDF number grammar admits — defers to the viewer's auto-size.
 fn field_appearance(spec: &FieldSpec) -> Vec<u8> {
     let size = spec
         .font_size
         .filter(|s| s.is_finite() && *s > 0.0)
         .unwrap_or(0.0);
-    let mut da = b"/".to_vec();
-    da.extend_from_slice(spec.font.resource_name().as_bytes());
-    da.extend_from_slice(format!(" {size} Tf 0 g").as_bytes());
-    da
+    appearance(spec.font.resource_name(), size)
 }
 
-/// Every face named by a `/DA` this stamp writes: the variable-text widgets'
-/// own, plus the Helvetica of the form-level [`DEFAULT_APPEARANCE`]. A checkbox
-/// or signature writes no `/DA`, so its `font` names nothing.
-fn fonts_used(fields: &[FieldSpec]) -> Vec<FormFont> {
-    let mut fonts: Vec<FormFont> = fields
+/// Every face a `/DA` this stamp writes names, as `(resource name, base font)`:
+/// the variable-text widgets' own, the check font of any checkbox, and the
+/// Helvetica of the form-level [`DEFAULT_APPEARANCE`]. A signature writes no
+/// `/DA` and a checkbox's is the engine's, so `font` names nothing on either.
+fn fonts_used(fields: &[FieldSpec]) -> Vec<(&'static str, &'static [u8])> {
+    let mut fonts: Vec<(&'static str, &'static [u8])> = fields
         .iter()
-        .filter(|f| {
-            matches!(
-                f.field_type,
-                FieldType::Text { .. } | FieldType::Choice { .. }
-            )
+        .filter_map(|f| match f.field_type {
+            FieldType::Text { .. } | FieldType::Choice { .. } => {
+                Some((f.font.resource_name(), f.font.base_font()))
+            }
+            FieldType::Checkbox => Some((CHECK_FONT_RESOURCE, CHECK_FONT)),
+            FieldType::Signature => None,
         })
-        .map(|f| f.font)
         .collect();
-    fonts.push(FormFont::Helvetica);
-    fonts.sort_by_key(|f| f.resource_name());
+    fonts.push((
+        FormFont::Helvetica.resource_name(),
+        FormFont::Helvetica.base_font(),
+    ));
+    fonts.sort_unstable_by_key(|&(resource, _)| resource);
     fonts.dedup();
     fonts
 }
@@ -145,9 +162,8 @@ pub fn stamp(
             });
         }
 
-        for (font, &fid) in fonts.iter().zip(&font_ids) {
-            up.objects
-                .push(type1_font_object(fid, font.base_font(), None)?);
+        for (&(_, base_font), &fid) in fonts.iter().zip(&font_ids) {
+            up.objects.push(type1_font_object(fid, base_font, None)?);
         }
 
         let has_signature = fields
@@ -170,8 +186,8 @@ pub fn stamp(
             {
                 let mut dr = form.insert(Name(b"DR")).dict();
                 let mut font_dict = dr.insert(Name(b"Font")).dict();
-                for (font, &fid) in fonts.iter().zip(&font_ids) {
-                    font_dict.pair(Name(font.resource_name().as_bytes()), to_ref(fid)?);
+                for (&(resource, _), &fid) in fonts.iter().zip(&font_ids) {
+                    font_dict.pair(Name(resource.as_bytes()), to_ref(fid)?);
                 }
             }
             form.finish();
@@ -261,7 +277,10 @@ fn write_widget_object(spec: &FieldSpec, wid: Ref, page_ref: Ref) -> Vec<u8> {
             }
             FieldType::Checkbox => {
                 field.field_type(PwFieldType::Button);
-                let on = spec.value.is_some();
+                // The viewer synthesizes the `/MK /CA` caption in the `/DA`
+                // face: under the form-level Helvetica the glyph is a digit.
+                field.vartext_default_appearance(Str(&appearance(CHECK_FONT_RESOURCE, 0.0)));
+                let on = spec.is_checked();
                 checkbox_on = Some(on);
                 field.pair(
                     Name(b"V"),
@@ -271,11 +290,9 @@ fn write_widget_object(spec: &FieldSpec, wid: Ref, page_ref: Ref) -> Vec<u8> {
                         Name(b"Off")
                     },
                 );
-                // /MK /CA (4): the ZapfDingbats check glyph the viewer
-                // synthesizes under NeedAppearances.
                 {
                     let mut mk = field.insert(Name(b"MK")).dict();
-                    mk.pair(Name(b"CA"), Str(b"4"));
+                    mk.pair(Name(b"CA"), Str(CHECK_GLYPH));
                 }
             }
             FieldType::Choice { options } => {

--- a/crates/quillmark-pdf/tests/stamp.rs
+++ b/crates/quillmark-pdf/tests/stamp.rs
@@ -765,8 +765,8 @@ fn a_base_that_already_carries_an_acroform_is_refused() {
     assert_eq!(err.code, "pdf::existing_acroform");
 }
 
-/// Only `Text` and `Choice` widgets write a `/DA`, so a checkbox's `font` names
-/// nothing and registering it would emit an unreferenced Type1 object.
+/// A checkbox's `/DA` is the engine's check font, so its `font` names nothing
+/// and registering it would emit an unreferenced Type1 object.
 #[test]
 fn a_checkbox_font_registers_no_font_object() {
     let mut agree = FieldSpec::new(
@@ -790,5 +790,57 @@ fn a_checkbox_font_registers_no_font_object() {
     assert!(
         text.contains("Times-Roman") && text.contains("/TiRo"),
         "a text widget's font is still registered"
+    );
+}
+
+/// The `/DR` `/Font` entry and the widget `/DA` a checkbox needs, and only a
+/// checkbox: a viewer synthesizing the `/MK /CA` caption under
+/// `/NeedAppearances` sets it in the `/DA` face, and in Helvetica the check
+/// glyph is the digit `4`.
+#[test]
+fn a_checkbox_appearance_names_the_registered_check_font() {
+    let agree = FieldSpec::new(
+        "Agree".into(),
+        0,
+        [180.0, 560.0, 194.0, 574.0],
+        FieldType::Checkbox,
+    );
+    let out = stamp(build_base_pdf(1), &[agree], &StampOptions::default()).expect("stamp ok");
+
+    let doc = lopdf::Document::load_mem(&out).expect("lopdf reparse");
+    let af_ref = doc.catalog().unwrap().get(b"AcroForm").unwrap().as_reference().unwrap();
+    let af = doc.get_object(af_ref).unwrap().as_dict().unwrap();
+    let fonts = af.get(b"DR").unwrap().as_dict().unwrap();
+    let fonts = fonts.get(b"Font").unwrap().as_dict().unwrap();
+    let zadb = fonts
+        .get(quillmark_pdf::CHECK_FONT_RESOURCE.as_bytes())
+        .expect("/DR registers the check font")
+        .as_reference()
+        .unwrap();
+    let zadb = doc.get_object(zadb).unwrap().as_dict().unwrap();
+    assert_eq!(
+        zadb.get(b"BaseFont").unwrap().as_name().unwrap(),
+        quillmark_pdf::CHECK_FONT
+    );
+
+    let widget_ref = af.get(b"Fields").unwrap().as_array().unwrap()[0]
+        .as_reference()
+        .unwrap();
+    let widget = doc.get_object(widget_ref).unwrap().as_dict().unwrap();
+    let da = String::from_utf8_lossy(widget.get(b"DA").unwrap().as_str().unwrap()).into_owned();
+    assert!(
+        da.starts_with(&format!("/{} ", quillmark_pdf::CHECK_FONT_RESOURCE)),
+        "checkbox /DA selects the check font, got {da:?}"
+    );
+
+    let out = stamp(
+        build_base_pdf(1),
+        &[text_field("X", "x", 0, [10.0, 10.0, 100.0, 30.0], "hi")],
+        &StampOptions::default(),
+    )
+    .expect("stamp ok");
+    assert!(
+        !String::from_utf8_lossy(&out).contains("ZapfDingbats"),
+        "a form with no checkbox registers no check font"
     );
 }

--- a/docs/quills/acroform-backend.md
+++ b/docs/quills/acroform-backend.md
@@ -171,7 +171,7 @@ A bound field's kind is derived from the **capability of the resolved schema fie
 | array of the above (scalar or prose) | **text**: elements joined with newlines |
 | `object`, or array of objects | **load error** `acroform::unbindable_field` |
 
-`multiline` on a text widget comes from the schema field's `ui.multiline`.
+`multiline` on a text widget comes from the schema field's `ui.multiline`, and a value holding a newline (a richtext of two paragraphs, a block scalar) widens it to multiline whatever the schema said, so the file shows every line the preview does.
 
 ### Top-left coordinates
 


### PR DESCRIPTION
Four of the epic's five sub-issues land here; the fifth closes on the merits.

## Landed

**#1779 — the checkbox `/DA` and its `/ZaDb`.** `stamp` wrote `/MK /CA (4)` and no `/DA`, so the widget inherited `/Helv 0 Tf 0 g` and no `/DR /Font` entry carried ZapfDingbats: a viewer synthesizing under `/NeedAppearances` drew the digit `4`. The checkbox arm now writes `/DA (/ZaDb 0 Tf 0 g)` and `fonts_used` registers `/ZaDb` whenever a checkbox is present. Rather than a fourth `FormFont` variant (the enum is the face a widget's *value text* is set in, and a check font on a text field is nothing), `fonts_used` collects `(resource, base font)` pairs and the check font rides beside the variable-text ones. The face, resource name and glyph are `quillmark_pdf::{CHECK_FONT, CHECK_FONT_RESOURCE, CHECK_GLYPH}`; the acroform flatten path reads them instead of restating `"ZapfDingbats"` / `"ZaDb"` / `(4)`. Test: `/DR` registers the font, the widget `/DA` names it, a form with no checkbox registers none.

**#1780 — one predicate for the on-state.** `FieldSpec::is_checked` reads `Some(CHECKBOX_ON_STATE)` strictly; both `stamp` and `flatten::has_drawable_value` call it. No test for the divergence, per the issue.

**#1781 — `MULTILINE` from the value.** `resolve::field_spec` promotes a `Text` widget to multiline when the resolved value holds a `\n`. One rule for richtext, plaintext, arrays and the block-scalar `String`, reading the same string the raster draws. Test: two richtext paragraphs and a block scalar reach the stamp multiline, one line does not. One departure from the proposal: `Array`'s forced `true` in `bind` stays. Relaxing it to `is_multiline(field)` would make the *blank* array widget single-line for a signer, who types elements one per line; the value rule covers the filled case and the schema rule the empty one. The comment there states the reason that remains.

**#1782 — `map_pos`'s accumulator.** `map_pos`, `is_deleted` and `inserted_spans` walk with `saturating_add`, as `expected_base_len` did. The test spells the run against `usize::MAX` so it overflows on every width; it panics with "attempt to add with overflow" on the old arithmetic and passes on the new.

## Closed on the merits

**#1778 — the two repository settings.** Closed as not planned: `v0.109.1` through `v0.112.0` were all tagged and published by `github-actions[bot]` under the same `Tag and push` step, and the last five Prepare Release dispatches opened their PRs under `GITHUB_TOKEN`. Both settings are proven by four releases; nothing gates 0.113. Details on the issue.

None of the changes is a `!`: `Some("Off")` on a checkbox stamping unchecked enforces the contract `CHECKBOX_ON_STATE` already documented, and the three consts and `is_checked` are additive.

Validated: `cargo test --workspace --all-features --locked` green, `RUSTDOCFLAGS=-Dwarnings cargo doc` clean on the three crates.

Closes #1777, closes #1779, closes #1780, closes #1781, closes #1782.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015TmpDvpJ3fWJrbtYa9GjCc

---
_Generated by [Claude Code](https://claude.ai/code/session_015TmpDvpJ3fWJrbtYa9GjCc)_